### PR TITLE
Ensure leaderboard entries link to user profiles

### DIFF
--- a/src/pages/leaderboard/index.astro
+++ b/src/pages/leaderboard/index.astro
@@ -170,39 +170,33 @@ const defaultGameId = games[0]?.id || 'tetris'
                             {/* Leaderboard Content */}
                             <div class="space-y-4">
                               {leaderboard.length > 0 ? (
-                                leaderboard.map((entry, index) => (
-                                  <div class="flex items-center justify-between p-4 bg-gray-800/50 rounded-lg border border-gray-700/50 hover:border-cyan-400/50 transition-colors">
-                                    <div class="flex items-center gap-4">
-                                      <div
-                                        class={`w-8 h-8 rounded-full flex items-center justify-center text-sm font-bold ${
-                                          index === 0
-                                            ? 'bg-yellow-500 text-black'
-                                            : index === 1
-                                              ? 'bg-gray-400 text-black'
-                                              : index === 2
-                                                ? 'bg-orange-600 text-white'
-                                                : 'bg-gray-700 text-white'
-                                        }`}
-                                      >
-                                        {index + 1}
-                                      </div>
-                                      {entry.username ? (
-                                        <a
-                                          href={`/profile/${entry.username}`}
-                                          aria-label={`View @${entry.username} profile`}
-                                          class="block"
+                                leaderboard.map((entry, index) => {
+                                  const normalizedUsername =
+                                    entry.username?.trim().toLowerCase() || null
+                                  const profileUrl = normalizedUsername
+                                    ? `/profile/${encodeURIComponent(normalizedUsername)}`
+                                    : null
+                                  const baseRowClasses =
+                                    'flex items-center justify-between gap-4 p-4 bg-gray-800/50 rounded-lg border border-gray-700/50 transition-colors'
+                                  const interactiveRowClasses = `${baseRowClasses} group hover:border-cyan-400/50 focus-visible:outline-none focus-visible:ring-2 focus-visible:ring-cyan-400 focus-visible:ring-offset-2 focus-visible:ring-offset-gray-900`
+                                  const staticRowClasses = `${baseRowClasses}`
+
+                                  const rowContent = (
+                                    <>
+                                      <div class="flex items-center gap-4">
+                                        <div
+                                          class={`w-8 h-8 rounded-full flex items-center justify-center text-sm font-bold ${
+                                            index === 0
+                                              ? 'bg-yellow-500 text-black'
+                                              : index === 1
+                                                ? 'bg-gray-400 text-black'
+                                                : index === 2
+                                                  ? 'bg-orange-600 text-white'
+                                                  : 'bg-gray-700 text-white'
+                                          }`}
                                         >
-                                          <Avatar
-                                            size="sm"
-                                            variant="cyan-purple"
-                                            src={entry.image || undefined}
-                                            alt={`${entry.name || 'Anonymous'} avatar`}
-                                            fallback={(
-                                              entry.name?.[0] || 'A'
-                                            ).toUpperCase()}
-                                          />
-                                        </a>
-                                      ) : (
+                                          {index + 1}
+                                        </div>
                                         <Avatar
                                           size="sm"
                                           variant="cyan-purple"
@@ -211,41 +205,57 @@ const defaultGameId = games[0]?.id || 'tetris'
                                           fallback={(
                                             entry.name?.[0] || 'A'
                                           ).toUpperCase()}
+                                          class={
+                                            profileUrl
+                                              ? 'transition-transform duration-300 group-hover:scale-105'
+                                              : ''
+                                          }
                                         />
-                                      )}
-                                      <div>
-                                        <div class="font-semibold text-white">
-                                          {entry.username ? (
-                                            <a
-                                              href={`/profile/${entry.username}`}
-                                              class="hover:text-cyan-300"
-                                            >
-                                              {entry.name || 'Anonymous'}
-                                            </a>
-                                          ) : (
-                                            entry.name || 'Anonymous'
-                                          )}
-                                        </div>
-                                        <div class="text-sm text-gray-400">
-                                          {new Date(
-                                            entry.created_at
-                                          ).toLocaleDateString()}
-                                        </div>
-                                      </div>
-                                    </div>
-                                    <div class="text-right">
-                                      <div class="text-xl font-bold text-cyan-400">
-                                        {entry.score.toLocaleString()}
-                                      </div>
-                                      {entry.achievements &&
-                                        entry.achievements.length > 0 && (
-                                          <div class="text-sm text-yellow-400">
-                                            {entry.achievements.join(', ')}
+                                        <div>
+                                          <div
+                                            class={`font-semibold text-white ${
+                                              profileUrl
+                                                ? 'transition-colors group-hover:text-cyan-300'
+                                                : ''
+                                            }`}
+                                          >
+                                            {entry.name || 'Anonymous'}
                                           </div>
-                                        )}
+                                          <div class="text-sm text-gray-400">
+                                            {new Date(
+                                              entry.created_at
+                                            ).toLocaleDateString()}
+                                          </div>
+                                        </div>
+                                      </div>
+                                      <div class="text-right">
+                                        <div class="text-xl font-bold text-cyan-400">
+                                          {entry.score.toLocaleString()}
+                                        </div>
+                                        {entry.achievements &&
+                                          entry.achievements.length > 0 && (
+                                            <div class="text-sm text-yellow-400">
+                                              {entry.achievements.join(', ')}
+                                            </div>
+                                          )}
+                                      </div>
+                                    </>
+                                  )
+
+                                  return profileUrl ? (
+                                    <a
+                                      href={profileUrl}
+                                      aria-label={`View @${normalizedUsername} profile`}
+                                      class={interactiveRowClasses}
+                                    >
+                                      {rowContent}
+                                    </a>
+                                  ) : (
+                                    <div class={staticRowClasses}>
+                                      {rowContent}
                                     </div>
-                                  </div>
-                                ))
+                                  )
+                                })
                               ) : (
                                 <div class="text-center py-12">
                                   <div class="w-16 h-16 mx-auto mb-4 bg-gray-800 rounded-full flex items-center justify-center">


### PR DESCRIPTION
## Summary
- wrap leaderboard rows in profile links when a username is available so the entire entry navigates to the public profile
- normalize and encode usernames before constructing profile URLs and keep anonymous entries non-interactive
- add subtle hover/focus styling so linked rows remain accessible without changing the visual structure

## Testing
- npm run lint

------
https://chatgpt.com/codex/tasks/task_e_68c8db0c335c8332a81dcb588ae87a3a