### PR TITLE
Fix timezone-dependent test expectations

### DIFF
--- a/src/lib/server/db/queries.test.ts
+++ b/src/lib/server/db/queries.test.ts
@@ -302,10 +302,20 @@ describe('Database Queries', () => {
 
             // Assert
             expect(result).toEqual({
-                games: mockHistory.map(game => ({
-                    ...game,
-                    created_at: game.created_at.toString(),
-                })),
+                games: [
+                    {
+                        game_id: 'tetris',
+                        game_name: 'Tetris Challenge',
+                        score: 1500,
+                        created_at: new Date('2025-07-10T12:00:00Z').toString(),
+                    },
+                    {
+                        game_id: 'bubble_shooter',
+                        game_name: 'Bubble Shooter',
+                        score: 2000,
+                        created_at: new Date('2025-07-10T11:00:00Z').toString(),
+                    },
+                ],
                 total: 23,
                 page: 2,
                 pageSize: 5,

--- a/src/lib/server/db/queries.test.ts
+++ b/src/lib/server/db/queries.test.ts
@@ -302,22 +302,10 @@ describe('Database Queries', () => {
 
             // Assert
             expect(result).toEqual({
-                games: [
-                    {
-                        game_id: 'tetris',
-                        game_name: 'Tetris Challenge',
-                        score: 1500,
-                        created_at:
-                            'Thu Jul 10 2025 05:00:00 GMT-0700 (Pacific Daylight Time)',
-                    },
-                    {
-                        game_id: 'bubble_shooter',
-                        game_name: 'Bubble Shooter',
-                        score: 2000,
-                        created_at:
-                            'Thu Jul 10 2025 04:00:00 GMT-0700 (Pacific Daylight Time)',
-                    },
-                ],
+                games: mockHistory.map(game => ({
+                    ...game,
+                    created_at: game.created_at.toString(),
+                })),
                 total: 23,
                 page: 2,
                 pageSize: 5,


### PR DESCRIPTION
## Summary
- fix `getUserGameHistoryPaginated` test to use dynamic `Date` string

## Testing
- `npm run test:run`


------
https://chatgpt.com/codex/tasks/task_e_68c7c269e9d48332a4082123b2d5f172

<!-- This is an auto-generated comment: release notes by coderabbit.ai -->
## Summary by CodeRabbit

- **Tests**
  - Replaced hard-coded timestamps in game history and paginated history tests with dynamically generated values to reduce flakiness across environments and time zones.
  - Improved test consistency and maintainability while preserving expected fields and behavior.
  - No changes to production functionality or public APIs; end-user experience unchanged.
<!-- end of auto-generated comment: release notes by coderabbit.ai -->