### PR TITLE
fix: make leaderboard score rows clickable by adding pointer-events-none

### DIFF
--- a/src/pages/leaderboard/index.astro
+++ b/src/pages/leaderboard/index.astro
@@ -205,24 +205,24 @@ const defaultGameId = games[0]?.id || 'tetris'
                                           ).toUpperCase()}
                                         />
                                         <div>
-                                          <div class="font-semibold text-white">
-                                            {entry.name || 'Anonymous'}
-                                          </div>
                                           {profileUrl ? (
                                             <a
                                               href={profileUrl}
-                                              class="text-sm text-white no-underline hover:underline transition-colors focus:outline-none focus:ring-2 focus:ring-cyan-400 focus:ring-offset-1 focus:ring-offset-gray-900 rounded"
+                                              class="font-semibold text-white no-underline hover:underline transition-colors focus:outline-none focus:ring-2 focus:ring-cyan-400 focus:ring-offset-1 focus:ring-offset-gray-900 rounded"
                                               aria-label={`Profile of ${normalizedUsername}`}
                                             >
-                                              @{normalizedUsername}
+                                              {entry.name || normalizedUsername}
                                             </a>
                                           ) : (
-                                            <div class="text-sm text-gray-400">
-                                              {new Date(
-                                                entry.created_at
-                                              ).toLocaleDateString()}
+                                            <div class="font-semibold text-white">
+                                              {entry.name || 'Anonymous'}
                                             </div>
                                           )}
+                                          <div class="text-sm text-gray-400">
+                                            {new Date(
+                                              entry.created_at
+                                            ).toLocaleDateString()}
+                                          </div>
                                         </div>
                                       </div>
                                       <div class="text-right">


### PR DESCRIPTION
Added pointer-events-none to background gradient div to allow click events to pass through to interactive leaderboard entries. This fixes the issue where score rows were not clickable due to an overlay blocking pointer events.

🤖 Generated with [Claude Code](https://claude.com/claude-code)

<!-- This is an auto-generated comment: release notes by coderabbit.ai -->
## Summary by CodeRabbit

* **Style**
  * Simplified leaderboard row presentation and gradient background behavior for a consistent, non-interactive base appearance.
* **Bug Fixes**
  * Fixed inconsistent row interactivity and hover/transition behavior; profile links now render inline when available and author/date display falls back correctly when no profile is present.

<sub>✏️ Tip: You can customize this high-level summary in your review settings.</sub>
<!-- end of auto-generated comment: release notes by coderabbit.ai -->