### PR TITLE
Fix leaderboard button click functionality

### DIFF
--- a/src/components/ui/Select.astro
+++ b/src/components/ui/Select.astro
@@ -245,17 +245,19 @@ const initialLabel = selectedOption ? selectedOption.label : placeholder
       this.trigger.setAttribute('aria-expanded', 'true')
       this.iconSpan.setAttribute('data-open', '')
 
-      // Set display:block first to allow element to be in the DOM
+      // Set display:block and ensure starting scale
       this.dropdown.style.display = 'block'
+      this.dropdown.style.transform = 'scale(0.95)' // Ensure starting state
 
-      // Use requestAnimationFrame to ensure display:block is applied before transition starts
+      // Use requestAnimationFrame to ensure display:block is rendered
       requestAnimationFrame(() => {
-        this.dropdown.setAttribute('data-open', '')
-        this.dropdown.style.transform = 'scale(1)'
-        this.dropdown.style.pointerEvents = 'auto'
-
-        // Focus first option after a brief delay to ensure dropdown is visible
+        // Use another requestAnimationFrame to trigger the transition
         requestAnimationFrame(() => {
+          this.dropdown.setAttribute('data-open', '')
+          this.dropdown.style.transform = 'scale(1)'
+          this.dropdown.style.pointerEvents = 'auto'
+
+          // Focus first option after animation starts
           const firstOption = this.options[0]
           if (firstOption) {
             firstOption.focus()


### PR DESCRIPTION
The Select component's dropdown was blocking clicks on the leaderboard content even when closed. Added explicit display:none when the dropdown is closed and display:block when open, in addition to the existing pointer-events management. This ensures the dropdown is completely hidden and cannot interfere with clicks on content below it.

Changes:
- Set display:none in init() to ensure dropdown starts hidden
- Set display:block in open() to show the dropdown
- Set display:none in close() to hide the dropdown when closed

<!-- This is an auto-generated comment: release notes by coderabbit.ai -->
## Summary by CodeRabbit

* **Bug Fixes**
  * Improved dropdown select show/hide behavior so open/close animations run smoothly and visibility is preserved during transitions.
  * Prevents flicker by delaying final hide until after the closing animation and ensures focus moves to the first option when opened.
<!-- end of auto-generated comment: release notes by coderabbit.ai -->