### PR TITLE
fix: update auth host port, fix hash function, and improve service exports

### DIFF
--- a/src/lib/auth-client.ts
+++ b/src/lib/auth-client.ts
@@ -7,7 +7,7 @@ export const authClient = createAuthClient({
         headers: {
             'X-Forwarded-Proto':
                 window?.location?.protocol?.replace(':', '') || 'http',
-            'X-Forwarded-Host': window?.location?.host || 'localhost:4321',
+            'X-Forwarded-Host': window?.location?.host || 'localhost:4325',
         },
     },
 })

--- a/src/lib/challenges.ts
+++ b/src/lib/challenges.ts
@@ -275,7 +275,7 @@ function hashDateToNumber(dateStr: string): number {
     for (let i = 0; i < dateStr.length; i++) {
         const char = dateStr.charCodeAt(i)
         hash = (hash << 5) - hash + char
-        hash = hash & hash // Convert to 32bit integer
+        hash |= 0 // Convert to 32bit integer
     }
     return Math.abs(hash)
 }

--- a/src/lib/services/challengeService.ts
+++ b/src/lib/services/challengeService.ts
@@ -233,9 +233,6 @@ export async function updateChallengeProgress(
 }
 
 /**
- * Check if all daily challenges are completed and update streak
- */
-/**
  * Check if all daily challenges are completed and update streak atomically
  */
 async function checkAndUpdateStreak(userId: string): Promise<void> {

--- a/src/lib/services/index.ts
+++ b/src/lib/services/index.ts
@@ -4,3 +4,5 @@
 
 export * from './scoreService'
 export * from './achievementService'
+export * from './challengeService'
+export * from './loginRewardService'


### PR DESCRIPTION
## Summary

- **Fixed auth client host port**: Updated default fallback from `localhost:4321` to `localhost:4325` to match the actual development server port
- **Fixed hash function**: Corrected `hashDateToNumber` function - replaced `hash & hash` with `hash |= 0` for proper 32-bit integer conversion
- **Removed outdated documentation**: Cleaned up obsolete JSDoc comment in challengeService.ts
- **Added service exports**: Exported `challengeService` and `loginRewardService` from services index for better module organization

## Changes

- `src/lib/auth-client.ts`: Update default host port
- `src/lib/challenges.ts`: Fix 32-bit integer conversion in hash function
- `src/lib/services/challengeService.ts`: Remove outdated comment
- `src/lib/services/index.ts`: Add missing service exports

<!-- This is an auto-generated comment: release notes by coderabbit.ai -->

## Summary by CodeRabbit

* **Refactor**
  * Improved internal code organization for service exports and binary operation optimization.
  * Adjusted default configuration for header fallback handling.

* **Documentation**
  * Clarified documentation for atomic operation handling.

<!-- end of auto-generated comment: release notes by coderabbit.ai -->