### PR TITLE
Remove placeholder Color Match and Number Puzzle games

### DIFF
--- a/src/pages/index.astro
+++ b/src/pages/index.astro
@@ -49,30 +49,7 @@ function convertGameToCardFormat(game: Game) {
 const systemGames = getAllGames()
 const availableGames = systemGames.map(convertGameToCardFormat)
 
-// Add placeholder games for future development
-const comingSoonGames = [
-  {
-    id: 8,
-    title: 'Color Match',
-    description: 'Match colors in this fast-paced puzzle',
-    icon: '🌈',
-    duration: '3-8 min',
-    difficulty: 'Easy',
-    available: false,
-  },
-  {
-    id: 9,
-    title: 'Number Puzzle',
-    description: 'Solve number sequences and patterns',
-    icon: '🔢',
-    duration: '5-15 min',
-    difficulty: 'Hard',
-    available: false,
-  },
-]
-
-// Combine available games with coming soon games
-const games = [...availableGames, ...comingSoonGames]
+const games = availableGames
 ---
 
 <AppLayout

--- a/tests/e2e/games/all-games-navigation.spec.ts
+++ b/tests/e2e/games/all-games-navigation.spec.ts
@@ -95,19 +95,6 @@ test.describe('Games Navigation and Basic Functionality', () => {
         }
     })
 
-    test('should show coming soon status for incomplete games', async ({
-        page,
-    }) => {
-        const comingSoonGames = ['Color Match', 'Number Puzzle']
-
-        for (const gameTitle of comingSoonGames) {
-            const gameCard = page
-                .locator(`h4:has-text("${gameTitle}")`)
-                .locator('..')
-            await expect(gameCard.getByText('Coming Soon')).toBeVisible()
-        }
-    })
-
     test('should display game descriptions correctly', async ({ page }) => {
         const gameDescriptions = [
             {


### PR DESCRIPTION
## Summary
- remove Color Match and Number Puzzle placeholder games from home page
- drop e2e test that expected coming soon games

## Testing
- `npm test` *(fails: getUserGameHistoryPaginated expected times in PDT vs UTC)*

------
https://chatgpt.com/codex/tasks/task_e_68c72de9d9948332824e1fcab5d56088

<!-- This is an auto-generated comment: release notes by coderabbit.ai -->

## Summary by CodeRabbit

* **New Features**
  * The Games page now shows only currently playable titles; “Coming Soon” placeholders and badges have been removed.
  * Cleaner game list with no placeholder entries.

* **Tests**
  * Removed end-to-end checks for “Coming Soon” status to align with the updated game list behavior.
  * Retained navigation and description tests for active games.

<!-- end of auto-generated comment: release notes by coderabbit.ai -->