### PR TITLE
feat(circuit-hacker): add Circuit Hacker game

### DIFF
--- a/bun.lock
+++ b/bun.lock
@@ -25,6 +25,7 @@
         "zod": "^4.2.1",
       },
       "devDependencies": {
+        "@astrojs/check": "^0.9.9",
         "@eslint/js": "^9.30.1",
         "@playwright/test": "^1.54.1",
         "@testing-library/dom": "^10.4.0",
@@ -42,6 +43,7 @@
         "prettier-plugin-astro": "^0.14.1",
         "turbo": "^2.1.3",
         "tw-animate-css": "^1.3.4",
+        "typescript": "^6.0.3",
         "typescript-eslint": "^8.35.1",
         "vitest": "^3.2.4",
       },
@@ -54,9 +56,13 @@
 
     "@asamuzakjp/css-color": ["@asamuzakjp/css-color@3.2.0", "", { "dependencies": { "@csstools/css-calc": "^2.1.3", "@csstools/css-color-parser": "^3.0.9", "@csstools/css-parser-algorithms": "^3.0.4", "@csstools/css-tokenizer": "^3.0.3", "lru-cache": "^10.4.3" } }, "sha512-K1A6z8tS3XsmCMM86xoWdn7Fkdn9m6RSVtocUrJYIwZnFVkng/PvkEoWtOWmP+Scc6saYWHWZYbndEEXxl24jw=="],
 
+    "@astrojs/check": ["@astrojs/check@0.9.9", "", { "dependencies": { "@astrojs/language-server": "^2.16.7", "chokidar": "^4.0.3", "kleur": "^4.1.5", "yargs": "^17.7.2" }, "peerDependencies": { "typescript": "^5.0.0 || ^6.0.0" }, "bin": { "astro-check": "bin/astro-check.js" } }, "sha512-A5UW8uIuErLWEoRQvzgXpO1gTjUFtK8r7nU2Z7GewAMxUb7bPvpk11qaKKgxqXlHJWlAvaaxy+Xg28A6bmQ1Tg=="],
+
     "@astrojs/compiler": ["@astrojs/compiler@2.12.2", "", {}, "sha512-w2zfvhjNCkNMmMMOn5b0J8+OmUaBL1o40ipMvqcG6NRpdC+lKxmTi48DT8Xw0SzJ3AfmeFLB45zXZXtmbsjcgw=="],
 
     "@astrojs/internal-helpers": ["@astrojs/internal-helpers@0.7.2", "", {}, "sha512-KCkCqR3Goym79soqEtbtLzJfqhTWMyVaizUi35FLzgGSzBotSw8DB1qwsu7U96ihOJgYhDk2nVPz+3LnXPeX6g=="],
+
+    "@astrojs/language-server": ["@astrojs/language-server@2.16.10", "", { "dependencies": { "@astrojs/compiler": "^2.13.1", "@astrojs/yaml2ts": "^0.2.4", "@jridgewell/sourcemap-codec": "^1.5.5", "@volar/kit": "~2.4.28", "@volar/language-core": "~2.4.28", "@volar/language-server": "~2.4.28", "@volar/language-service": "~2.4.28", "muggle-string": "^0.4.1", "tinyglobby": "^0.2.16", "volar-service-css": "0.0.70", "volar-service-emmet": "0.0.70", "volar-service-html": "0.0.70", "volar-service-prettier": "0.0.70", "volar-service-typescript": "0.0.70", "volar-service-typescript-twoslash-queries": "0.0.70", "volar-service-yaml": "0.0.70", "vscode-html-languageservice": "^5.6.2", "vscode-uri": "^3.1.0" }, "peerDependencies": { "prettier": "^3.0.0", "prettier-plugin-astro": ">=0.11.0" }, "optionalPeers": ["prettier", "prettier-plugin-astro"], "bin": { "astro-ls": "./bin/nodeServer.js" } }, "sha512-87VQ/5GSdHlRnUA+hGuerYyIGAj+9RbZmATyuKLEUePinUXhQ5YkRnRrHhOD9sSi5JOErLjrLkHnfZFEvGrV8w=="],
 
     "@astrojs/markdown-remark": ["@astrojs/markdown-remark@6.3.6", "", { "dependencies": { "@astrojs/internal-helpers": "0.7.2", "@astrojs/prism": "3.3.0", "github-slugger": "^2.0.0", "hast-util-from-html": "^2.0.3", "hast-util-to-text": "^4.0.2", "import-meta-resolve": "^4.1.0", "js-yaml": "^4.1.0", "mdast-util-definitions": "^6.0.0", "rehype-raw": "^7.0.0", "rehype-stringify": "^10.0.1", "remark-gfm": "^4.0.1", "remark-parse": "^11.0.0", "remark-rehype": "^11.1.2", "remark-smartypants": "^3.0.2", "shiki": "^3.2.1", "smol-toml": "^1.3.4", "unified": "^11.0.5", "unist-util-remove-position": "^5.0.0", "unist-util-visit": "^5.0.0", "unist-util-visit-parents": "^6.0.1", "vfile": "^6.0.3" } }, "sha512-bwylYktCTsLMVoCOEHbn2GSUA3c5KT/qilekBKA3CBng0bo1TYjNZPr761vxumRk9kJGqTOtU+fgCAp5Vwokug=="],
 
@@ -67,6 +73,8 @@
     "@astrojs/telemetry": ["@astrojs/telemetry@3.3.0", "", { "dependencies": { "ci-info": "^4.2.0", "debug": "^4.4.0", "dlv": "^1.1.3", "dset": "^3.1.4", "is-docker": "^3.0.0", "is-wsl": "^3.1.0", "which-pm-runs": "^1.1.0" } }, "sha512-UFBgfeldP06qu6khs/yY+q1cDAaArM2/7AEIqQ9Cuvf7B1hNLq0xDrZkct+QoIGyjq56y8IaE2I3CTvG99mlhQ=="],
 
     "@astrojs/vercel": ["@astrojs/vercel@8.2.7", "", { "dependencies": { "@astrojs/internal-helpers": "0.7.2", "@vercel/analytics": "^1.5.0", "@vercel/functions": "^2.2.2", "@vercel/nft": "^0.29.2", "@vercel/routing-utils": "^5.1.1", "esbuild": "^0.25.0", "tinyglobby": "^0.2.13" }, "peerDependencies": { "astro": "^5.0.0" } }, "sha512-QeozkGU/0qch8MZlKJDKt+Dp8IUKA/E4MxnecVz1J0eVaXB6ao/HYcW7Tcr8LpWYU77Twhc60SgHIjrE3j2nYg=="],
+
+    "@astrojs/yaml2ts": ["@astrojs/yaml2ts@0.2.4", "", { "dependencies": { "yaml": "^2.8.3" } }, "sha512-8oddpOae35pJsXPQXhTkM0ypfKPskVsh2bCxRtbf7e+/Epw2nReakFYpLKjZMEr75CsoF203PMnCocpfz0s69A=="],
 
     "@babel/code-frame": ["@babel/code-frame@7.27.1", "", { "dependencies": { "@babel/helper-validator-identifier": "^7.27.1", "js-tokens": "^4.0.0", "picocolors": "^1.1.1" } }, "sha512-cjQ7ZlQ0Mv3b47hABuTevyTuYN4i+loJKGeV9flcCgIK37cCXRh+L1bd3iBHlynerhQ7BhCkn2BPbQUL+rGqFg=="],
 
@@ -97,6 +105,20 @@
     "@csstools/css-parser-algorithms": ["@csstools/css-parser-algorithms@3.0.5", "", { "peerDependencies": { "@csstools/css-tokenizer": "^3.0.4" } }, "sha512-DaDeUkXZKjdGhgYaHNJTV9pV7Y9B3b644jCLs9Upc3VeNGg6LWARAT6O+Q+/COo+2gg/bM5rhpMAtf70WqfBdQ=="],
 
     "@csstools/css-tokenizer": ["@csstools/css-tokenizer@3.0.4", "", {}, "sha512-Vd/9EVDiu6PPJt9yAh6roZP6El1xHrdvIVGjyBsHR0RYwNHgL7FJPyIIW4fANJNG6FtyZfvlRPpFI4ZM/lubvw=="],
+
+    "@emmetio/abbreviation": ["@emmetio/abbreviation@2.3.3", "", { "dependencies": { "@emmetio/scanner": "^1.0.4" } }, "sha512-mgv58UrU3rh4YgbE/TzgLQwJ3pFsHHhCLqY20aJq+9comytTXUDNGG/SMtSeMJdkpxgXSXunBGLD8Boka3JyVA=="],
+
+    "@emmetio/css-abbreviation": ["@emmetio/css-abbreviation@2.1.8", "", { "dependencies": { "@emmetio/scanner": "^1.0.4" } }, "sha512-s9yjhJ6saOO/uk1V74eifykk2CBYi01STTK3WlXWGOepyKa23ymJ053+DNQjpFcy1ingpaO7AxCcwLvHFY9tuw=="],
+
+    "@emmetio/css-parser": ["@emmetio/css-parser@0.4.1", "", { "dependencies": { "@emmetio/stream-reader": "^2.2.0", "@emmetio/stream-reader-utils": "^0.1.0" } }, "sha512-2bC6m0MV/voF4CTZiAbG5MWKbq5EBmDPKu9Sb7s7nVcEzNQlrZP6mFFFlIaISM8X6514H9shWMme1fCm8cWAfQ=="],
+
+    "@emmetio/html-matcher": ["@emmetio/html-matcher@1.3.0", "", { "dependencies": { "@emmetio/scanner": "^1.0.0" } }, "sha512-NTbsvppE5eVyBMuyGfVu2CRrLvo7J4YHb6t9sBFLyY03WYhXET37qA4zOYUjBWFCRHO7pS1B9khERtY0f5JXPQ=="],
+
+    "@emmetio/scanner": ["@emmetio/scanner@1.0.4", "", {}, "sha512-IqRuJtQff7YHHBk4G8YZ45uB9BaAGcwQeVzgj/zj8/UdOhtQpEIupUhSk8dys6spFIWVZVeK20CzGEnqR5SbqA=="],
+
+    "@emmetio/stream-reader": ["@emmetio/stream-reader@2.2.0", "", {}, "sha512-fXVXEyFA5Yv3M3n8sUGT7+fvecGrZP4k6FnWWMSZVQf69kAq0LLpaBQLGcPR30m3zMmKYhECP4k/ZkzvhEW5kw=="],
+
+    "@emmetio/stream-reader-utils": ["@emmetio/stream-reader-utils@0.1.0", "", {}, "sha512-ZsZ2I9Vzso3Ho/pjZFsmmZ++FWeEd/txqybHTm4OgaZzdS8V9V/YYWQwg5TC38Z7uLWUV1vavpLLbjJtKubR1A=="],
 
     "@emnapi/runtime": ["@emnapi/runtime@1.5.0", "", { "dependencies": { "tslib": "^2.4.0" } }, "sha512-97/BJ3iXHww3djw6hYIfErCZFee7qCtrneuLa20UXFCOTCfBM2cvQHjWJ2EG0s0MtdNwInarqCTz35i4wWXHsQ=="],
 
@@ -492,6 +514,22 @@
 
     "@vitest/utils": ["@vitest/utils@3.2.4", "", { "dependencies": { "@vitest/pretty-format": "3.2.4", "loupe": "^3.1.4", "tinyrainbow": "^2.0.0" } }, "sha512-fB2V0JFrQSMsCo9HiSq3Ezpdv4iYaXRG1Sx8edX3MwxfyNn83mKiGzOcH+Fkxt4MHxr3y42fQi1oeAInqgX2QA=="],
 
+    "@volar/kit": ["@volar/kit@2.4.28", "", { "dependencies": { "@volar/language-service": "2.4.28", "@volar/typescript": "2.4.28", "typesafe-path": "^0.2.2", "vscode-languageserver-textdocument": "^1.0.11", "vscode-uri": "^3.0.8" }, "peerDependencies": { "typescript": "*" } }, "sha512-cKX4vK9dtZvDRaAzeoUdaAJEew6IdxHNCRrdp5Kvcl6zZOqb6jTOfk3kXkIkG3T7oTFXguEMt5+9ptyqYR84Pg=="],
+
+    "@volar/language-core": ["@volar/language-core@2.4.28", "", { "dependencies": { "@volar/source-map": "2.4.28" } }, "sha512-w4qhIJ8ZSitgLAkVay6AbcnC7gP3glYM3fYwKV3srj8m494E3xtrCv6E+bWviiK/8hs6e6t1ij1s2Endql7vzQ=="],
+
+    "@volar/language-server": ["@volar/language-server@2.4.28", "", { "dependencies": { "@volar/language-core": "2.4.28", "@volar/language-service": "2.4.28", "@volar/typescript": "2.4.28", "path-browserify": "^1.0.1", "request-light": "^0.7.0", "vscode-languageserver": "^9.0.1", "vscode-languageserver-protocol": "^3.17.5", "vscode-languageserver-textdocument": "^1.0.11", "vscode-uri": "^3.0.8" } }, "sha512-NqcLnE5gERKuS4PUFwlhMxf6vqYo7hXtbMFbViXcbVkbZ905AIVWhnSo0ZNBC2V127H1/2zP7RvVOVnyITFfBw=="],
+
+    "@volar/language-service": ["@volar/language-service@2.4.28", "", { "dependencies": { "@volar/language-core": "2.4.28", "vscode-languageserver-protocol": "^3.17.5", "vscode-languageserver-textdocument": "^1.0.11", "vscode-uri": "^3.0.8" } }, "sha512-Rh/wYCZJrI5vCwMk9xyw/Z+MsWxlJY1rmMZPsxUoJKfzIRjS/NF1NmnuEcrMbEVGja00aVpCsInJfixQTMdvLw=="],
+
+    "@volar/source-map": ["@volar/source-map@2.4.28", "", {}, "sha512-yX2BDBqJkRXfKw8my8VarTyjv48QwxdJtvRgUpNE5erCsgEUdI2DsLbpa+rOQVAJYshY99szEcRDmyHbF10ggQ=="],
+
+    "@volar/typescript": ["@volar/typescript@2.4.28", "", { "dependencies": { "@volar/language-core": "2.4.28", "path-browserify": "^1.0.1", "vscode-uri": "^3.0.8" } }, "sha512-Ja6yvWrbis2QtN4ClAKreeUZPVYMARDYZl9LMEv1iQ1QdepB6wn0jTRxA9MftYmYa4DQ4k/DaSZpFPUfxl8giw=="],
+
+    "@vscode/emmet-helper": ["@vscode/emmet-helper@2.11.0", "", { "dependencies": { "emmet": "^2.4.3", "jsonc-parser": "^2.3.0", "vscode-languageserver-textdocument": "^1.0.1", "vscode-languageserver-types": "^3.15.1", "vscode-uri": "^3.0.8" } }, "sha512-QLxjQR3imPZPQltfbWRnHU6JecWTF1QSWhx3GAKQpslx7y3Dp6sIIXhKjiUJ/BR9FX8PVthjr9PD6pNwOJfAzw=="],
+
+    "@vscode/l10n": ["@vscode/l10n@0.0.18", "", {}, "sha512-KYSIHVmslkaCDyw013pphY+d7x1qV8IZupYfeIfzNA+nsaWHbn5uPuQRvdRFsa9zFzGeudPuoGoZ1Op4jrJXIQ=="],
+
     "@webgpu/types": ["@webgpu/types@0.1.64", "", {}, "sha512-84kRIAGV46LJTlJZWxShiOrNL30A+9KokD7RB3dRCIqODFjodS5tCD5yyiZ8kIReGVZSDfA3XkkwyyOIF6K62A=="],
 
     "@xmldom/xmldom": ["@xmldom/xmldom@0.8.11", "", {}, "sha512-cQzWCtO6C8TQiYl1ruKNn2U6Ao4o4WBBcbL61yJl84x+j5sOWWFU9X7DpND8XZG3daDppSsigMdfAIl2upQBRw=="],
@@ -507,6 +545,8 @@
     "agent-base": ["agent-base@7.1.4", "", {}, "sha512-MnA+YT8fwfJPgBx3m60MNqakm30XOkyIoH1y6huTQvC0PwZG7ki8NacLBcrPbNoo8vEZy7Jpuk7+jMO+CUovTQ=="],
 
     "ajv": ["ajv@6.12.6", "", { "dependencies": { "fast-deep-equal": "^3.1.1", "fast-json-stable-stringify": "^2.0.0", "json-schema-traverse": "^0.4.1", "uri-js": "^4.2.2" } }, "sha512-j3fVLgvTo527anyYyJOGTYJbG+vnnQYvE0m5mmkc1TK+nxAppkCLMIL0aZ4dblVCNoGShhm+kzE4ZUykBoMg4g=="],
+
+    "ajv-draft-04": ["ajv-draft-04@1.0.0", "", { "peerDependencies": { "ajv": "^8.5.0" }, "optionalPeers": ["ajv"] }, "sha512-mv00Te6nmYbRp5DCwclxtt7yV/joXJPGS7nM+97GdxvuttCOfgI3K4U25zboyeX0O+myI8ERluxQe5wljMmVIw=="],
 
     "ansi-align": ["ansi-align@3.0.1", "", { "dependencies": { "string-width": "^4.1.0" } }, "sha512-IOfwwBF5iczOjp/WeY4YxyjqAFMQoZufdQWDd19SEExbVLNXqvpzSJ/M7Za4/sCPmQ0+GRquoA7bGcINcxew6w=="],
 
@@ -604,6 +644,8 @@
 
     "cli-truncate": ["cli-truncate@4.0.0", "", { "dependencies": { "slice-ansi": "^5.0.0", "string-width": "^7.0.0" } }, "sha512-nPdaFdQ0h/GEigbPClz11D0v/ZJEwxmeVZGeMo3Z5StPtUTkA9o1lD6QwoirYiSDzbcwn2XcjwmCp68W1IS4TA=="],
 
+    "cliui": ["cliui@8.0.1", "", { "dependencies": { "string-width": "^4.2.0", "strip-ansi": "^6.0.1", "wrap-ansi": "^7.0.0" } }, "sha512-BSeNnyus75C4//NQ9gQt1/csTXyo/8Sb+afLAkzAptFuMsod9HFokGNudZpi/oQV73hnVK+sR+5PVRMd+Dr7YQ=="],
+
     "clone": ["clone@2.1.2", "", {}, "sha512-3Pe/CF1Nn94hyhIYpjtiLhdCoEoz0DqQ+988E9gmeEdQZlojxnOb74wctFyuwWQHzqyf9X7C7MG8juUpqBJT8w=="],
 
     "clsx": ["clsx@2.1.1", "", {}, "sha512-eYm0QWBtUrBWZWG0d386OGAw16Z995PiOVo2B7bjWSbHedGl5e0ZWaq65kOGgUSNesEIDkB9ISbTg/JK9dhCZA=="],
@@ -694,7 +736,9 @@
 
     "eastasianwidth": ["eastasianwidth@0.2.0", "", {}, "sha512-I88TYZWc9XiYHRQ4/3c5rjjfgkjhLyW2luGIheGERbNQ6OY7yTybanSpDXZa8y7VUP9YmDcYa+eyq4ca7iLqWA=="],
 
-    "emoji-regex": ["emoji-regex@10.5.0", "", {}, "sha512-lb49vf1Xzfx080OKA0o6l8DQQpV+6Vg95zyCJX9VB/BqKYlhG7N4wgROUUHRA+ZPUefLnteQOad7z1kT2bV7bg=="],
+    "emmet": ["emmet@2.4.11", "", { "dependencies": { "@emmetio/abbreviation": "^2.3.3", "@emmetio/css-abbreviation": "^2.1.8" } }, "sha512-23QPJB3moh/U9sT4rQzGgeyyGIrcM+GH5uVYg2C6wZIxAIJq7Ng3QLT79tl8FUwDXhyq9SusfknOrofAKqvgyQ=="],
+
+    "emoji-regex": ["emoji-regex@8.0.0", "", {}, "sha512-MSjYzcWNOA0ewAHpz0MxpYFvwg6yjy1NG3xteoqz644VCo/RPgnr1/GGt+ic3iJTzQ8Eu3TdM14SawnVUmGE6A=="],
 
     "enhanced-resolve": ["enhanced-resolve@5.18.3", "", { "dependencies": { "graceful-fs": "^4.2.4", "tapable": "^2.2.0" } }, "sha512-d4lC8xfavMeBjzGr2vECC3fsGXziXZQyJxD868h2M/mBI3PwAuODxAkLkq5HYuvrPYcUtiLzsTo8U3PgX3Ocww=="],
 
@@ -709,6 +753,8 @@
     "esast-util-from-js": ["esast-util-from-js@2.0.1", "", { "dependencies": { "@types/estree-jsx": "^1.0.0", "acorn": "^8.0.0", "esast-util-from-estree": "^2.0.0", "vfile-message": "^4.0.0" } }, "sha512-8Ja+rNJ0Lt56Pcf3TAmpBZjmx8ZcK5Ts4cAzIOjsjevg9oSXJnl6SUQ2EevU8tv3h6ZLWmoKL5H4fgWvdvfETw=="],
 
     "esbuild": ["esbuild@0.25.9", "", { "optionalDependencies": { "@esbuild/aix-ppc64": "0.25.9", "@esbuild/android-arm": "0.25.9", "@esbuild/android-arm64": "0.25.9", "@esbuild/android-x64": "0.25.9", "@esbuild/darwin-arm64": "0.25.9", "@esbuild/darwin-x64": "0.25.9", "@esbuild/freebsd-arm64": "0.25.9", "@esbuild/freebsd-x64": "0.25.9", "@esbuild/linux-arm": "0.25.9", "@esbuild/linux-arm64": "0.25.9", "@esbuild/linux-ia32": "0.25.9", "@esbuild/linux-loong64": "0.25.9", "@esbuild/linux-mips64el": "0.25.9", "@esbuild/linux-ppc64": "0.25.9", "@esbuild/linux-riscv64": "0.25.9", "@esbuild/linux-s390x": "0.25.9", "@esbuild/linux-x64": "0.25.9", "@esbuild/netbsd-arm64": "0.25.9", "@esbuild/netbsd-x64": "0.25.9", "@esbuild/openbsd-arm64": "0.25.9", "@esbuild/openbsd-x64": "0.25.9", "@esbuild/openharmony-arm64": "0.25.9", "@esbuild/sunos-x64": "0.25.9", "@esbuild/win32-arm64": "0.25.9", "@esbuild/win32-ia32": "0.25.9", "@esbuild/win32-x64": "0.25.9" }, "bin": "bin/esbuild" }, "sha512-CRbODhYyQx3qp7ZEwzxOk4JBqmD/seJrzPa/cGjY1VtIn5E09Oi9/dB4JwctnfZ8Q8iT7rioVv5k/FNT/uf54g=="],
+
+    "escalade": ["escalade@3.2.0", "", {}, "sha512-WUj2qlxaQtO4g6Pq5c29GTcWGDyd8itL8zTlipgECz3JesAiiOKotd8JU6otB3PACgG6xkJUyVhboMS+bje/jA=="],
 
     "escape-string-regexp": ["escape-string-regexp@4.0.0", "", {}, "sha512-TtpcNJ3XAzx3Gq8sWRzJaVajRs0uVxA2YAkdb1jm2YkPz4G6egUFAyA3n5vtEIZefPk5Wa4UXbKuS5fKkJWdgA=="],
 
@@ -760,6 +806,8 @@
 
     "fast-levenshtein": ["fast-levenshtein@2.0.6", "", {}, "sha512-DCXu6Ifhqcks7TZKY3Hxp3y6qphY5SJZmrWMDrKcERSOXWQdMhU9Ig/PYrzyw/ul9jOIyh0N4M0tbC5hodg8dw=="],
 
+    "fast-uri": ["fast-uri@3.1.2", "", {}, "sha512-rVjf7ArG3LTk+FS6Yw81V1DLuZl1bRbNrev6Tmd/9RaroeeRRJhAt7jg/6YFxbvAQXUCavSoZhPPj6oOx+5KjQ=="],
+
     "fastq": ["fastq@1.19.1", "", { "dependencies": { "reusify": "^1.0.4" } }, "sha512-GwLTyxkCXjXbxqIhTsMI2Nui8huMPtnxg7krajPJAjnEG/iiOS7i+zCtWGZR9G0NBKbXKh6X9m9UIsYX/N6vvQ=="],
 
     "fdir": ["fdir@6.5.0", "", { "peerDependencies": { "picomatch": "^3 || ^4" } }, "sha512-tIbYtZbucOs0BRGqPJkshJUYdL+SDH7dVM8gjy+ERp3WAUjLEFJE+02kanyHtwjWOnwrKYBiwAmM0p4kLJAnXg=="],
@@ -791,6 +839,8 @@
     "formdata-polyfill": ["formdata-polyfill@4.0.10", "", { "dependencies": { "fetch-blob": "^3.1.2" } }, "sha512-buewHzMvYL29jdeQTVILecSaZKnt/RJWjoZCF5OW60Z67/GmSLBkOFM7qh1PI3zFNtJbaZL5eQu1vLfazOwj4g=="],
 
     "fsevents": ["fsevents@2.3.2", "", { "os": "darwin" }, "sha512-xiqMQR4xAeHTuB9uWm+fFRcIOgKBMiOBP+eXiyT7jsgVCq1bkVygt00oASowB7EdtpOHaaPgKt812P9ab+DDKA=="],
+
+    "get-caller-file": ["get-caller-file@2.0.5", "", {}, "sha512-DyFP3BM/3YHTQOCUL/w0OZHR0lpKeGrxotcHWcqNEdnltqFwXVfhEBQ94eIo34AfQpo0rGki4cyIiftY06h2Fg=="],
 
     "get-east-asian-width": ["get-east-asian-width@1.3.0", "", {}, "sha512-vpeMIQKxczTD/0s2CdEWHcb0eeJe6TFjxb+J5xgX7hScxqrGuyjmv4c1D4A/gelKfyox0gJJwIHF+fLjeaM8kQ=="],
 
@@ -878,7 +928,7 @@
 
     "is-extglob": ["is-extglob@2.1.1", "", {}, "sha512-SbKbANkN603Vi4jEZv49LeVJMn4yGwsbzZworEoyEiutsN3nJYdbO36zfhGJ6QEDpOZIFkDtnq5JRxmvl3jsoQ=="],
 
-    "is-fullwidth-code-point": ["is-fullwidth-code-point@4.0.0", "", {}, "sha512-O4L094N2/dZ7xqVdrXhh9r1KODPJpFms8B5sGdJLPy664AgvXsreZUyCQQNItZRDlYug4xStLjNp/sz3HvBowQ=="],
+    "is-fullwidth-code-point": ["is-fullwidth-code-point@3.0.0", "", {}, "sha512-zymm5+u+sCsSWyD9qNaejV3DFvhCKclKdizYaJUuHA83RLjb7nSuGnddCHGv0hk+KY7BMAlsWeK4Ueg6EV6XQg=="],
 
     "is-glob": ["is-glob@4.0.3", "", { "dependencies": { "is-extglob": "^2.1.1" } }, "sha512-xelSayHH36ZgE7ZWhli7pW34hNbNl8Ojv5KVmkJD4hBdD3th8Tfk9vYasLM+mXWOZhFkgZfxhLSnrwRr4elSSg=="],
 
@@ -927,6 +977,8 @@
     "json-schema-traverse": ["json-schema-traverse@0.4.1", "", {}, "sha512-xbbCH5dCYU5T8LcEhhuh7HJ88HXuW3qsI3Y0zOZFKfZEHcpWiHU/Jxzk629Brsab/mMiHQti9wMP+845RPe3Vg=="],
 
     "json-stable-stringify-without-jsonify": ["json-stable-stringify-without-jsonify@1.0.1", "", {}, "sha512-Bdboy+l7tA3OGW6FjyFHWkP5LuByj1Tk33Ljyq0axyzdk9//JSi2u3fP1QSmd1KNwq6VOKYGlAu87CisVir6Pw=="],
+
+    "jsonc-parser": ["jsonc-parser@2.3.1", "", {}, "sha512-H8jvkz1O50L3dMZCsLqiuB2tA7muqbSg1AtGEkN0leAqGjsUzDJir3Zwr02BhqdcITPg3ei3mZ+HjMocAknhhg=="],
 
     "keyv": ["keyv@4.5.4", "", { "dependencies": { "json-buffer": "3.0.1" } }, "sha512-oxVHkHR/EJf2CNXnWxRLW6mg7JyCCUcG0DtEGmL2ctUo1PNTin1PUil+r/+4r5MpVgC/fn1kjsx7mjSujKqIpw=="],
 
@@ -1118,6 +1170,8 @@
 
     "ms": ["ms@2.1.3", "", {}, "sha512-6FlzubTLZG3J2a/NVCAleEhjzq5oxgHyaCU9yYXvcLsvoVaHJq/s5xXI6/XXP6tz7R9xAOtHnSO/tXtF3WRTlA=="],
 
+    "muggle-string": ["muggle-string@0.4.1", "", {}, "sha512-VNTrAak/KhO2i8dqqnqnAHOa3cYBwXEZe9h+D5h/1ZqFSTEFHdM65lR7RoIqq3tBBYavsOXV84NoHXZ0AkPyqQ=="],
+
     "nano-spawn": ["nano-spawn@1.0.2", "", {}, "sha512-21t+ozMQDAL/UGgQVBbZ/xXvNO10++ZPuTmKRO8k9V3AClVRht49ahtDjfY8l1q6nSHOrE5ASfthzH3ol6R/hg=="],
 
     "nanoid": ["nanoid@3.3.11", "", { "bin": "bin/nanoid.cjs" }, "sha512-N8SpfPUnUp1bK+PMYW8qSWdl9U+wwNWI4QKxOYDy9JAro3WMX7p2OeVRF9v+347pnakNevPmiHhNmZ2HbFA76w=="],
@@ -1181,6 +1235,8 @@
     "parse-svg-path": ["parse-svg-path@0.1.2", "", {}, "sha512-JyPSBnkTJ0AI8GGJLfMXvKq42cj5c006fnLz6fXy6zfoVjJizi8BNTpu8on8ziI1cKy9d9DGNuY17Ce7wuejpQ=="],
 
     "parse5": ["parse5@7.3.0", "", { "dependencies": { "entities": "^6.0.0" } }, "sha512-IInvU7fabl34qmi9gY8XOVxhYyMyuH2xUNpb2q8/Y+7552KlejkRvqvD19nMoUW/uQGGbqNpA6Tufu5FL5BZgw=="],
+
+    "path-browserify": ["path-browserify@1.0.1", "", {}, "sha512-b7uo2UCUOYZcnF/3ID0lulOJi/bafxa1xPe7ZPsammBSpjSWQkjNxlt635YGS2MiR9GjvuXCtz2emr3jbsz98g=="],
 
     "path-exists": ["path-exists@4.0.0", "", {}, "sha512-ak9Qy5Q7jYb2Wwcey5Fpvg2KoAc/ZIhLSLOSBmRmygPsGwkVVt0fZa0qrtMz+m6tJTAHfZQ8FnmB4MG4LWy7/w=="],
 
@@ -1282,6 +1338,12 @@
 
     "remark-stringify": ["remark-stringify@11.0.0", "", { "dependencies": { "@types/mdast": "^4.0.0", "mdast-util-to-markdown": "^2.0.0", "unified": "^11.0.0" } }, "sha512-1OSmLd3awB/t8qdoEOMazZkNsfVTeY4fTsgzcQFdXNq8ToTN4ZGwrMnlda4K6smTFKD+GRV6O48i6Z4iKgPPpw=="],
 
+    "request-light": ["request-light@0.7.0", "", {}, "sha512-lMbBMrDoxgsyO+yB3sDcrDuX85yYt7sS8BfQd11jtbW/z5ZWgLZRcEGLsLoYw7I0WSUGQBs8CC8ScIxkTX1+6Q=="],
+
+    "require-directory": ["require-directory@2.1.1", "", {}, "sha512-fGxEI7+wsG9xrvdjsrlmL22OMTTiHRwAMroiEeMgq8gzoLC/PQr7RsRDSTLUg/bZAZtF+TVIkHc6/4RIKrui+Q=="],
+
+    "require-from-string": ["require-from-string@2.0.2", "", {}, "sha512-Xf0nWe6RseziFMu+Ap9biiUbmplq6S9/p+7w7YXP/JBHhrUDDUhwa+vANyubuqfZWTveU//DYVGsDG7RKL/vEw=="],
+
     "resolve-from": ["resolve-from@5.0.0", "", {}, "sha512-qYg9KP24dD5qka9J47d0aVky0N+b4fTU89LN9iDnjB5waksiC49rvMB0PrUJQGoTmH50XPiqOvAjDfaijGxYZw=="],
 
     "restore-cursor": ["restore-cursor@5.1.0", "", { "dependencies": { "onetime": "^7.0.0", "signal-exit": "^4.1.0" } }, "sha512-oMA2dcrw6u0YfxJQXm342bFKX/E4sG9rbTzO9ptUcR/e8A33cHuvStiYOwH7fszkZlZ1z/ta9AAoPk2F4qIOHA=="],
@@ -1354,13 +1416,13 @@
 
     "string-argv": ["string-argv@0.3.2", "", {}, "sha512-aqD2Q0144Z+/RqG52NeHEkZauTAUWJO8c6yTftGJKO3Tja5tUgIfmIl6kExvhtxSDP7fXB6DvzkfMpCd/F3G+Q=="],
 
-    "string-width": ["string-width@7.2.0", "", { "dependencies": { "emoji-regex": "^10.3.0", "get-east-asian-width": "^1.0.0", "strip-ansi": "^7.1.0" } }, "sha512-tsaTIkKW9b4N+AEj+SVA+WhJzV7/zMhcSu78mLKWSk7cXMOSHsBKFWUs0fWwq8QyK3MgJBQRX6Gbi4kYbdvGkQ=="],
+    "string-width": ["string-width@4.2.3", "", { "dependencies": { "emoji-regex": "^8.0.0", "is-fullwidth-code-point": "^3.0.0", "strip-ansi": "^6.0.1" } }, "sha512-wKyQRQpjJ0sIp62ErSZdGsjMJWsap5oRNihHhu6G7JVO/9jIB6UyevL+tXuOqrng8j/cxKTWyWUwvSTriiZz/g=="],
 
     "string-width-cjs": ["string-width@4.2.3", "", { "dependencies": { "emoji-regex": "^8.0.0", "is-fullwidth-code-point": "^3.0.0", "strip-ansi": "^6.0.1" } }, "sha512-wKyQRQpjJ0sIp62ErSZdGsjMJWsap5oRNihHhu6G7JVO/9jIB6UyevL+tXuOqrng8j/cxKTWyWUwvSTriiZz/g=="],
 
     "stringify-entities": ["stringify-entities@4.0.4", "", { "dependencies": { "character-entities-html4": "^2.0.0", "character-entities-legacy": "^3.0.0" } }, "sha512-IwfBptatlO+QCJUo19AqvrPNqlVMpW9YEL2LIVY+Rpv2qsjCGxaDLNRgeGsQWJhfItebuJhsGSLjaBbNSQ+ieg=="],
 
-    "strip-ansi": ["strip-ansi@7.1.0", "", { "dependencies": { "ansi-regex": "^6.0.1" } }, "sha512-iq6eVVI64nQQTRYq2KtEg2d2uU7LElhTJwsH4YzIHZshxlgZms/wIc4VoDQTlG/IvVIrBKG06CrZnp0qv7hkcQ=="],
+    "strip-ansi": ["strip-ansi@6.0.1", "", { "dependencies": { "ansi-regex": "^5.0.1" } }, "sha512-Y38VPSHcqkFrCpFnQ9vuSXmquuv5oXOKpGeT6aGrr3o3Gc9AlVa6JBfUSOCnbxGGZF+/0ooI7KrPuUSztUdU5A=="],
 
     "strip-ansi-cjs": ["strip-ansi@6.0.1", "", { "dependencies": { "ansi-regex": "^5.0.1" } }, "sha512-Y38VPSHcqkFrCpFnQ9vuSXmquuv5oXOKpGeT6aGrr3o3Gc9AlVa6JBfUSOCnbxGGZF+/0ooI7KrPuUSztUdU5A=="],
 
@@ -1448,7 +1510,11 @@
 
     "type-fest": ["type-fest@4.41.0", "", {}, "sha512-TeTSQ6H5YHvpqVwBRcnLDCBnDOHWYu7IvGbHT6N8AOymcr9PJGjc1GTtiWZTYg0NCgYwvnYWEkVChQAr9bjfwA=="],
 
-    "typescript": ["typescript@5.9.2", "", { "bin": { "tsc": "bin/tsc", "tsserver": "bin/tsserver" } }, "sha512-CWBzXQrc/qOkhidw1OzBTQuYRbfyxDXJMVJ1XNwUHGROVmuaeiEm3OslpZ1RV96d7SKKjZKrSJu3+t/xlw3R9A=="],
+    "typesafe-path": ["typesafe-path@0.2.2", "", {}, "sha512-OJabfkAg1WLZSqJAJ0Z6Sdt3utnbzr/jh+NAHoyWHJe8CMSy79Gm085094M9nvTPy22KzTVn5Zq5mbapCI/hPA=="],
+
+    "typescript": ["typescript@6.0.3", "", { "bin": { "tsc": "bin/tsc", "tsserver": "bin/tsserver" } }, "sha512-y2TvuxSZPDyQakkFRPZHKFm+KKVqIisdg9/CZwm9ftvKXLP8NRWj38/ODjNbr43SsoXqNuAisEf1GdCxqWcdBw=="],
+
+    "typescript-auto-import-cache": ["typescript-auto-import-cache@0.3.6", "", { "dependencies": { "semver": "^7.3.8" } }, "sha512-RpuHXrknHdVdK7wv/8ug3Fr0WNsNi5l5aB8MYYuXhq2UH5lnEB1htJ1smhtD5VeCsGr2p8mUDtd83LCQDFVgjQ=="],
 
     "typescript-eslint": ["typescript-eslint@8.41.0", "", { "dependencies": { "@typescript-eslint/eslint-plugin": "8.41.0", "@typescript-eslint/parser": "8.41.0", "@typescript-eslint/typescript-estree": "8.41.0", "@typescript-eslint/utils": "8.41.0" }, "peerDependencies": { "eslint": "^8.57.0 || ^9.0.0", "typescript": ">=4.8.4 <6.0.0" } }, "sha512-n66rzs5OBXW3SFSnZHr2T685q1i4ODm2nulFJhMZBotaTavsS8TrI3d7bDlRSs9yWo7HmyWrN9qDu14Qv7Y0Dw=="],
 
@@ -1508,6 +1574,40 @@
 
     "vitest": ["vitest@3.2.4", "", { "dependencies": { "@types/chai": "^5.2.2", "@vitest/expect": "3.2.4", "@vitest/mocker": "3.2.4", "@vitest/pretty-format": "^3.2.4", "@vitest/runner": "3.2.4", "@vitest/snapshot": "3.2.4", "@vitest/spy": "3.2.4", "@vitest/utils": "3.2.4", "chai": "^5.2.0", "debug": "^4.4.1", "expect-type": "^1.2.1", "magic-string": "^0.30.17", "pathe": "^2.0.3", "picomatch": "^4.0.2", "std-env": "^3.9.0", "tinybench": "^2.9.0", "tinyexec": "^0.3.2", "tinyglobby": "^0.2.14", "tinypool": "^1.1.1", "tinyrainbow": "^2.0.0", "vite": "^5.0.0 || ^6.0.0 || ^7.0.0-0", "vite-node": "3.2.4", "why-is-node-running": "^2.3.0" }, "peerDependencies": { "@edge-runtime/vm": "*", "@types/debug": "^4.1.12", "@types/node": "^18.0.0 || ^20.0.0 || >=22.0.0", "@vitest/browser": "3.2.4", "@vitest/ui": "3.2.4", "happy-dom": "*", "jsdom": "*" }, "optionalPeers": ["@edge-runtime/vm", "@vitest/browser", "happy-dom"], "bin": "vitest.mjs" }, "sha512-LUCP5ev3GURDysTWiP47wRRUpLKMOfPh+yKTx3kVIEiu5KOMeqzpnYNsKyOoVrULivR8tLcks4+lga33Whn90A=="],
 
+    "volar-service-css": ["volar-service-css@0.0.70", "", { "dependencies": { "vscode-css-languageservice": "^6.3.0", "vscode-languageserver-textdocument": "^1.0.11", "vscode-uri": "^3.0.8" }, "peerDependencies": { "@volar/language-service": "~2.4.0" }, "optionalPeers": ["@volar/language-service"] }, "sha512-K1qyOvBpE3rzdAv3e4/6Rv5yizrYPy5R/ne3IWCAzLBuMO4qBMV3kSqWzj6KUVe6S0AnN6wxF7cRkiaKfYMYJw=="],
+
+    "volar-service-emmet": ["volar-service-emmet@0.0.70", "", { "dependencies": { "@emmetio/css-parser": "^0.4.1", "@emmetio/html-matcher": "^1.3.0", "@vscode/emmet-helper": "^2.9.3", "vscode-uri": "^3.0.8" }, "peerDependencies": { "@volar/language-service": "~2.4.0" }, "optionalPeers": ["@volar/language-service"] }, "sha512-xi5bC4m/VyE3zy/n2CXspKeDZs3qA41tHLTw275/7dNWM/RqE2z3BnDICQybHIVp/6G1iOQj5c1qXMgQC08TNg=="],
+
+    "volar-service-html": ["volar-service-html@0.0.70", "", { "dependencies": { "vscode-html-languageservice": "^5.3.0", "vscode-languageserver-textdocument": "^1.0.11", "vscode-uri": "^3.0.8" }, "peerDependencies": { "@volar/language-service": "~2.4.0" }, "optionalPeers": ["@volar/language-service"] }, "sha512-eR6vCgMdmYAo4n+gcT7DSyBQbwB8S3HZZvSagTf0sxNaD4WppMCFfpqWnkrlGStPKMZvMiejRRVmqsX9dYcTvQ=="],
+
+    "volar-service-prettier": ["volar-service-prettier@0.0.70", "", { "dependencies": { "vscode-uri": "^3.0.8" }, "peerDependencies": { "@volar/language-service": "~2.4.0", "prettier": "^2.2 || ^3.0" }, "optionalPeers": ["@volar/language-service", "prettier"] }, "sha512-Z6BCFSpGVCd8BPAsZ785Kce1BGlWd5ODqmqZGVuB14MJvrR4+CYz6cDy4F+igmE1gMifqfvMhdgT8Aud4M5ngg=="],
+
+    "volar-service-typescript": ["volar-service-typescript@0.0.70", "", { "dependencies": { "path-browserify": "^1.0.1", "semver": "^7.6.2", "typescript-auto-import-cache": "^0.3.5", "vscode-languageserver-textdocument": "^1.0.11", "vscode-nls": "^5.2.0", "vscode-uri": "^3.0.8" }, "peerDependencies": { "@volar/language-service": "~2.4.0" }, "optionalPeers": ["@volar/language-service"] }, "sha512-l46Bx4cokkUedTd74ojO5H/zqHZJ8SUuyZ0IB8JN4jfRqUM3bQFBHoOwlZCyZmOeO0A3RQNkMnFclxO4c++gsg=="],
+
+    "volar-service-typescript-twoslash-queries": ["volar-service-typescript-twoslash-queries@0.0.70", "", { "dependencies": { "vscode-uri": "^3.0.8" }, "peerDependencies": { "@volar/language-service": "~2.4.0" }, "optionalPeers": ["@volar/language-service"] }, "sha512-IdD13Z9N2Bu8EM6CM0fDV1E69olEYGHDU25X51YXmq8Y0CmJ2LNj6gOiBJgpS5JGUqFzECVhMNBW7R0sPdRTMQ=="],
+
+    "volar-service-yaml": ["volar-service-yaml@0.0.70", "", { "dependencies": { "vscode-uri": "^3.0.8", "yaml-language-server": "~1.20.0" }, "peerDependencies": { "@volar/language-service": "~2.4.0" }, "optionalPeers": ["@volar/language-service"] }, "sha512-0c8bXDBeoATF9F6iPIlOuYTuZAC4c+yi0siQo920u7eiBJk8oQmUmg9cDUbR4+Gl++bvGP4plj3fErbJuPqdcQ=="],
+
+    "vscode-css-languageservice": ["vscode-css-languageservice@6.3.10", "", { "dependencies": { "@vscode/l10n": "^0.0.18", "vscode-languageserver-textdocument": "^1.0.12", "vscode-languageserver-types": "3.17.5", "vscode-uri": "^3.1.0" } }, "sha512-eq5N9Er3fC4vA9zd9EFhyBG90wtCCuXgRSpAndaOgXMh1Wgep5lBgRIeDgjZBW9pa+332yC9+49cZMW8jcL3MA=="],
+
+    "vscode-html-languageservice": ["vscode-html-languageservice@5.6.2", "", { "dependencies": { "@vscode/l10n": "^0.0.18", "vscode-languageserver-textdocument": "^1.0.12", "vscode-languageserver-types": "^3.17.5", "vscode-uri": "^3.1.0" } }, "sha512-ulCrSnFnfQ16YzvwnYUgEbUEl/ZG7u2eV27YhvLObSHKkb8fw1Z9cgsnUwjTEeDIdJDoTDTDpxuhQwoenoLNMg=="],
+
+    "vscode-json-languageservice": ["vscode-json-languageservice@4.1.8", "", { "dependencies": { "jsonc-parser": "^3.0.0", "vscode-languageserver-textdocument": "^1.0.1", "vscode-languageserver-types": "^3.16.0", "vscode-nls": "^5.0.0", "vscode-uri": "^3.0.2" } }, "sha512-0vSpg6Xd9hfV+eZAaYN63xVVMOTmJ4GgHxXnkLCh+9RsQBkWKIghzLhW2B9ebfG+LQQg8uLtsQ2aUKjTgE+QOg=="],
+
+    "vscode-jsonrpc": ["vscode-jsonrpc@9.0.0", "", {}, "sha512-+VvMmQPJhtvJ+8O+zu2JKIRiLxXF8NW7krWgyMGeOHrp4Cn23T5hc0v2LknNeopDOB70wghHAds7mKtcZ0I4Sg=="],
+
+    "vscode-languageserver": ["vscode-languageserver@9.0.1", "", { "dependencies": { "vscode-languageserver-protocol": "3.17.5" }, "bin": { "installServerIntoExtension": "bin/installServerIntoExtension" } }, "sha512-woByF3PDpkHFUreUa7Hos7+pUWdeWMXRd26+ZX2A8cFx6v/JPTtd4/uN0/jB6XQHYaOlHbio03NTHCqrgG5n7g=="],
+
+    "vscode-languageserver-protocol": ["vscode-languageserver-protocol@3.18.0", "", { "dependencies": { "vscode-jsonrpc": "9.0.0", "vscode-languageserver-types": "3.18.0" } }, "sha512-Zdz+kJ12Iz6tc11xfZyEo501bBATHXrCjmMfnaR3pMnf1CoqZBKIynba3P+/bi9VEdrMbNtAVKYpKhbODvqy+Q=="],
+
+    "vscode-languageserver-textdocument": ["vscode-languageserver-textdocument@1.0.12", "", {}, "sha512-cxWNPesCnQCcMPeenjKKsOCKQZ/L6Tv19DTRIGuLWe32lyzWhihGVJ/rcckZXJxfdKCFvRLS3fpBIsV/ZGX4zA=="],
+
+    "vscode-languageserver-types": ["vscode-languageserver-types@3.18.0", "", {}, "sha512-8TsGPNMIMiiBdkORgRSvLjuiEIiAFtO+KssmYWxQ+uSVvlf7RjK8YKCOjPzZ+YA04jXEV7+7LvkSmHkhpNS99g=="],
+
+    "vscode-nls": ["vscode-nls@5.2.0", "", {}, "sha512-RAaHx7B14ZU04EU31pT+rKz2/zSl7xMsfIZuo8pd+KZO6PXtQmpevpq3vxvWNcrGbdmhM/rr5Uw5Mz+NBfhVng=="],
+
+    "vscode-uri": ["vscode-uri@3.1.0", "", {}, "sha512-/BpdSx+yCQGnCvecbyXdxHDkuk55/G3xwnC0GqY4gmQ3j+A+g8kzzgB4Nk/SINjqn6+waqw3EgbVF2QKExkRxQ=="],
+
     "w3c-xmlserializer": ["w3c-xmlserializer@5.0.0", "", { "dependencies": { "xml-name-validator": "^5.0.0" } }, "sha512-o8qghlI8NZHU1lLPrpi2+Uq7abh4GGPpYANlalzWxyWteJOCsr/P+oPBA49TOLu5FTZO4d3F9MnWJfiMo4BkmA=="],
 
     "web-namespaces": ["web-namespaces@2.0.1", "", {}, "sha512-bKr1DkiNa2krS7qxNtdrtHAmzuYGFQLiQ13TsorsdT6ULTkPLKuu5+GsFpDlg6JFjUTwX2DyhMPG2be8uPrqsQ=="],
@@ -1544,9 +1644,15 @@
 
     "xxhash-wasm": ["xxhash-wasm@1.1.0", "", {}, "sha512-147y/6YNh+tlp6nd/2pWq38i9h6mz/EuQ6njIrmW8D1BS5nCqs0P6DG+m6zTGnNz5I+uhZ0SHxBs9BsPrwcKDA=="],
 
+    "y18n": ["y18n@5.0.8", "", {}, "sha512-0pfFzegeDWJHJIAmTLRP2DwHjdF5s7jo9tuztdQxAhINCdvS+3nGINqPd00AphqJR/0LhANUS6/+7SCb98YOfA=="],
+
     "yallist": ["yallist@5.0.0", "", {}, "sha512-YgvUTfwqyc7UXVMrB+SImsVYSmTS8X/tSrtdNZMImM+n7+QTriRXyXim0mBrTXNeqzVF0KWGgHPeiyViFFrNDw=="],
 
     "yaml": ["yaml@2.8.1", "", { "bin": "bin.mjs" }, "sha512-lcYcMxX2PO9XMGvAJkJ3OsNMw+/7FKes7/hgerGUYWIoWu5j/+YQqcZr5JnPZWzOsEBgMbSbiSTn/dv/69Mkpw=="],
+
+    "yaml-language-server": ["yaml-language-server@1.20.0", "", { "dependencies": { "@vscode/l10n": "^0.0.18", "ajv": "^8.17.1", "ajv-draft-04": "^1.0.0", "prettier": "^3.5.0", "request-light": "^0.5.7", "vscode-json-languageservice": "4.1.8", "vscode-languageserver": "^9.0.0", "vscode-languageserver-textdocument": "^1.0.1", "vscode-languageserver-types": "^3.16.0", "vscode-uri": "^3.0.2", "yaml": "2.7.1" }, "bin": { "yaml-language-server": "bin/yaml-language-server" } }, "sha512-qhjK/bzSRZ6HtTvgeFvjNPJGWdZ0+x5NREV/9XZWFjIGezew2b4r5JPy66IfOhd5OA7KeFwk1JfmEbnTvev0cA=="],
+
+    "yargs": ["yargs@17.7.3", "", { "dependencies": { "cliui": "^8.0.1", "escalade": "^3.1.1", "get-caller-file": "^2.0.5", "require-directory": "^2.1.1", "string-width": "^4.2.3", "y18n": "^5.0.5", "yargs-parser": "^21.1.1" } }, "sha512-GZtjxm/J/4TSxuL3FNYjCmLktBTnIw/rVmKSIyKeYAZpmJB2ig9VauCC5xsa82GNKVKDAqpOn3KVzNt0zmrU0g=="],
 
     "yargs-parser": ["yargs-parser@21.1.1", "", {}, "sha512-tVpsJW7DdjecAiFpbIB1e3qxIQsE6NoPc5/eTdrbbIC4h0LVsWhnoa3g+m2HclBIujHzsxZ4VJVA+GUuc2/LBw=="],
 
@@ -1564,6 +1670,12 @@
 
     "zwitch": ["zwitch@2.0.4", "", {}, "sha512-bXE4cR/kVZhKZX/RjPEflHaKVhUVl85noU3v6b8apfQEc1x4A+zBxjZ4lN8LqGd6WZ3dl98pY4o717VFmoPp+A=="],
 
+    "@astrojs/language-server/@astrojs/compiler": ["@astrojs/compiler@2.13.1", "", {}, "sha512-f3FN83d2G/v32ipNClRKgYv30onQlMZX1vCeZMjPsMMPl1mDpmbl0+N5BYo4S/ofzqJyS5hvwacEo0CCVDn/Qg=="],
+
+    "@astrojs/language-server/tinyglobby": ["tinyglobby@0.2.17", "", { "dependencies": { "fdir": "^6.5.0", "picomatch": "^4.0.4" } }, "sha512-wXR/dYpcqKmfWpEdZjiKJOwCNFndD0DMnrW/cYjVGttEkBfVgcLFHoNrlj47mjOVic9yyNu65alsgF4NQyTa2g=="],
+
+    "@astrojs/yaml2ts/yaml": ["yaml@2.9.0", "", { "bin": { "yaml": "bin.mjs" } }, "sha512-2AvhNX3mb8zd6Zy7INTtSpl1F15HW6Wnqj0srWlkKLcpYl/gMIMJiyuGq2KeI2YFxUPjdlB+3Lc10seMLtL4cA=="],
+
     "@eslint-community/eslint-utils/eslint-visitor-keys": ["eslint-visitor-keys@3.4.3", "", {}, "sha512-wpc+LXeiyiisxPlEkUzU6svyS1frIO3Mgxj1fdy7Pm8Ygzguax2N3Fa/D/ag1WqbOprdI+uY6wMUl8/a2G+iag=="],
 
     "@eslint/eslintrc/globals": ["globals@14.0.0", "", {}, "sha512-oahGvuMGQlPw/ivIYBjVSrWAfWLBeku5tpPE2fOPLi+WHffIWbuh2tCjhyQhTBPMf5E9jDEH4FOmTYgYwbKwtQ=="],
@@ -1571,6 +1683,8 @@
     "@humanfs/node/@humanwhocodes/retry": ["@humanwhocodes/retry@0.3.1", "", {}, "sha512-JBxkERygn7Bv/GbN5Rv8Ul6LVknS+5Bp6RgDC/O8gEBU/yeH5Ui5C/OlWrTb6qct7LjjfT6Re2NxB0ln0yYybA=="],
 
     "@isaacs/cliui/string-width": ["string-width@5.1.2", "", { "dependencies": { "eastasianwidth": "^0.2.0", "emoji-regex": "^9.2.2", "strip-ansi": "^7.0.1" } }, "sha512-HnLOCR3vjcY8beoNLtcjZ5/nxn2afmME6lhrDrebokqMap+XbeW8n9TXpPDOqdGK5qcI3oT0GKTW6wC7EMiVqA=="],
+
+    "@isaacs/cliui/strip-ansi": ["strip-ansi@7.1.0", "", { "dependencies": { "ansi-regex": "^6.0.1" } }, "sha512-iq6eVVI64nQQTRYq2KtEg2d2uU7LElhTJwsH4YzIHZshxlgZms/wIc4VoDQTlG/IvVIrBKG06CrZnp0qv7hkcQ=="],
 
     "@isaacs/cliui/wrap-ansi": ["wrap-ansi@8.1.0", "", { "dependencies": { "ansi-styles": "^6.1.0", "string-width": "^5.0.1", "strip-ansi": "^7.0.1" } }, "sha512-si7QWI6zUMq56bESFvagtmzMdGOtoxfR+Sez11Mobfc7tm+VkUckk9bW2UeffTGVUbOksxmSw0AA2gs8g71NCQ=="],
 
@@ -1592,8 +1706,6 @@
 
     "@vercel/nft/estree-walker": ["estree-walker@2.0.2", "", {}, "sha512-Rfkk/Mp/DL7JVje3u18FxFujQlTNR2q6QfMSMB7AvCBx91NGj/ba3kCfza0f6dVDbw7YlRf/nDrn7pQrCCyQ/w=="],
 
-    "ansi-align/string-width": ["string-width@4.2.3", "", { "dependencies": { "emoji-regex": "^8.0.0", "is-fullwidth-code-point": "^3.0.0", "strip-ansi": "^6.0.1" } }, "sha512-wKyQRQpjJ0sIp62ErSZdGsjMJWsap5oRNihHhu6G7JVO/9jIB6UyevL+tXuOqrng8j/cxKTWyWUwvSTriiZz/g=="],
-
     "anymatch/picomatch": ["picomatch@2.3.1", "", {}, "sha512-JU3teHTNjmE2VCGFzuY8EXzCDVwEqB2a8fsIvwaStHhAWJEeVd1o1QD80CU6+ZdEXXSLbSsuLwJjkCBWqRQUVA=="],
 
     "ast-v8-to-istanbul/js-tokens": ["js-tokens@9.0.1", "", {}, "sha512-mxa9E9ITFOt0ban3j6L5MpjwegGz6lBQmM1IJkWeBZGcMxto50+eWdjC/52xDbS2vy0k7vIMK0Fe2wfL9OQSpQ=="],
@@ -1606,7 +1718,13 @@
 
     "boxen/chalk": ["chalk@5.6.0", "", {}, "sha512-46QrSQFyVSEyYAgQ22hQ+zDa60YHA4fBstHmtSApj1Y5vKtG27fWowW03jCk5KcbXEWPZUIR894aARCA/G1kfQ=="],
 
+    "boxen/string-width": ["string-width@7.2.0", "", { "dependencies": { "emoji-regex": "^10.3.0", "get-east-asian-width": "^1.0.0", "strip-ansi": "^7.1.0" } }, "sha512-tsaTIkKW9b4N+AEj+SVA+WhJzV7/zMhcSu78mLKWSk7cXMOSHsBKFWUs0fWwq8QyK3MgJBQRX6Gbi4kYbdvGkQ=="],
+
     "chalk/ansi-styles": ["ansi-styles@4.3.0", "", { "dependencies": { "color-convert": "^2.0.1" } }, "sha512-zbB9rCJAT1rbjiVDb2hqKFHNYLxgtk8NURxZ3IZwD3F6NtxbXZQCnnSi1Lkx+IDohdPlFp222wVALIheZJQSEg=="],
+
+    "cli-truncate/string-width": ["string-width@7.2.0", "", { "dependencies": { "emoji-regex": "^10.3.0", "get-east-asian-width": "^1.0.0", "strip-ansi": "^7.1.0" } }, "sha512-tsaTIkKW9b4N+AEj+SVA+WhJzV7/zMhcSu78mLKWSk7cXMOSHsBKFWUs0fWwq8QyK3MgJBQRX6Gbi4kYbdvGkQ=="],
+
+    "cliui/wrap-ansi": ["wrap-ansi@7.0.0", "", { "dependencies": { "ansi-styles": "^4.0.0", "string-width": "^4.1.0", "strip-ansi": "^6.0.0" } }, "sha512-YVGIj2kamLSTxw6NsZjoBxfSwsn0ycdesmc4p+Q21c5zPuZ1pl+NfxVdxPtdHvmNVOQ6XSYG4AUtyt/Fi7D16Q=="],
 
     "cross-fetch/node-fetch": ["node-fetch@2.7.0", "", { "dependencies": { "whatwg-url": "^5.0.0" }, "peerDependencies": { "encoding": "^0.1.0" }, "optionalPeers": ["encoding"] }, "sha512-c4FRfUm/dbcWZ7U+1Wq0AwCyFL+3nt2bEw05wfxSz+DWpWsitgmSgYmy2dQdWyKC1694ELPqMs/YzUSNozLt8A=="],
 
@@ -1626,6 +1744,8 @@
 
     "log-update/slice-ansi": ["slice-ansi@7.1.0", "", { "dependencies": { "ansi-styles": "^6.2.1", "is-fullwidth-code-point": "^5.0.0" } }, "sha512-bSiSngZ/jWeX93BqeIAbImyTbEihizcwNjFoRUIY/T1wWQsfsm2Vw1agPKylXvQTU7iASGdHhyqRlqQzfz+Htg=="],
 
+    "log-update/strip-ansi": ["strip-ansi@7.1.0", "", { "dependencies": { "ansi-regex": "^6.0.1" } }, "sha512-iq6eVVI64nQQTRYq2KtEg2d2uU7LElhTJwsH4YzIHZshxlgZms/wIc4VoDQTlG/IvVIrBKG06CrZnp0qv7hkcQ=="],
+
     "mdast-util-find-and-replace/escape-string-regexp": ["escape-string-regexp@5.0.0", "", {}, "sha512-/veY75JbMK4j1yjvuUxuVsiS/hr/4iHs9FTT6cgTexxdE0Ly/glccBAkloH/DofkjRbZU3bnoj38mOmhkZ0lHw=="],
 
     "micromatch/picomatch": ["picomatch@2.3.1", "", {}, "sha512-JU3teHTNjmE2VCGFzuY8EXzCDVwEqB2a8fsIvwaStHhAWJEeVd1o1QD80CU6+ZdEXXSLbSsuLwJjkCBWqRQUVA=="],
@@ -1640,13 +1760,7 @@
 
     "slice-ansi/ansi-styles": ["ansi-styles@6.2.1", "", {}, "sha512-bN798gFfQX+viw3R7yrGWRqnrN2oRkEkUjjl4JNn4E8GxxbjtG3FbrEIIY3l8/hrwUwIeCZvi4QuOTP4MErVug=="],
 
-    "string-width-cjs/emoji-regex": ["emoji-regex@8.0.0", "", {}, "sha512-MSjYzcWNOA0ewAHpz0MxpYFvwg6yjy1NG3xteoqz644VCo/RPgnr1/GGt+ic3iJTzQ8Eu3TdM14SawnVUmGE6A=="],
-
-    "string-width-cjs/is-fullwidth-code-point": ["is-fullwidth-code-point@3.0.0", "", {}, "sha512-zymm5+u+sCsSWyD9qNaejV3DFvhCKclKdizYaJUuHA83RLjb7nSuGnddCHGv0hk+KY7BMAlsWeK4Ueg6EV6XQg=="],
-
-    "string-width-cjs/strip-ansi": ["strip-ansi@6.0.1", "", { "dependencies": { "ansi-regex": "^5.0.1" } }, "sha512-Y38VPSHcqkFrCpFnQ9vuSXmquuv5oXOKpGeT6aGrr3o3Gc9AlVa6JBfUSOCnbxGGZF+/0ooI7KrPuUSztUdU5A=="],
-
-    "strip-ansi/ansi-regex": ["ansi-regex@6.2.0", "", {}, "sha512-TKY5pyBkHyADOPYlRT9Lx6F544mPl0vS5Ew7BJ45hA08Q+t3GjbueLliBWN3sMICk6+y7HdyxSzC4bWS8baBdg=="],
+    "slice-ansi/is-fullwidth-code-point": ["is-fullwidth-code-point@4.0.0", "", {}, "sha512-O4L094N2/dZ7xqVdrXhh9r1KODPJpFms8B5sGdJLPy664AgvXsreZUyCQQNItZRDlYug4xStLjNp/sz3HvBowQ=="],
 
     "strip-literal/js-tokens": ["js-tokens@9.0.1", "", {}, "sha512-mxa9E9ITFOt0ban3j6L5MpjwegGz6lBQmM1IJkWeBZGcMxto50+eWdjC/52xDbS2vy0k7vIMK0Fe2wfL9OQSpQ=="],
 
@@ -1654,15 +1768,33 @@
 
     "vite/fsevents": ["fsevents@2.3.3", "", { "os": "darwin" }, "sha512-5xoDfX+fL7faATnagmWPpbFtwh/R77WmMMqqHGS65C3vvB0YHrgF+B1YmZ3441tMj5n63k0212XNoJwzlhffQw=="],
 
+    "vscode-css-languageservice/vscode-languageserver-types": ["vscode-languageserver-types@3.17.5", "", {}, "sha512-Ld1VelNuX9pdF39h2Hgaeb5hEZM2Z3jUrrMgWQAu82jMtZp7p3vJT3BzToKtZI7NgQssZje5o0zryOrhQvzQAg=="],
+
+    "vscode-json-languageservice/jsonc-parser": ["jsonc-parser@3.3.1", "", {}, "sha512-HUgH65KyejrUFPvHFPbqOY0rsFip3Bo5wb4ngvdi1EpCYWUQDC5V+Y7mZws+DLkr4M//zQJoanu1SP+87Dv1oQ=="],
+
+    "vscode-languageserver/vscode-languageserver-protocol": ["vscode-languageserver-protocol@3.17.5", "", { "dependencies": { "vscode-jsonrpc": "8.2.0", "vscode-languageserver-types": "3.17.5" } }, "sha512-mb1bvRJN8SVznADSGWM9u/b07H7Ecg0I3OgXDuLdn307rl/J3A9YD6/eYOssqhecL27hK1IPZAsaqh00i/Jljg=="],
+
+    "widest-line/string-width": ["string-width@7.2.0", "", { "dependencies": { "emoji-regex": "^10.3.0", "get-east-asian-width": "^1.0.0", "strip-ansi": "^7.1.0" } }, "sha512-tsaTIkKW9b4N+AEj+SVA+WhJzV7/zMhcSu78mLKWSk7cXMOSHsBKFWUs0fWwq8QyK3MgJBQRX6Gbi4kYbdvGkQ=="],
+
     "wrap-ansi/ansi-styles": ["ansi-styles@6.2.1", "", {}, "sha512-bN798gFfQX+viw3R7yrGWRqnrN2oRkEkUjjl4JNn4E8GxxbjtG3FbrEIIY3l8/hrwUwIeCZvi4QuOTP4MErVug=="],
+
+    "wrap-ansi/string-width": ["string-width@7.2.0", "", { "dependencies": { "emoji-regex": "^10.3.0", "get-east-asian-width": "^1.0.0", "strip-ansi": "^7.1.0" } }, "sha512-tsaTIkKW9b4N+AEj+SVA+WhJzV7/zMhcSu78mLKWSk7cXMOSHsBKFWUs0fWwq8QyK3MgJBQRX6Gbi4kYbdvGkQ=="],
+
+    "wrap-ansi/strip-ansi": ["strip-ansi@7.1.0", "", { "dependencies": { "ansi-regex": "^6.0.1" } }, "sha512-iq6eVVI64nQQTRYq2KtEg2d2uU7LElhTJwsH4YzIHZshxlgZms/wIc4VoDQTlG/IvVIrBKG06CrZnp0qv7hkcQ=="],
 
     "wrap-ansi-cjs/ansi-styles": ["ansi-styles@4.3.0", "", { "dependencies": { "color-convert": "^2.0.1" } }, "sha512-zbB9rCJAT1rbjiVDb2hqKFHNYLxgtk8NURxZ3IZwD3F6NtxbXZQCnnSi1Lkx+IDohdPlFp222wVALIheZJQSEg=="],
 
-    "wrap-ansi-cjs/string-width": ["string-width@4.2.3", "", { "dependencies": { "emoji-regex": "^8.0.0", "is-fullwidth-code-point": "^3.0.0", "strip-ansi": "^6.0.1" } }, "sha512-wKyQRQpjJ0sIp62ErSZdGsjMJWsap5oRNihHhu6G7JVO/9jIB6UyevL+tXuOqrng8j/cxKTWyWUwvSTriiZz/g=="],
+    "yaml-language-server/ajv": ["ajv@8.20.0", "", { "dependencies": { "fast-deep-equal": "^3.1.3", "fast-uri": "^3.0.1", "json-schema-traverse": "^1.0.0", "require-from-string": "^2.0.2" } }, "sha512-Thbli+OlOj+iMPYFBVBfJ3OmCAnaSyNn4M1vz9T6Gka5Jt9ba/HIR56joy65tY6kx/FCF5VXNB819Y7/GUrBGA=="],
 
-    "wrap-ansi-cjs/strip-ansi": ["strip-ansi@6.0.1", "", { "dependencies": { "ansi-regex": "^5.0.1" } }, "sha512-Y38VPSHcqkFrCpFnQ9vuSXmquuv5oXOKpGeT6aGrr3o3Gc9AlVa6JBfUSOCnbxGGZF+/0ooI7KrPuUSztUdU5A=="],
+    "yaml-language-server/request-light": ["request-light@0.5.8", "", {}, "sha512-3Zjgh+8b5fhRJBQZoy+zbVKpAQGLyka0MPgW3zruTF4dFFJ8Fqcfu9YsAvi/rvdcaTeWG3MkbZv4WKxAn/84Lg=="],
+
+    "yaml-language-server/yaml": ["yaml@2.7.1", "", { "bin": { "yaml": "bin.mjs" } }, "sha512-10ULxpnOCQXxJvBgxsn9ptjq6uviG/htZKk9veJGhlqn3w/DxQ631zFF+nlQXLwmImeS5amR2dl2U8sg6U9jsQ=="],
+
+    "@astrojs/language-server/tinyglobby/picomatch": ["picomatch@4.0.4", "", {}, "sha512-QP88BAKvMam/3NxH6vj2o21R6MjxZUAd6nlwAS/pnGvN9IVLocLHxGYIzFhg6fUQ+5th6P4dv4eW9jX3DSIj7A=="],
 
     "@isaacs/cliui/string-width/emoji-regex": ["emoji-regex@9.2.2", "", {}, "sha512-L18DaJsXSUk2+42pv8mLs5jJT2hqFkFE4j21wOmgbUqsZ2hL72NsUU785g9RXgo3s0ZNgVl42TiHp3ZtOv/Vyg=="],
+
+    "@isaacs/cliui/strip-ansi/ansi-regex": ["ansi-regex@6.2.0", "", {}, "sha512-TKY5pyBkHyADOPYlRT9Lx6F544mPl0vS5Ew7BJ45hA08Q+t3GjbueLliBWN3sMICk6+y7HdyxSzC4bWS8baBdg=="],
 
     "@isaacs/cliui/wrap-ansi/ansi-styles": ["ansi-styles@6.2.1", "", {}, "sha512-bN798gFfQX+viw3R7yrGWRqnrN2oRkEkUjjl4JNn4E8GxxbjtG3FbrEIIY3l8/hrwUwIeCZvi4QuOTP4MErVug=="],
 
@@ -1676,13 +1808,17 @@
 
     "@typescript-eslint/typescript-estree/minimatch/brace-expansion": ["brace-expansion@2.0.2", "", { "dependencies": { "balanced-match": "^1.0.0" } }, "sha512-Jt0vHyM+jmUBqojB7E1NIYadt0vI0Qxjxd2TErW94wDz+E2LAm5vKMXXwg6ZZBTHPuUlDgQHKXvjGBdfcF1ZDQ=="],
 
-    "ansi-align/string-width/emoji-regex": ["emoji-regex@8.0.0", "", {}, "sha512-MSjYzcWNOA0ewAHpz0MxpYFvwg6yjy1NG3xteoqz644VCo/RPgnr1/GGt+ic3iJTzQ8Eu3TdM14SawnVUmGE6A=="],
-
-    "ansi-align/string-width/is-fullwidth-code-point": ["is-fullwidth-code-point@3.0.0", "", {}, "sha512-zymm5+u+sCsSWyD9qNaejV3DFvhCKclKdizYaJUuHA83RLjb7nSuGnddCHGv0hk+KY7BMAlsWeK4Ueg6EV6XQg=="],
-
-    "ansi-align/string-width/strip-ansi": ["strip-ansi@6.0.1", "", { "dependencies": { "ansi-regex": "^5.0.1" } }, "sha512-Y38VPSHcqkFrCpFnQ9vuSXmquuv5oXOKpGeT6aGrr3o3Gc9AlVa6JBfUSOCnbxGGZF+/0ooI7KrPuUSztUdU5A=="],
-
     "astro/vite/fsevents": ["fsevents@2.3.3", "", { "os": "darwin" }, "sha512-5xoDfX+fL7faATnagmWPpbFtwh/R77WmMMqqHGS65C3vvB0YHrgF+B1YmZ3441tMj5n63k0212XNoJwzlhffQw=="],
+
+    "boxen/string-width/emoji-regex": ["emoji-regex@10.5.0", "", {}, "sha512-lb49vf1Xzfx080OKA0o6l8DQQpV+6Vg95zyCJX9VB/BqKYlhG7N4wgROUUHRA+ZPUefLnteQOad7z1kT2bV7bg=="],
+
+    "boxen/string-width/strip-ansi": ["strip-ansi@7.1.0", "", { "dependencies": { "ansi-regex": "^6.0.1" } }, "sha512-iq6eVVI64nQQTRYq2KtEg2d2uU7LElhTJwsH4YzIHZshxlgZms/wIc4VoDQTlG/IvVIrBKG06CrZnp0qv7hkcQ=="],
+
+    "cli-truncate/string-width/emoji-regex": ["emoji-regex@10.5.0", "", {}, "sha512-lb49vf1Xzfx080OKA0o6l8DQQpV+6Vg95zyCJX9VB/BqKYlhG7N4wgROUUHRA+ZPUefLnteQOad7z1kT2bV7bg=="],
+
+    "cli-truncate/string-width/strip-ansi": ["strip-ansi@7.1.0", "", { "dependencies": { "ansi-regex": "^6.0.1" } }, "sha512-iq6eVVI64nQQTRYq2KtEg2d2uU7LElhTJwsH4YzIHZshxlgZms/wIc4VoDQTlG/IvVIrBKG06CrZnp0qv7hkcQ=="],
+
+    "cliui/wrap-ansi/ansi-styles": ["ansi-styles@4.3.0", "", { "dependencies": { "color-convert": "^2.0.1" } }, "sha512-zbB9rCJAT1rbjiVDb2hqKFHNYLxgtk8NURxZ3IZwD3F6NtxbXZQCnnSi1Lkx+IDohdPlFp222wVALIheZJQSEg=="],
 
     "cross-fetch/node-fetch/whatwg-url": ["whatwg-url@5.0.0", "", { "dependencies": { "tr46": "~0.0.3", "webidl-conversions": "^3.0.0" } }, "sha512-saE57nupxk6v3HY35+jzBwYa0rKSy0XR8JSxZPwgLr7ys0IBzhGviA1/TUGJLmSVqs8pb9AnvICXEuOHLprYTw=="],
 
@@ -1692,13 +1828,25 @@
 
     "log-update/slice-ansi/is-fullwidth-code-point": ["is-fullwidth-code-point@5.0.0", "", { "dependencies": { "get-east-asian-width": "^1.0.0" } }, "sha512-OVa3u9kkBbw7b8Xw5F9P+D/T9X+Z4+JruYVNapTjPYZYUznQ5YfWeFkOj606XYYW8yugTfC8Pj0hYqvi4ryAhA=="],
 
+    "log-update/strip-ansi/ansi-regex": ["ansi-regex@6.2.0", "", {}, "sha512-TKY5pyBkHyADOPYlRT9Lx6F544mPl0vS5Ew7BJ45hA08Q+t3GjbueLliBWN3sMICk6+y7HdyxSzC4bWS8baBdg=="],
+
     "p-locate/p-limit/yocto-queue": ["yocto-queue@0.1.0", "", {}, "sha512-rVksvsnNCdJ/ohGc6xgPwyN8eheCxsiLM8mxuE/t/mOVqJewPuO1miLpTHQiRgTKCLexL4MeAFVagts7HmNZ2Q=="],
 
     "test-exclude/minimatch/brace-expansion": ["brace-expansion@2.0.2", "", { "dependencies": { "balanced-match": "^1.0.0" } }, "sha512-Jt0vHyM+jmUBqojB7E1NIYadt0vI0Qxjxd2TErW94wDz+E2LAm5vKMXXwg6ZZBTHPuUlDgQHKXvjGBdfcF1ZDQ=="],
 
-    "wrap-ansi-cjs/string-width/emoji-regex": ["emoji-regex@8.0.0", "", {}, "sha512-MSjYzcWNOA0ewAHpz0MxpYFvwg6yjy1NG3xteoqz644VCo/RPgnr1/GGt+ic3iJTzQ8Eu3TdM14SawnVUmGE6A=="],
+    "vscode-languageserver/vscode-languageserver-protocol/vscode-jsonrpc": ["vscode-jsonrpc@8.2.0", "", {}, "sha512-C+r0eKJUIfiDIfwJhria30+TYWPtuHJXHtI7J0YlOmKAo7ogxP20T0zxB7HZQIFhIyvoBPwWskjxrvAtfjyZfA=="],
 
-    "wrap-ansi-cjs/string-width/is-fullwidth-code-point": ["is-fullwidth-code-point@3.0.0", "", {}, "sha512-zymm5+u+sCsSWyD9qNaejV3DFvhCKclKdizYaJUuHA83RLjb7nSuGnddCHGv0hk+KY7BMAlsWeK4Ueg6EV6XQg=="],
+    "vscode-languageserver/vscode-languageserver-protocol/vscode-languageserver-types": ["vscode-languageserver-types@3.17.5", "", {}, "sha512-Ld1VelNuX9pdF39h2Hgaeb5hEZM2Z3jUrrMgWQAu82jMtZp7p3vJT3BzToKtZI7NgQssZje5o0zryOrhQvzQAg=="],
+
+    "widest-line/string-width/emoji-regex": ["emoji-regex@10.5.0", "", {}, "sha512-lb49vf1Xzfx080OKA0o6l8DQQpV+6Vg95zyCJX9VB/BqKYlhG7N4wgROUUHRA+ZPUefLnteQOad7z1kT2bV7bg=="],
+
+    "widest-line/string-width/strip-ansi": ["strip-ansi@7.1.0", "", { "dependencies": { "ansi-regex": "^6.0.1" } }, "sha512-iq6eVVI64nQQTRYq2KtEg2d2uU7LElhTJwsH4YzIHZshxlgZms/wIc4VoDQTlG/IvVIrBKG06CrZnp0qv7hkcQ=="],
+
+    "wrap-ansi/string-width/emoji-regex": ["emoji-regex@10.5.0", "", {}, "sha512-lb49vf1Xzfx080OKA0o6l8DQQpV+6Vg95zyCJX9VB/BqKYlhG7N4wgROUUHRA+ZPUefLnteQOad7z1kT2bV7bg=="],
+
+    "wrap-ansi/strip-ansi/ansi-regex": ["ansi-regex@6.2.0", "", {}, "sha512-TKY5pyBkHyADOPYlRT9Lx6F544mPl0vS5Ew7BJ45hA08Q+t3GjbueLliBWN3sMICk6+y7HdyxSzC4bWS8baBdg=="],
+
+    "yaml-language-server/ajv/json-schema-traverse": ["json-schema-traverse@1.0.0", "", {}, "sha512-NM8/P9n3XjXhIZn1lLhkFaACTOURQXjWhV4BA/RnOv8xvgqtqpAX9IO4mRQxSx1Rlo4tqzeqb0sOlruaOy3dug=="],
 
     "@libsql/kysely-libsql/@libsql/client/@libsql/hrana-client/@libsql/isomorphic-fetch": ["@libsql/isomorphic-fetch@0.2.5", "", {}, "sha512-8s/B2TClEHms2yb+JGpsVRTPBfy1ih/Pq6h6gvyaNcYnMVJvgQRY7wAa8U2nD0dppbCuDU5evTNMEhrQ17ZKKg=="],
 
@@ -1720,8 +1868,14 @@
 
     "@mapbox/node-pre-gyp/node-fetch/whatwg-url/webidl-conversions": ["webidl-conversions@3.0.1", "", {}, "sha512-2JAn3z8AR6rjK8Sm8orRC0h/bcl/DqL7tRPdGZ4I1CjdF+EaMLmYxBHyXuKL849eucPFhvBoxMsflfOb8kxaeQ=="],
 
+    "boxen/string-width/strip-ansi/ansi-regex": ["ansi-regex@6.2.0", "", {}, "sha512-TKY5pyBkHyADOPYlRT9Lx6F544mPl0vS5Ew7BJ45hA08Q+t3GjbueLliBWN3sMICk6+y7HdyxSzC4bWS8baBdg=="],
+
+    "cli-truncate/string-width/strip-ansi/ansi-regex": ["ansi-regex@6.2.0", "", {}, "sha512-TKY5pyBkHyADOPYlRT9Lx6F544mPl0vS5Ew7BJ45hA08Q+t3GjbueLliBWN3sMICk6+y7HdyxSzC4bWS8baBdg=="],
+
     "cross-fetch/node-fetch/whatwg-url/tr46": ["tr46@0.0.3", "", {}, "sha512-N3WMsuqV66lT30CrXNbEjx4GEwlow3v6rr4mCcv6prnfwhS01rkgyFdjPNBYd9br7LpXV1+Emh01fHnq2Gdgrw=="],
 
     "cross-fetch/node-fetch/whatwg-url/webidl-conversions": ["webidl-conversions@3.0.1", "", {}, "sha512-2JAn3z8AR6rjK8Sm8orRC0h/bcl/DqL7tRPdGZ4I1CjdF+EaMLmYxBHyXuKL849eucPFhvBoxMsflfOb8kxaeQ=="],
+
+    "widest-line/string-width/strip-ansi/ansi-regex": ["ansi-regex@6.2.0", "", {}, "sha512-TKY5pyBkHyADOPYlRT9Lx6F544mPl0vS5Ew7BJ45hA08Q+t3GjbueLliBWN3sMICk6+y7HdyxSzC4bWS8baBdg=="],
   }
 }

--- a/docs/superpowers/plans/2026-06-19-circuit-hacker.md
+++ b/docs/superpowers/plans/2026-06-19-circuit-hacker.md
@@ -1,0 +1,2581 @@
+# Circuit Hacker Implementation Plan
+
+> **For agentic workers:** REQUIRED SUB-SKILL: Use superpowers:subagent-driven-development (recommended) or superpowers:executing-plans to implement this plan task-by-task. Steps use checkbox (`- [ ]`) syntax for tracking.
+
+**Goal:** Add "Circuit Hacker", a PixiJS tile-rotation puzzle (13th Cetus game) where the player rotates circuit tiles to power a path from a source node to one or more cores before a countdown expires.
+
+**Architecture:** Follows the self-contained PixiJS game pattern used by Evader (`types.ts` → `utils.ts` → `generator.ts` → `game.ts` → `renderer.ts` → `init.ts`), not the optional `BaseGame` framework. Pure logic (connector math, power flood-fill, scoring, puzzle generation) lives in `utils.ts`/`generator.ts` and is unit-tested in isolation. The `CircuitHackerGame` class owns state and rules; the functional renderer draws to a PixiJS canvas and maps pointer coordinates to grid cells; `init.ts` wires game + renderer + DOM + score submission. Puzzles are solvable by construction (carve solution → scramble).
+
+**Tech Stack:** Astro 5 (SSR), TypeScript, PixiJS 8, Vitest + jsdom, Tailwind CSS 4, Bun.
+
+## Global Constraints
+
+- Package manager / runner: **Bun**. Run tests with `bun run test:run <path>`.
+- Import alias: `@/` maps to `src/` (e.g. `@/lib/games`). Use it for cross-module imports.
+- All game HTML structure lives in the Astro page; TypeScript only manipulates dynamic content and the canvas (project Astro–TS rule). Never build structure with `innerHTML` except the documented error-fallback block.
+- Game IDs are the single source of truth in `src/lib/games.ts` (`GameID` enum). Validation (`validations.ts`) and `formatGameName` auto-derive from it — do not touch them.
+- Tests must pass with PixiJS mocked (`vi.mock('pixi.js', …)`); never rely on a real WebGL context in unit tests.
+- Score submission goes through `saveGameScore(gameId, score, onSuccess, onError, gameData)` from `@/lib/services/scoreService`. It already no-ops when `score <= 0`.
+- New game id string: `circuit_hacker`. Enum member: `GameID.CIRCUIT_HACKER`. Route: `/circuit-hacker`. Icon: `🔌`. Display name: `Circuit Hacker`.
+- Difficulty tiers and constants (verbatim):
+  - easy: 5×5, 1 core, 0 blockers, 120s, ×1
+  - medium: 7×7, 1 core, 3 blockers, 180s, ×2
+  - hard: 9×9, 2 cores, 6 blockers, 240s, ×3.5
+  - expert: 11×11, 3 cores, 10 blockers, 300s, ×5
+- Scoring (verbatim): `finalScore = round((1000 + secondsRemaining*15 + max(0, rotatableTileCount*2 - rotationsUsed)*25) * multiplier)`.
+
+---
+
+### Task 1: Types & connector math
+
+**Files:**
+- Create: `src/lib/games/circuit-hacker/types.ts`
+- Create: `src/lib/games/circuit-hacker/utils.ts`
+- Test: `src/lib/games/circuit-hacker/utils.test.ts`
+
+**Interfaces:**
+- Consumes: nothing (first task).
+- Produces:
+  - `types.ts`: `Direction = 'N'|'E'|'S'|'W'`; `Difficulty = 'easy'|'medium'|'hard'|'expert'`; `TileType = 'straight'|'elbow'|'t-junction'|'cross'|'source'|'core'|'blocker'`; `Tile = { type: TileType; orientation: number; locked: boolean; powered: boolean }`; `GridPosition = { row: number; col: number }`; `DifficultyConfig = { difficulty: Difficulty; rows: number; cols: number; cores: number; blockers: number; duration: number; multiplier: number }`; `CircuitHackerConfig = { difficulty: Difficulty; cellSize: number }`; `CircuitHackerGameData = { difficulty: Difficulty; secondsRemaining: number; rotationsUsed: number; solved: boolean }`; `CircuitHackerStats = { finalScore: number; difficulty: Difficulty; secondsRemaining: number; rotationsUsed: number; solved: boolean }`; `CircuitHackerState = { grid: Tile[][]; sourcePos: GridPosition; corePositions: GridPosition[]; rows: number; cols: number; score: number; timeRemaining: number; rotationsUsed: number; isGameActive: boolean; isGameOver: boolean; solved: boolean }`; `CircuitHackerCallbacks = { onTimeUpdate: (t: number) => void; onRotation: (rotationsUsed: number) => void; onSolved: (finalScore: number, stats: CircuitHackerStats) => void; onFail: (stats: CircuitHackerStats) => void; onGameStart: () => void }`.
+  - `utils.ts`: `oppositeDirection(dir: Direction): Direction`; `rotateConnectors(connectors: Direction[], times: number): Direction[]`; `getBaseConnectors(type: TileType): Direction[]`; `getConnectors(tile: Tile): Direction[]`; `cellsConnect(from: Tile, dir: Direction, to: Tile): boolean`.
+
+- [ ] **Step 1: Write `types.ts`** (types only, no logic)
+
+```typescript
+// src/lib/games/circuit-hacker/types.ts
+
+// Edge direction of a tile connector
+export type Direction = 'N' | 'E' | 'S' | 'W'
+
+// Difficulty tiers (chosen up front)
+export type Difficulty = 'easy' | 'medium' | 'hard' | 'expert'
+
+// Shapes a tile can take
+export type TileType =
+    | 'straight'
+    | 'elbow'
+    | 't-junction'
+    | 'cross'
+    | 'source'
+    | 'core'
+    | 'blocker'
+
+// A single grid cell
+export interface Tile {
+    type: TileType
+    // number of 90° clockwise rotations from the base orientation (0..3)
+    orientation: number
+    // locked tiles (source, core, blocker) cannot be rotated by the player
+    locked: boolean
+    // currently reachable from the source through matching connectors
+    powered: boolean
+}
+
+export interface GridPosition {
+    row: number
+    col: number
+}
+
+// Per-difficulty configuration
+export interface DifficultyConfig {
+    difficulty: Difficulty
+    rows: number
+    cols: number
+    cores: number
+    blockers: number
+    duration: number // seconds
+    multiplier: number
+}
+
+// Runtime game configuration
+export interface CircuitHackerConfig {
+    difficulty: Difficulty
+    cellSize: number // pixels per tile on the canvas
+}
+
+// Submitted with the score and used for achievement checks
+export interface CircuitHackerGameData {
+    difficulty: Difficulty
+    secondsRemaining: number
+    rotationsUsed: number
+    solved: boolean
+}
+
+// Returned at game end
+export interface CircuitHackerStats {
+    finalScore: number
+    difficulty: Difficulty
+    secondsRemaining: number
+    rotationsUsed: number
+    solved: boolean
+}
+
+export interface CircuitHackerState {
+    grid: Tile[][]
+    sourcePos: GridPosition
+    corePositions: GridPosition[]
+    rows: number
+    cols: number
+    score: number
+    timeRemaining: number
+    rotationsUsed: number
+    isGameActive: boolean
+    isGameOver: boolean
+    solved: boolean
+}
+
+export interface CircuitHackerCallbacks {
+    onTimeUpdate: (timeRemaining: number) => void
+    onRotation: (rotationsUsed: number) => void
+    onSolved: (finalScore: number, stats: CircuitHackerStats) => void
+    onFail: (stats: CircuitHackerStats) => void
+    onGameStart: () => void
+}
+```
+
+- [ ] **Step 2: Write the failing test**
+
+```typescript
+// src/lib/games/circuit-hacker/utils.test.ts
+import { describe, it, expect } from 'vitest'
+import {
+    oppositeDirection,
+    rotateConnectors,
+    getBaseConnectors,
+    getConnectors,
+    cellsConnect,
+} from './utils'
+import type { Tile } from './types'
+
+const tile = (type: Tile['type'], orientation = 0): Tile => ({
+    type,
+    orientation,
+    locked: false,
+    powered: false,
+})
+
+describe('connector math', () => {
+    it('returns opposite directions', () => {
+        expect(oppositeDirection('N')).toBe('S')
+        expect(oppositeDirection('S')).toBe('N')
+        expect(oppositeDirection('E')).toBe('W')
+        expect(oppositeDirection('W')).toBe('E')
+    })
+
+    it('rotates connectors clockwise', () => {
+        expect(rotateConnectors(['N'], 1)).toEqual(['E'])
+        expect(rotateConnectors(['N'], 2)).toEqual(['S'])
+        expect(rotateConnectors(['N', 'E'], 1).sort()).toEqual(['E', 'S'])
+        expect(rotateConnectors(['N'], 4)).toEqual(['N'])
+    })
+
+    it('defines base connectors per tile type', () => {
+        expect(getBaseConnectors('straight').sort()).toEqual(['N', 'S'])
+        expect(getBaseConnectors('elbow').sort()).toEqual(['E', 'N'])
+        expect(getBaseConnectors('t-junction').sort()).toEqual(['E', 'N', 'S'])
+        expect(getBaseConnectors('cross').sort()).toEqual(['E', 'N', 'S', 'W'])
+        expect(getBaseConnectors('source')).toEqual(['N'])
+        expect(getBaseConnectors('core')).toEqual(['N'])
+        expect(getBaseConnectors('blocker')).toEqual([])
+    })
+
+    it('applies orientation to connectors', () => {
+        expect(getConnectors(tile('straight', 1)).sort()).toEqual(['E', 'W'])
+        expect(getConnectors(tile('source', 1))).toEqual(['E'])
+    })
+
+    it('connects two tiles only when both face each other', () => {
+        // straight vertical (N,S) above a straight vertical: A's S meets B's N
+        expect(cellsConnect(tile('straight', 0), 'S', tile('straight', 0))).toBe(
+            true
+        )
+        // straight horizontal has no S connector
+        expect(cellsConnect(tile('straight', 1), 'S', tile('straight', 0))).toBe(
+            false
+        )
+        // blocker never connects
+        expect(cellsConnect(tile('cross'), 'E', tile('blocker'))).toBe(false)
+    })
+})
+```
+
+- [ ] **Step 3: Run the test, verify it fails**
+
+Run: `bun run test:run src/lib/games/circuit-hacker/utils.test.ts`
+Expected: FAIL — `Failed to resolve import "./utils"` / functions not defined.
+
+- [ ] **Step 4: Write `utils.ts` connector functions**
+
+```typescript
+// src/lib/games/circuit-hacker/utils.ts
+import type { Direction, Tile, TileType } from './types'
+
+const CLOCKWISE: Direction[] = ['N', 'E', 'S', 'W']
+
+export function oppositeDirection(dir: Direction): Direction {
+    switch (dir) {
+        case 'N':
+            return 'S'
+        case 'S':
+            return 'N'
+        case 'E':
+            return 'W'
+        case 'W':
+            return 'E'
+    }
+}
+
+export function rotateConnectors(
+    connectors: Direction[],
+    times: number
+): Direction[] {
+    const steps = ((times % 4) + 4) % 4
+    return connectors.map(dir => {
+        const idx = CLOCKWISE.indexOf(dir)
+        return CLOCKWISE[(idx + steps) % 4]
+    })
+}
+
+export function getBaseConnectors(type: TileType): Direction[] {
+    switch (type) {
+        case 'straight':
+            return ['N', 'S']
+        case 'elbow':
+            return ['N', 'E']
+        case 't-junction':
+            return ['N', 'E', 'S']
+        case 'cross':
+            return ['N', 'E', 'S', 'W']
+        case 'source':
+            return ['N']
+        case 'core':
+            return ['N']
+        case 'blocker':
+            return []
+    }
+}
+
+export function getConnectors(tile: Tile): Direction[] {
+    return rotateConnectors(getBaseConnectors(tile.type), tile.orientation)
+}
+
+export function cellsConnect(from: Tile, dir: Direction, to: Tile): boolean {
+    return (
+        getConnectors(from).includes(dir) &&
+        getConnectors(to).includes(oppositeDirection(dir))
+    )
+}
+```
+
+- [ ] **Step 5: Run the test, verify it passes**
+
+Run: `bun run test:run src/lib/games/circuit-hacker/utils.test.ts`
+Expected: PASS (5 tests).
+
+- [ ] **Step 6: Commit**
+
+```bash
+git add src/lib/games/circuit-hacker/types.ts src/lib/games/circuit-hacker/utils.ts src/lib/games/circuit-hacker/utils.test.ts
+git commit -m "feat(circuit-hacker): add types and connector math"
+```
+
+---
+
+### Task 2: Power flood-fill & win check
+
+**Files:**
+- Modify: `src/lib/games/circuit-hacker/utils.ts`
+- Test: `src/lib/games/circuit-hacker/utils.test.ts`
+
+**Interfaces:**
+- Consumes: `cellsConnect`, `Tile`, `GridPosition` from Task 1.
+- Produces: `computePoweredCells(grid: Tile[][], source: GridPosition): boolean[][]`; `isSolved(grid: Tile[][], source: GridPosition, cores: GridPosition[]): boolean`.
+
+- [ ] **Step 1: Add the failing test** (append inside `utils.test.ts`)
+
+```typescript
+import { computePoweredCells, isSolved } from './utils'
+import type { GridPosition } from './types'
+
+const t = (type: Tile['type'], orientation = 0, locked = false): Tile => ({
+    type,
+    orientation,
+    locked,
+    powered: false,
+})
+
+describe('power flood-fill', () => {
+    // 1x3 row: source(→E) — straight(horizontal) — core(←W)
+    // source base 'N' rotated to 'E' = orientation 1
+    // core base 'N' rotated to 'W' = orientation 3
+    const source: GridPosition = { row: 0, col: 0 }
+    const cores: GridPosition[] = [{ row: 0, col: 2 }]
+
+    it('powers a fully connected line', () => {
+        const grid: Tile[][] = [
+            [t('source', 1, true), t('straight', 1), t('core', 3, true)],
+        ]
+        const powered = computePoweredCells(grid, source)
+        expect(powered[0][0]).toBe(true)
+        expect(powered[0][1]).toBe(true)
+        expect(powered[0][2]).toBe(true)
+        expect(isSolved(grid, source, cores)).toBe(true)
+    })
+
+    it('does not power past a broken connection', () => {
+        // middle straight left vertical (orientation 0 -> N,S) breaks the row
+        const grid: Tile[][] = [
+            [t('source', 1, true), t('straight', 0), t('core', 3, true)],
+        ]
+        const powered = computePoweredCells(grid, source)
+        expect(powered[0][0]).toBe(true)
+        expect(powered[0][1]).toBe(false)
+        expect(powered[0][2]).toBe(false)
+        expect(isSolved(grid, source, cores)).toBe(false)
+    })
+})
+```
+
+- [ ] **Step 2: Run the test, verify it fails**
+
+Run: `bun run test:run src/lib/games/circuit-hacker/utils.test.ts`
+Expected: FAIL — `computePoweredCells`/`isSolved` not exported.
+
+- [ ] **Step 3: Implement power flood-fill in `utils.ts`** (append)
+
+```typescript
+import type { Direction, GridPosition } from './types'
+
+// (Direction already imported in Task 1; keep a single import line at top.)
+
+const DELTA: Record<Direction, { dr: number; dc: number }> = {
+    N: { dr: -1, dc: 0 },
+    E: { dr: 0, dc: 1 },
+    S: { dr: 1, dc: 0 },
+    W: { dr: 0, dc: -1 },
+}
+
+export function computePoweredCells(
+    grid: Tile[][],
+    source: GridPosition
+): boolean[][] {
+    const rows = grid.length
+    const cols = rows > 0 ? grid[0].length : 0
+    const powered: boolean[][] = grid.map(row => row.map(() => false))
+
+    const queue: GridPosition[] = [source]
+    powered[source.row][source.col] = true
+
+    while (queue.length > 0) {
+        const { row, col } = queue.shift() as GridPosition
+        const from = grid[row][col]
+        for (const dir of ['N', 'E', 'S', 'W'] as Direction[]) {
+            const nr = row + DELTA[dir].dr
+            const nc = col + DELTA[dir].dc
+            if (nr < 0 || nr >= rows || nc < 0 || nc >= cols) {
+                continue
+            }
+            if (powered[nr][nc]) {
+                continue
+            }
+            if (cellsConnect(from, dir, grid[nr][nc])) {
+                powered[nr][nc] = true
+                queue.push({ row: nr, col: nc })
+            }
+        }
+    }
+
+    return powered
+}
+
+export function isSolved(
+    grid: Tile[][],
+    source: GridPosition,
+    cores: GridPosition[]
+): boolean {
+    const powered = computePoweredCells(grid, source)
+    return cores.every(core => powered[core.row][core.col])
+}
+```
+
+> Note: merge the `Direction`/`GridPosition` import with the existing top-of-file import from Task 1 rather than adding a duplicate `import` line.
+
+- [ ] **Step 4: Run the test, verify it passes**
+
+Run: `bun run test:run src/lib/games/circuit-hacker/utils.test.ts`
+Expected: PASS (7 tests total).
+
+- [ ] **Step 5: Commit**
+
+```bash
+git add src/lib/games/circuit-hacker/utils.ts src/lib/games/circuit-hacker/utils.test.ts
+git commit -m "feat(circuit-hacker): add power flood-fill and win check"
+```
+
+---
+
+### Task 3: Difficulty configs & scoring
+
+**Files:**
+- Modify: `src/lib/games/circuit-hacker/utils.ts`
+- Test: `src/lib/games/circuit-hacker/utils.test.ts`
+
+**Interfaces:**
+- Consumes: `Tile`, `Difficulty`, `DifficultyConfig` from Task 1.
+- Produces: `DIFFICULTY_CONFIGS: Record<Difficulty, DifficultyConfig>`; `countRotatableTiles(grid: Tile[][]): number`; `computeFinalScore(params: { secondsRemaining: number; rotationsUsed: number; rotatableTileCount: number; multiplier: number }): number`.
+
+- [ ] **Step 1: Add the failing test** (append inside `utils.test.ts`)
+
+```typescript
+import {
+    DIFFICULTY_CONFIGS,
+    countRotatableTiles,
+    computeFinalScore,
+} from './utils'
+
+describe('difficulty configs & scoring', () => {
+    it('defines all four tiers with the agreed constants', () => {
+        expect(DIFFICULTY_CONFIGS.easy).toMatchObject({
+            rows: 5,
+            cols: 5,
+            cores: 1,
+            blockers: 0,
+            duration: 120,
+            multiplier: 1,
+        })
+        expect(DIFFICULTY_CONFIGS.expert).toMatchObject({
+            rows: 11,
+            cols: 11,
+            cores: 3,
+            blockers: 10,
+            duration: 300,
+            multiplier: 5,
+        })
+    })
+
+    it('counts only unlocked tiles as rotatable', () => {
+        const grid: Tile[][] = [
+            [t('source', 0, true), t('straight'), t('blocker', 0, true)],
+            [t('elbow'), t('core', 0, true), t('cross')],
+        ]
+        expect(countRotatableTiles(grid)).toBe(3)
+    })
+
+    it('computes final score with the agreed formula', () => {
+        // base 1000 + time 30*15=450 + rotationBonus max(0, 10*2 - 8)*25 = 300
+        // sum 1750 * multiplier 2 = 3500
+        expect(
+            computeFinalScore({
+                secondsRemaining: 30,
+                rotationsUsed: 8,
+                rotatableTileCount: 10,
+                multiplier: 2,
+            })
+        ).toBe(3500)
+    })
+
+    it('floors rotation bonus at zero when over budget', () => {
+        // base 1000 + 0 time + max(0, 2*2 - 99)*25 = 0 -> 1000 * 1
+        expect(
+            computeFinalScore({
+                secondsRemaining: 0,
+                rotationsUsed: 99,
+                rotatableTileCount: 2,
+                multiplier: 1,
+            })
+        ).toBe(1000)
+    })
+})
+```
+
+- [ ] **Step 2: Run the test, verify it fails**
+
+Run: `bun run test:run src/lib/games/circuit-hacker/utils.test.ts`
+Expected: FAIL — new exports undefined.
+
+- [ ] **Step 3: Implement configs & scoring in `utils.ts`** (append)
+
+```typescript
+import type { Difficulty, DifficultyConfig } from './types'
+// (merge with existing top-of-file type import)
+
+export const DIFFICULTY_CONFIGS: Record<Difficulty, DifficultyConfig> = {
+    easy: {
+        difficulty: 'easy',
+        rows: 5,
+        cols: 5,
+        cores: 1,
+        blockers: 0,
+        duration: 120,
+        multiplier: 1,
+    },
+    medium: {
+        difficulty: 'medium',
+        rows: 7,
+        cols: 7,
+        cores: 1,
+        blockers: 3,
+        duration: 180,
+        multiplier: 2,
+    },
+    hard: {
+        difficulty: 'hard',
+        rows: 9,
+        cols: 9,
+        cores: 2,
+        blockers: 6,
+        duration: 240,
+        multiplier: 3.5,
+    },
+    expert: {
+        difficulty: 'expert',
+        rows: 11,
+        cols: 11,
+        cores: 3,
+        blockers: 10,
+        duration: 300,
+        multiplier: 5,
+    },
+}
+
+export function countRotatableTiles(grid: Tile[][]): number {
+    let count = 0
+    for (const row of grid) {
+        for (const tile of row) {
+            if (!tile.locked) {
+                count++
+            }
+        }
+    }
+    return count
+}
+
+export function computeFinalScore(params: {
+    secondsRemaining: number
+    rotationsUsed: number
+    rotatableTileCount: number
+    multiplier: number
+}): number {
+    const base = 1000
+    const timeBonus = params.secondsRemaining * 15
+    const rotationBudget = params.rotatableTileCount * 2
+    const rotationBonus =
+        Math.max(0, rotationBudget - params.rotationsUsed) * 25
+    return Math.round(
+        (base + timeBonus + rotationBonus) * params.multiplier
+    )
+}
+```
+
+- [ ] **Step 4: Run the test, verify it passes**
+
+Run: `bun run test:run src/lib/games/circuit-hacker/utils.test.ts`
+Expected: PASS (11 tests total).
+
+- [ ] **Step 5: Commit**
+
+```bash
+git add src/lib/games/circuit-hacker/utils.ts src/lib/games/circuit-hacker/utils.test.ts
+git commit -m "feat(circuit-hacker): add difficulty configs and scoring"
+```
+
+---
+
+### Task 4: Puzzle generator
+
+**Files:**
+- Create: `src/lib/games/circuit-hacker/generator.ts`
+- Test: `src/lib/games/circuit-hacker/generator.test.ts`
+
+**Interfaces:**
+- Consumes: `DifficultyConfig`, `Tile`, `GridPosition`, `Direction` from Task 1; `getBaseConnectors`, `rotateConnectors`, `isSolved`, `computePoweredCells` from Tasks 1–2.
+- Produces: `GeneratedPuzzle = { grid: Tile[][]; sourcePos: GridPosition; corePositions: GridPosition[]; solutionOrientations: number[][] }`; `generatePuzzle(config: DifficultyConfig, rng?: () => number): GeneratedPuzzle`.
+
+The generator builds a *solved* board, records each cell's solved orientation, then scrambles rotatable tiles. Solvability is guaranteed because applying `solutionOrientations` reconnects the source to every core.
+
+- [ ] **Step 1: Write the failing test**
+
+```typescript
+// src/lib/games/circuit-hacker/generator.test.ts
+import { describe, it, expect } from 'vitest'
+import { generatePuzzle } from './generator'
+import { DIFFICULTY_CONFIGS, computePoweredCells } from './utils'
+import type { Difficulty, Tile } from './types'
+
+// Deterministic LCG so tests are reproducible
+function seededRng(seed: number): () => number {
+    let s = seed >>> 0
+    return () => {
+        s = (s * 1664525 + 1013904223) >>> 0
+        return s / 0xffffffff
+    }
+}
+
+const difficulties: Difficulty[] = ['easy', 'medium', 'hard', 'expert']
+
+describe('generatePuzzle', () => {
+    it.each(difficulties)(
+        'produces a grid of the right shape and counts for %s',
+        difficulty => {
+            const config = DIFFICULTY_CONFIGS[difficulty]
+            const puzzle = generatePuzzle(config, seededRng(42))
+
+            expect(puzzle.grid).toHaveLength(config.rows)
+            for (const row of puzzle.grid) {
+                expect(row).toHaveLength(config.cols)
+            }
+
+            const flat = puzzle.grid.flat()
+            expect(flat.filter(t => t.type === 'source')).toHaveLength(1)
+            expect(flat.filter(t => t.type === 'core')).toHaveLength(
+                config.cores
+            )
+            expect(flat.filter(t => t.type === 'blocker')).toHaveLength(
+                config.blockers
+            )
+            expect(puzzle.corePositions).toHaveLength(config.cores)
+        }
+    )
+
+    it.each(difficulties)(
+        'is solvable by construction for %s',
+        difficulty => {
+            const config = DIFFICULTY_CONFIGS[difficulty]
+            const puzzle = generatePuzzle(config, seededRng(7))
+
+            // Apply the recorded solution orientations
+            const solved: Tile[][] = puzzle.grid.map((row, r) =>
+                row.map((tile, c) => ({
+                    ...tile,
+                    orientation: puzzle.solutionOrientations[r][c],
+                }))
+            )
+            const powered = computePoweredCells(solved, puzzle.sourcePos)
+            for (const core of puzzle.corePositions) {
+                expect(powered[core.row][core.col]).toBe(true)
+            }
+        }
+    )
+
+    it('marks source, core and blocker tiles as locked', () => {
+        const puzzle = generatePuzzle(DIFFICULTY_CONFIGS.hard, seededRng(3))
+        for (const row of puzzle.grid) {
+            for (const tile of row) {
+                if (
+                    tile.type === 'source' ||
+                    tile.type === 'core' ||
+                    tile.type === 'blocker'
+                ) {
+                    expect(tile.locked).toBe(true)
+                } else {
+                    expect(tile.locked).toBe(false)
+                }
+            }
+        }
+    })
+})
+```
+
+- [ ] **Step 2: Run the test, verify it fails**
+
+Run: `bun run test:run src/lib/games/circuit-hacker/generator.test.ts`
+Expected: FAIL — `Failed to resolve import "./generator"`.
+
+- [ ] **Step 3: Implement `generator.ts`**
+
+```typescript
+// src/lib/games/circuit-hacker/generator.ts
+import type {
+    DifficultyConfig,
+    Direction,
+    GridPosition,
+    Tile,
+    TileType,
+} from './types'
+import { getBaseConnectors, rotateConnectors } from './utils'
+
+export interface GeneratedPuzzle {
+    grid: Tile[][]
+    sourcePos: GridPosition
+    corePositions: GridPosition[]
+    solutionOrientations: number[][]
+}
+
+const ALL_DIRS: Direction[] = ['N', 'E', 'S', 'W']
+const DELTA: Record<Direction, { dr: number; dc: number }> = {
+    N: { dr: -1, dc: 0 },
+    E: { dr: 0, dc: 1 },
+    S: { dr: 1, dc: 0 },
+    W: { dr: 0, dc: -1 },
+}
+
+function key(pos: GridPosition): string {
+    return `${pos.row},${pos.col}`
+}
+
+function inBounds(pos: GridPosition, rows: number, cols: number): boolean {
+    return pos.row >= 0 && pos.row < rows && pos.col >= 0 && pos.col < cols
+}
+
+function shuffle<T>(arr: T[], rng: () => number): T[] {
+    const copy = [...arr]
+    for (let i = copy.length - 1; i > 0; i--) {
+        const j = Math.floor(rng() * (i + 1))
+        ;[copy[i], copy[j]] = [copy[j], copy[i]]
+    }
+    return copy
+}
+
+// Random simple path from start to goal via randomized DFS over a fresh grid.
+function findPath(
+    start: GridPosition,
+    goal: GridPosition,
+    rows: number,
+    cols: number,
+    rng: () => number
+): GridPosition[] | null {
+    const visited = new Set<string>([key(start)])
+    const stack: GridPosition[][] = [[start]]
+
+    while (stack.length > 0) {
+        const path = stack.pop() as GridPosition[]
+        const head = path[path.length - 1]
+        if (head.row === goal.row && head.col === goal.col) {
+            return path
+        }
+        for (const dir of shuffle(ALL_DIRS, rng)) {
+            const next = {
+                row: head.row + DELTA[dir].dr,
+                col: head.col + DELTA[dir].dc,
+            }
+            if (!inBounds(next, rows, cols) || visited.has(key(next))) {
+                continue
+            }
+            visited.add(key(next))
+            stack.push([...path, next])
+        }
+    }
+    return null
+}
+
+// Pick the tile type + orientation whose connectors equal a required dir set.
+function tileForDirections(dirs: Set<Direction>): {
+    type: TileType
+    orientation: number
+} {
+    const required = ALL_DIRS.filter(d => dirs.has(d))
+    const candidates: TileType[] =
+        required.length === 1
+            ? [] // handled by source/core elsewhere
+            : ['straight', 'elbow', 't-junction', 'cross']
+
+    for (const type of candidates) {
+        for (let orientation = 0; orientation < 4; orientation++) {
+            const conn = rotateConnectors(
+                getBaseConnectors(type),
+                orientation
+            )
+            if (
+                conn.length === required.length &&
+                required.every(d => conn.includes(d))
+            ) {
+                return { type, orientation }
+            }
+        }
+    }
+    // Fallback (should not happen for size 2..4): a cross covers any set
+    return { type: 'cross', orientation: 0 }
+}
+
+function orientationForSingle(dir: Direction): number {
+    for (let orientation = 0; orientation < 4; orientation++) {
+        if (rotateConnectors(['N'], orientation)[0] === dir) {
+            return orientation
+        }
+    }
+    return 0
+}
+
+export function generatePuzzle(
+    config: DifficultyConfig,
+    rng: () => number = Math.random
+): GeneratedPuzzle {
+    const { rows, cols, cores, blockers } = config
+
+    const allCells: GridPosition[] = []
+    for (let r = 0; r < rows; r++) {
+        for (let c = 0; c < cols; c++) {
+            allCells.push({ row: r, col: c })
+        }
+    }
+
+    const shuffled = shuffle(allCells, rng)
+    const sourcePos = shuffled[0]
+    const corePositions = shuffled.slice(1, 1 + cores)
+
+    // Accumulate the directions each cell needs in the solved state.
+    const required: Map<string, Set<Direction>> = new Map()
+    const addDir = (pos: GridPosition, dir: Direction) => {
+        const k = key(pos)
+        if (!required.has(k)) {
+            required.set(k, new Set())
+        }
+        required.get(k)!.add(dir)
+    }
+    const dirBetween = (a: GridPosition, b: GridPosition): Direction => {
+        if (b.row === a.row - 1) return 'N'
+        if (b.row === a.row + 1) return 'S'
+        if (b.col === a.col + 1) return 'E'
+        return 'W'
+    }
+
+    const pathCells = new Set<string>([key(sourcePos)])
+    for (const core of corePositions) {
+        const path = findPath(sourcePos, core, rows, cols, rng)
+        if (!path) {
+            continue
+        }
+        for (let i = 0; i < path.length; i++) {
+            pathCells.add(key(path[i]))
+            if (i > 0) {
+                addDir(path[i], dirBetween(path[i], path[i - 1]))
+            }
+            if (i < path.length - 1) {
+                addDir(path[i], dirBetween(path[i], path[i + 1]))
+            }
+        }
+        pathCells.add(key(core))
+    }
+
+    // Build the solved grid.
+    const grid: Tile[][] = []
+    const solutionOrientations: number[][] = []
+    for (let r = 0; r < rows; r++) {
+        const gridRow: Tile[] = []
+        const solRow: number[] = []
+        for (let c = 0; c < cols; c++) {
+            const pos = { row: r, col: c }
+            const k = key(pos)
+            const dirs = required.get(k) ?? new Set<Direction>()
+
+            let type: TileType
+            let orientation: number
+            let locked = false
+
+            if (pos.row === sourcePos.row && pos.col === sourcePos.col) {
+                type = 'source'
+                orientation = orientationForSingle([...dirs][0] ?? 'N')
+                locked = true
+            } else if (corePositions.some(p => key(p) === k)) {
+                type = 'core'
+                orientation = orientationForSingle([...dirs][0] ?? 'N')
+                locked = true
+            } else if (pathCells.has(k)) {
+                const t = tileForDirections(dirs)
+                type = t.type
+                orientation = t.orientation
+            } else {
+                // Decoy cell: random pipe tile (loose ends are allowed).
+                const decoys: TileType[] = [
+                    'straight',
+                    'elbow',
+                    't-junction',
+                    'cross',
+                ]
+                type = decoys[Math.floor(rng() * decoys.length)]
+                orientation = Math.floor(rng() * 4)
+            }
+
+            gridRow.push({ type, orientation, locked, powered: false })
+            solRow.push(orientation)
+        }
+        grid.push(gridRow)
+        solutionOrientations.push(solRow)
+    }
+
+    // Place blockers on non-path, non-source/core cells.
+    const blockerCandidates = shuffle(
+        allCells.filter(p => !pathCells.has(key(p))),
+        rng
+    ).slice(0, blockers)
+    for (const pos of blockerCandidates) {
+        grid[pos.row][pos.col] = {
+            type: 'blocker',
+            orientation: 0,
+            locked: true,
+            powered: false,
+        }
+        solutionOrientations[pos.row][pos.col] = 0
+    }
+
+    // Scramble every rotatable tile to a random orientation.
+    for (let r = 0; r < rows; r++) {
+        for (let c = 0; c < cols; c++) {
+            if (!grid[r][c].locked) {
+                grid[r][c].orientation = Math.floor(rng() * 4)
+            }
+        }
+    }
+
+    return { grid, sourcePos, corePositions, solutionOrientations }
+}
+```
+
+- [ ] **Step 4: Run the test, verify it passes**
+
+Run: `bun run test:run src/lib/games/circuit-hacker/generator.test.ts`
+Expected: PASS. If any "solvable" case fails for a seed, it indicates a path/tile-assignment bug — fix `tileForDirections`/path accumulation, do not weaken the assertion.
+
+- [ ] **Step 5: Commit**
+
+```bash
+git add src/lib/games/circuit-hacker/generator.ts src/lib/games/circuit-hacker/generator.test.ts
+git commit -m "feat(circuit-hacker): add solvable puzzle generator"
+```
+
+---
+
+### Task 5: Game class
+
+**Files:**
+- Create: `src/lib/games/circuit-hacker/game.ts`
+- Test: `src/lib/games/circuit-hacker/game.test.ts`
+
+**Interfaces:**
+- Consumes: types from Task 1; `DIFFICULTY_CONFIGS`, `computePoweredCells`, `isSolved`, `countRotatableTiles`, `computeFinalScore` from Tasks 2–3; `generatePuzzle` from Task 4.
+- Produces: class `CircuitHackerGame` with `constructor(config: CircuitHackerConfig, callbacks: CircuitHackerCallbacks, rng?: () => number)`; methods `startGame(): void`, `rotateTile(row: number, col: number): void`, `stopGame(): void`, `getState(): CircuitHackerState`, `getStats(): CircuitHackerStats`, `cleanup(): void`.
+
+- [ ] **Step 1: Write the failing test**
+
+```typescript
+// src/lib/games/circuit-hacker/game.test.ts
+import { describe, it, expect, vi, beforeEach, afterEach } from 'vitest'
+import { CircuitHackerGame } from './game'
+import type { CircuitHackerCallbacks, CircuitHackerConfig } from './types'
+
+function seededRng(seed: number): () => number {
+    let s = seed >>> 0
+    return () => {
+        s = (s * 1664525 + 1013904223) >>> 0
+        return s / 0xffffffff
+    }
+}
+
+const config: CircuitHackerConfig = { difficulty: 'easy', cellSize: 48 }
+
+function makeCallbacks(): CircuitHackerCallbacks {
+    return {
+        onTimeUpdate: vi.fn(),
+        onRotation: vi.fn(),
+        onSolved: vi.fn(),
+        onFail: vi.fn(),
+        onGameStart: vi.fn(),
+    }
+}
+
+describe('CircuitHackerGame', () => {
+    beforeEach(() => vi.useFakeTimers())
+    afterEach(() => vi.useRealTimers())
+
+    it('starts a game and builds a grid', () => {
+        const cb = makeCallbacks()
+        const game = new CircuitHackerGame(config, cb, seededRng(1))
+        game.startGame()
+        const state = game.getState()
+        expect(state.isGameActive).toBe(true)
+        expect(state.grid).toHaveLength(5)
+        expect(cb.onGameStart).toHaveBeenCalled()
+        game.cleanup()
+    })
+
+    it('rotates an unlocked tile and counts the rotation', () => {
+        const cb = makeCallbacks()
+        const game = new CircuitHackerGame(config, cb, seededRng(1))
+        game.startGame()
+        // find first unlocked tile
+        const state = game.getState()
+        let target = { row: 0, col: 0 }
+        outer: for (let r = 0; r < state.rows; r++) {
+            for (let c = 0; c < state.cols; c++) {
+                if (!state.grid[r][c].locked) {
+                    target = { row: r, col: c }
+                    break outer
+                }
+            }
+        }
+        const before = game.getState().grid[target.row][target.col].orientation
+        game.rotateTile(target.row, target.col)
+        const after = game.getState().grid[target.row][target.col].orientation
+        expect(after).toBe((before + 1) % 4)
+        expect(game.getState().rotationsUsed).toBe(1)
+        expect(cb.onRotation).toHaveBeenCalledWith(1)
+        game.cleanup()
+    })
+
+    it('does not rotate a locked tile', () => {
+        const cb = makeCallbacks()
+        const game = new CircuitHackerGame(config, cb, seededRng(1))
+        game.startGame()
+        const { sourcePos } = game.getState()
+        const before =
+            game.getState().grid[sourcePos.row][sourcePos.col].orientation
+        game.rotateTile(sourcePos.row, sourcePos.col)
+        const after =
+            game.getState().grid[sourcePos.row][sourcePos.col].orientation
+        expect(after).toBe(before)
+        expect(game.getState().rotationsUsed).toBe(0)
+        game.cleanup()
+    })
+
+    it('solves when the board is rotated into the solution', () => {
+        const cb = makeCallbacks()
+        const game = new CircuitHackerGame(config, cb, seededRng(1))
+        game.startGame()
+        game.solveForTest() // test helper applies solution orientations
+        expect(cb.onSolved).toHaveBeenCalledTimes(1)
+        const [score, stats] = (cb.onSolved as ReturnType<typeof vi.fn>).mock
+            .calls[0]
+        expect(score).toBeGreaterThan(0)
+        expect(stats.solved).toBe(true)
+        expect(game.getState().isGameActive).toBe(false)
+        game.cleanup()
+    })
+
+    it('fails when the timer runs out', () => {
+        const cb = makeCallbacks()
+        const game = new CircuitHackerGame(config, cb, seededRng(1))
+        game.startGame()
+        vi.advanceTimersByTime(121_000) // past the 120s easy timer
+        expect(cb.onFail).toHaveBeenCalledTimes(1)
+        expect(game.getState().isGameOver).toBe(true)
+        game.cleanup()
+    })
+})
+```
+
+- [ ] **Step 2: Run the test, verify it fails**
+
+Run: `bun run test:run src/lib/games/circuit-hacker/game.test.ts`
+Expected: FAIL — `Failed to resolve import "./game"`.
+
+- [ ] **Step 3: Implement `game.ts`**
+
+```typescript
+// src/lib/games/circuit-hacker/game.ts
+import type {
+    CircuitHackerCallbacks,
+    CircuitHackerConfig,
+    CircuitHackerState,
+    CircuitHackerStats,
+} from './types'
+import {
+    DIFFICULTY_CONFIGS,
+    computePoweredCells,
+    countRotatableTiles,
+    computeFinalScore,
+    isSolved,
+} from './utils'
+import { generatePuzzle, type GeneratedPuzzle } from './generator'
+
+export class CircuitHackerGame {
+    private config: CircuitHackerConfig
+    private callbacks: CircuitHackerCallbacks
+    private rng: () => number
+    private state: CircuitHackerState
+    private puzzle: GeneratedPuzzle
+    private timer: number | null = null
+
+    constructor(
+        config: CircuitHackerConfig,
+        callbacks: CircuitHackerCallbacks,
+        rng: () => number = Math.random
+    ) {
+        this.config = config
+        this.callbacks = callbacks
+        this.rng = rng
+        this.puzzle = this.buildPuzzle()
+        this.state = this.buildInitialState()
+    }
+
+    private buildPuzzle(): GeneratedPuzzle {
+        return generatePuzzle(DIFFICULTY_CONFIGS[this.config.difficulty], this.rng)
+    }
+
+    private buildInitialState(): CircuitHackerState {
+        const tier = DIFFICULTY_CONFIGS[this.config.difficulty]
+        const state: CircuitHackerState = {
+            grid: this.puzzle.grid,
+            sourcePos: this.puzzle.sourcePos,
+            corePositions: this.puzzle.corePositions,
+            rows: tier.rows,
+            cols: tier.cols,
+            score: 0,
+            timeRemaining: tier.duration,
+            rotationsUsed: 0,
+            isGameActive: false,
+            isGameOver: false,
+            solved: false,
+        }
+        this.applyPower(state)
+        return state
+    }
+
+    private applyPower(state: CircuitHackerState): void {
+        const powered = computePoweredCells(state.grid, state.sourcePos)
+        for (let r = 0; r < state.rows; r++) {
+            for (let c = 0; c < state.cols; c++) {
+                state.grid[r][c].powered = powered[r][c]
+            }
+        }
+    }
+
+    startGame(): void {
+        if (this.state.isGameActive) {
+            return
+        }
+        // Fresh puzzle each run at the configured difficulty.
+        this.puzzle = this.buildPuzzle()
+        this.state = this.buildInitialState()
+        this.state.isGameActive = true
+
+        this.callbacks.onGameStart()
+        this.callbacks.onTimeUpdate(this.state.timeRemaining)
+
+        this.timer = window.setInterval(() => {
+            if (!this.state.isGameActive) {
+                return
+            }
+            this.state.timeRemaining--
+            this.callbacks.onTimeUpdate(this.state.timeRemaining)
+            if (this.state.timeRemaining <= 0) {
+                this.fail()
+            }
+        }, 1000)
+    }
+
+    rotateTile(row: number, col: number): void {
+        if (!this.state.isGameActive) {
+            return
+        }
+        if (
+            row < 0 ||
+            row >= this.state.rows ||
+            col < 0 ||
+            col >= this.state.cols
+        ) {
+            return
+        }
+        const tile = this.state.grid[row][col]
+        if (tile.locked) {
+            return
+        }
+
+        tile.orientation = (tile.orientation + 1) % 4
+        this.state.rotationsUsed++
+        this.applyPower(this.state)
+        this.callbacks.onRotation(this.state.rotationsUsed)
+
+        if (
+            isSolved(
+                this.state.grid,
+                this.state.sourcePos,
+                this.state.corePositions
+            )
+        ) {
+            this.solve()
+        }
+    }
+
+    private solve(): void {
+        this.clearTimer()
+        this.state.isGameActive = false
+        this.state.isGameOver = true
+        this.state.solved = true
+        this.state.score = computeFinalScore({
+            secondsRemaining: this.state.timeRemaining,
+            rotationsUsed: this.state.rotationsUsed,
+            rotatableTileCount: countRotatableTiles(this.state.grid),
+            multiplier: DIFFICULTY_CONFIGS[this.config.difficulty].multiplier,
+        })
+        this.callbacks.onSolved(this.state.score, this.getStats())
+    }
+
+    private fail(): void {
+        this.clearTimer()
+        this.state.isGameActive = false
+        this.state.isGameOver = true
+        this.state.solved = false
+        this.state.timeRemaining = Math.max(0, this.state.timeRemaining)
+        this.callbacks.onFail(this.getStats())
+    }
+
+    stopGame(): void {
+        if (!this.state.isGameActive) {
+            return
+        }
+        this.fail()
+    }
+
+    getState(): CircuitHackerState {
+        return this.state
+    }
+
+    getStats(): CircuitHackerStats {
+        return {
+            finalScore: this.state.score,
+            difficulty: this.config.difficulty,
+            secondsRemaining: this.state.timeRemaining,
+            rotationsUsed: this.state.rotationsUsed,
+            solved: this.state.solved,
+        }
+    }
+
+    private clearTimer(): void {
+        if (this.timer !== null) {
+            clearInterval(this.timer)
+            this.timer = null
+        }
+    }
+
+    cleanup(): void {
+        this.clearTimer()
+    }
+
+    /** Test-only helper: rotate every tile into the known solution. */
+    solveForTest(): void {
+        for (let r = 0; r < this.state.rows; r++) {
+            for (let c = 0; c < this.state.cols; c++) {
+                this.state.grid[r][c].orientation =
+                    this.puzzle.solutionOrientations[r][c]
+            }
+        }
+        this.applyPower(this.state)
+        if (
+            isSolved(
+                this.state.grid,
+                this.state.sourcePos,
+                this.state.corePositions
+            )
+        ) {
+            this.solve()
+        }
+    }
+}
+```
+
+- [ ] **Step 4: Run the test, verify it passes**
+
+Run: `bun run test:run src/lib/games/circuit-hacker/game.test.ts`
+Expected: PASS (5 tests).
+
+- [ ] **Step 5: Commit**
+
+```bash
+git add src/lib/games/circuit-hacker/game.ts src/lib/games/circuit-hacker/game.test.ts
+git commit -m "feat(circuit-hacker): add game state machine"
+```
+
+---
+
+### Task 6: PixiJS renderer
+
+**Files:**
+- Create: `src/lib/games/circuit-hacker/renderer.ts`
+- Test: `src/lib/games/circuit-hacker/renderer.test.ts`
+
+**Interfaces:**
+- Consumes: `CircuitHackerState`, `GridPosition`, `Tile`, `Direction` from Task 1; `getConnectors` from Task 1.
+- Produces: `RendererState = { app: Application; tileGraphic: Graphics }`; `setupPixiJS(container: HTMLElement, rows: number, cols: number, cellSize: number): Promise<RendererState>`; `renderGrid(rendererState: RendererState, state: CircuitHackerState, cellSize: number): void`; `pointerToCell(x: number, y: number, cellSize: number, rows: number, cols: number): GridPosition | null`; `cleanup(rendererState: RendererState): void`.
+
+- [ ] **Step 1: Write the failing test**
+
+```typescript
+// src/lib/games/circuit-hacker/renderer.test.ts
+import { describe, it, expect, vi, beforeEach } from 'vitest'
+
+vi.mock('pixi.js', () => {
+    const makeGraphics = () => {
+        const g: Record<string, unknown> = { alpha: 1, x: 0, y: 0 }
+        for (const m of [
+            'clear',
+            'rect',
+            'fill',
+            'stroke',
+            'circle',
+            'moveTo',
+            'lineTo',
+            'roundRect',
+        ]) {
+            g[m] = vi.fn(() => g)
+        }
+        g['destroy'] = vi.fn()
+        return g
+    }
+    const makeApp = () => {
+        const canvas = document.createElement('canvas')
+        Object.defineProperty(canvas, 'style', {
+            value: { border: '', borderRadius: '', boxShadow: '' },
+            writable: true,
+        })
+        return {
+            init: vi.fn().mockResolvedValue(undefined),
+            canvas,
+            stage: { addChild: vi.fn() },
+            destroy: vi.fn(),
+        }
+    }
+    return {
+        Application: vi.fn(makeApp),
+        Container: vi.fn(() => ({ addChild: vi.fn(), destroy: vi.fn() })),
+        Graphics: vi.fn(makeGraphics),
+    }
+})
+
+import { setupPixiJS, renderGrid, pointerToCell, cleanup } from './renderer'
+import type { CircuitHackerState, Tile } from './types'
+
+const tile = (over: Partial<Tile> = {}): Tile => ({
+    type: 'straight',
+    orientation: 0,
+    locked: false,
+    powered: false,
+    ...over,
+})
+
+describe('circuit-hacker renderer', () => {
+    let container: HTMLElement
+    beforeEach(() => {
+        container = document.createElement('div')
+        document.body.appendChild(container)
+    })
+
+    it('initializes a PixiJS app sized to the grid', async () => {
+        const rs = await setupPixiJS(container, 5, 5, 48)
+        expect(rs.app.init).toHaveBeenCalledWith(
+            expect.objectContaining({ width: 240, height: 240 })
+        )
+        expect(container.contains(rs.app.canvas)).toBe(true)
+    })
+
+    it('maps pointer coordinates to a cell', () => {
+        expect(pointerToCell(10, 10, 48, 5, 5)).toEqual({ row: 0, col: 0 })
+        expect(pointerToCell(100, 50, 48, 5, 5)).toEqual({ row: 1, col: 2 })
+        expect(pointerToCell(-5, 10, 48, 5, 5)).toBeNull()
+        expect(pointerToCell(10, 9999, 48, 5, 5)).toBeNull()
+    })
+
+    it('renders without throwing', async () => {
+        const rs = await setupPixiJS(container, 1, 2, 48)
+        const state = {
+            grid: [[tile({ type: 'source', locked: true }), tile()]],
+            sourcePos: { row: 0, col: 0 },
+            corePositions: [],
+            rows: 1,
+            cols: 2,
+            score: 0,
+            timeRemaining: 10,
+            rotationsUsed: 0,
+            isGameActive: true,
+            isGameOver: false,
+            solved: false,
+        } as CircuitHackerState
+        expect(() => renderGrid(rs, state, 48)).not.toThrow()
+        expect(rs.tileGraphic.clear).toHaveBeenCalled()
+        cleanup(rs)
+        expect(rs.app.destroy).toHaveBeenCalled()
+    })
+})
+```
+
+- [ ] **Step 2: Run the test, verify it fails**
+
+Run: `bun run test:run src/lib/games/circuit-hacker/renderer.test.ts`
+Expected: FAIL — `Failed to resolve import "./renderer"`.
+
+- [ ] **Step 3: Implement `renderer.ts`**
+
+```typescript
+// src/lib/games/circuit-hacker/renderer.ts
+import { Application, Graphics } from 'pixi.js'
+import type { CircuitHackerState, Direction, GridPosition, Tile } from './types'
+import { getConnectors } from './utils'
+
+export interface RendererState {
+    app: Application
+    tileGraphic: Graphics
+}
+
+const BACKGROUND = '#000a14'
+const COLOR_WIRE_OFF = 0x335577
+const COLOR_WIRE_ON = 0x22d3ee
+const COLOR_SOURCE = 0x22c55e
+const COLOR_CORE_OFF = 0x9333ea
+const COLOR_CORE_ON = 0xf472b6
+const COLOR_BLOCKER = 0x1e293b
+
+export async function setupPixiJS(
+    container: HTMLElement,
+    rows: number,
+    cols: number,
+    cellSize: number
+): Promise<RendererState> {
+    try {
+        const app = new Application()
+        await app.init({
+            width: cols * cellSize,
+            height: rows * cellSize,
+            backgroundColor: BACKGROUND,
+            antialias: true,
+            resolution: window.devicePixelRatio || 1,
+            autoDensity: true,
+        })
+
+        container.appendChild(app.canvas)
+        app.canvas.style.border = '2px solid rgba(6, 182, 212, 0.3)'
+        app.canvas.style.borderRadius = '12px'
+        app.canvas.style.boxShadow = '0 0 30px rgba(6, 182, 212, 0.3)'
+
+        const tileGraphic = new Graphics()
+        app.stage.addChild(tileGraphic)
+
+        return { app, tileGraphic }
+    } catch (error) {
+        container.innerHTML = ''
+        throw new Error(`Failed to initialize PixiJS: ${error}`)
+    }
+}
+
+function dirOffset(dir: Direction): { dx: number; dy: number } {
+    switch (dir) {
+        case 'N':
+            return { dx: 0, dy: -1 }
+        case 'S':
+            return { dx: 0, dy: 1 }
+        case 'E':
+            return { dx: 1, dy: 0 }
+        case 'W':
+            return { dx: -1, dy: 0 }
+    }
+}
+
+function drawTile(
+    g: Graphics,
+    tile: Tile,
+    x: number,
+    y: number,
+    cellSize: number
+): void {
+    const cx = x + cellSize / 2
+    const cy = y + cellSize / 2
+    const half = cellSize / 2
+
+    // Cell background
+    g.rect(x + 1, y + 1, cellSize - 2, cellSize - 2).fill({
+        color: 0x001122,
+        alpha: 0.5,
+    })
+    g.rect(x + 1, y + 1, cellSize - 2, cellSize - 2).stroke({
+        color: 0x0ea5e9,
+        width: 1,
+        alpha: 0.15,
+    })
+
+    if (tile.type === 'blocker') {
+        g.rect(x + 6, y + 6, cellSize - 12, cellSize - 12).fill(COLOR_BLOCKER)
+        return
+    }
+
+    const wireColor = tile.powered ? COLOR_WIRE_ON : COLOR_WIRE_OFF
+    const wireWidth = tile.powered ? 6 : 4
+
+    // Draw a wire segment from the centre out to each connector edge.
+    for (const dir of getConnectors(tile)) {
+        const { dx, dy } = dirOffset(dir)
+        g.moveTo(cx, cy)
+            .lineTo(cx + dx * half, cy + dy * half)
+            .stroke({ color: wireColor, width: wireWidth })
+    }
+
+    // Centre hub / node
+    if (tile.type === 'source') {
+        g.circle(cx, cy, half * 0.35).fill(COLOR_SOURCE)
+    } else if (tile.type === 'core') {
+        g.circle(cx, cy, half * 0.35).fill(
+            tile.powered ? COLOR_CORE_ON : COLOR_CORE_OFF
+        )
+    } else {
+        g.circle(cx, cy, wireWidth * 0.9).fill(wireColor)
+    }
+}
+
+export function renderGrid(
+    rendererState: RendererState,
+    state: CircuitHackerState,
+    cellSize: number
+): void {
+    const g = rendererState.tileGraphic
+    g.clear()
+    for (let r = 0; r < state.rows; r++) {
+        for (let c = 0; c < state.cols; c++) {
+            drawTile(g, state.grid[r][c], c * cellSize, r * cellSize, cellSize)
+        }
+    }
+}
+
+export function pointerToCell(
+    x: number,
+    y: number,
+    cellSize: number,
+    rows: number,
+    cols: number
+): GridPosition | null {
+    const col = Math.floor(x / cellSize)
+    const row = Math.floor(y / cellSize)
+    if (row < 0 || row >= rows || col < 0 || col >= cols) {
+        return null
+    }
+    return { row, col }
+}
+
+export function cleanup(rendererState: RendererState): void {
+    rendererState.app.destroy(true, { children: true, texture: true })
+}
+```
+
+- [ ] **Step 4: Run the test, verify it passes**
+
+Run: `bun run test:run src/lib/games/circuit-hacker/renderer.test.ts`
+Expected: PASS (3 tests).
+
+- [ ] **Step 5: Commit**
+
+```bash
+git add src/lib/games/circuit-hacker/renderer.ts src/lib/games/circuit-hacker/renderer.test.ts
+git commit -m "feat(circuit-hacker): add PixiJS renderer"
+```
+
+---
+
+### Task 7: Init wiring & score submission
+
+**Files:**
+- Create: `src/lib/games/circuit-hacker/init.ts`
+- Test: `src/lib/games/circuit-hacker/init.test.ts`
+
+**Interfaces:**
+- Consumes: `CircuitHackerGame` (Task 5); renderer functions (Task 6); `DIFFICULTY_CONFIGS` (Task 3); `Difficulty`, `CircuitHackerStats` (Task 1); `saveGameScore` from `@/lib/services/scoreService`; `GameID` from `@/lib/games`.
+- Produces: `initializeCircuitHackerGame(container: HTMLElement, callbacks: CircuitHackerUICallbacks): Promise<CircuitHackerHandle>` where `CircuitHackerUICallbacks = { onTimeUpdate: (t: number) => void; onRotation: (n: number) => void; onStart: () => void; onEnd: (stats: CircuitHackerStats) => void }` and `CircuitHackerHandle = { start: (difficulty: Difficulty) => Promise<void>; stop: () => void; cleanup: () => void; getGame: () => CircuitHackerGame | null }`. Also re-exports `GameID` usage internally; default cell size constant `CELL_SIZE = 48`.
+
+`init.ts` owns: building the game/renderer for the chosen difficulty, wiring canvas pointer events to `rotateTile`, re-rendering on change, submitting the score on solve, and updating the game-over overlay DOM (mirroring Evader's `handleGameOver`).
+
+- [ ] **Step 1: Write the failing test**
+
+```typescript
+// src/lib/games/circuit-hacker/init.test.ts
+import { describe, it, expect, vi, beforeEach, afterEach } from 'vitest'
+
+vi.mock('pixi.js', () => {
+    const makeGraphics = () => {
+        const g: Record<string, unknown> = { alpha: 1, x: 0, y: 0 }
+        for (const m of [
+            'clear',
+            'rect',
+            'fill',
+            'stroke',
+            'circle',
+            'moveTo',
+            'lineTo',
+            'roundRect',
+        ]) {
+            g[m] = vi.fn(() => g)
+        }
+        g['destroy'] = vi.fn()
+        return g
+    }
+    const makeApp = () => {
+        const canvas = document.createElement('canvas')
+        Object.defineProperty(canvas, 'style', {
+            value: { border: '', borderRadius: '', boxShadow: '' },
+            writable: true,
+        })
+        // getBoundingClientRect is used to translate pointer coords
+        canvas.getBoundingClientRect = () =>
+            ({ left: 0, top: 0, width: 240, height: 240 }) as DOMRect
+        return {
+            init: vi.fn().mockResolvedValue(undefined),
+            canvas,
+            stage: { addChild: vi.fn() },
+            destroy: vi.fn(),
+        }
+    }
+    return {
+        Application: vi.fn(makeApp),
+        Container: vi.fn(() => ({ addChild: vi.fn(), destroy: vi.fn() })),
+        Graphics: vi.fn(makeGraphics),
+    }
+})
+
+const saveGameScore = vi.fn().mockResolvedValue(undefined)
+vi.mock('@/lib/services/scoreService', () => ({
+    saveGameScore: (...args: unknown[]) => saveGameScore(...args),
+}))
+
+import { initializeCircuitHackerGame } from './init'
+import { GameID } from '@/lib/games'
+
+function setupDom(): HTMLElement {
+    document.body.innerHTML = `
+        <div id="game-canvas-container"></div>
+        <span id="final-score">0</span>
+        <span id="final-time">0</span>
+        <span id="final-rotations">0</span>
+        <span id="game-over-title"></span>
+        <div id="game-over-overlay" class="hidden"></div>
+        <button id="start-btn"></button>
+        <button id="stop-btn" style="display:none"></button>
+    `
+    return document.getElementById('game-canvas-container') as HTMLElement
+}
+
+describe('initializeCircuitHackerGame', () => {
+    beforeEach(() => {
+        vi.useFakeTimers()
+        saveGameScore.mockClear()
+    })
+    afterEach(() => vi.useRealTimers())
+
+    it('starts a game of the chosen difficulty', async () => {
+        const container = setupDom()
+        const onStart = vi.fn()
+        const handle = await initializeCircuitHackerGame(container, {
+            onTimeUpdate: vi.fn(),
+            onRotation: vi.fn(),
+            onStart,
+            onEnd: vi.fn(),
+        })
+        await handle.start('easy')
+        expect(onStart).toHaveBeenCalled()
+        expect(handle.getGame()?.getState().rows).toBe(5)
+        handle.cleanup()
+    })
+
+    it('submits the score with gameData when solved', async () => {
+        const container = setupDom()
+        const handle = await initializeCircuitHackerGame(container, {
+            onTimeUpdate: vi.fn(),
+            onRotation: vi.fn(),
+            onStart: vi.fn(),
+            onEnd: vi.fn(),
+        })
+        await handle.start('easy')
+        // Force a solve via the game's test helper
+        ;(
+            handle.getGame() as unknown as { solveForTest: () => void }
+        ).solveForTest()
+        await vi.runAllTimersAsync()
+        expect(saveGameScore).toHaveBeenCalledTimes(1)
+        const [gameId, score, , , gameData] = saveGameScore.mock.calls[0]
+        expect(gameId).toBe(GameID.CIRCUIT_HACKER)
+        expect(score).toBeGreaterThan(0)
+        expect(gameData).toMatchObject({ difficulty: 'easy', solved: true })
+        handle.cleanup()
+    })
+
+    it('does not submit a score when the run fails', async () => {
+        const container = setupDom()
+        const handle = await initializeCircuitHackerGame(container, {
+            onTimeUpdate: vi.fn(),
+            onRotation: vi.fn(),
+            onStart: vi.fn(),
+            onEnd: vi.fn(),
+        })
+        await handle.start('easy')
+        vi.advanceTimersByTime(121_000)
+        await vi.runAllTimersAsync()
+        expect(saveGameScore).not.toHaveBeenCalled()
+        handle.cleanup()
+    })
+})
+```
+
+- [ ] **Step 2: Run the test, verify it fails**
+
+Run: `bun run test:run src/lib/games/circuit-hacker/init.test.ts`
+Expected: FAIL — `Failed to resolve import "./init"`.
+
+- [ ] **Step 3: Implement `init.ts`**
+
+```typescript
+// src/lib/games/circuit-hacker/init.ts
+import { CircuitHackerGame } from './game'
+import {
+    setupPixiJS,
+    renderGrid,
+    pointerToCell,
+    cleanup as rendererCleanup,
+    type RendererState,
+} from './renderer'
+import { DIFFICULTY_CONFIGS } from './utils'
+import type { Difficulty, CircuitHackerStats } from './types'
+import { saveGameScore } from '@/lib/services/scoreService'
+import { GameID } from '@/lib/games'
+
+export const CELL_SIZE = 48
+
+export interface CircuitHackerUICallbacks {
+    onTimeUpdate: (timeRemaining: number) => void
+    onRotation: (rotationsUsed: number) => void
+    onStart: () => void
+    onEnd: (stats: CircuitHackerStats) => void
+}
+
+export interface CircuitHackerHandle {
+    start: (difficulty: Difficulty) => Promise<void>
+    stop: () => void
+    cleanup: () => void
+    getGame: () => CircuitHackerGame | null
+}
+
+function setText(id: string, value: string): void {
+    const el = document.getElementById(id)
+    if (el) {
+        el.textContent = value
+    }
+}
+
+function resetButtons(): void {
+    const startBtn = document.getElementById('start-btn')
+    const stopBtn = document.getElementById('stop-btn')
+    if (startBtn) {
+        startBtn.style.display = 'inline-flex'
+    }
+    if (stopBtn) {
+        stopBtn.style.display = 'none'
+    }
+}
+
+function showOverlay(title: string, stats: CircuitHackerStats): void {
+    setText('game-over-title', title)
+    setText('final-score', stats.finalScore.toString())
+    setText('final-time', `${stats.secondsRemaining}s`)
+    setText('final-rotations', stats.rotationsUsed.toString())
+    const overlay = document.getElementById('game-over-overlay')
+    if (overlay) {
+        overlay.classList.remove('hidden')
+    }
+}
+
+export async function initializeCircuitHackerGame(
+    container: HTMLElement,
+    callbacks: CircuitHackerUICallbacks
+): Promise<CircuitHackerHandle> {
+    let game: CircuitHackerGame | null = null
+    let renderer: RendererState | null = null
+    let pointerHandler: ((event: PointerEvent) => void) | null = null
+
+    const teardownRenderer = () => {
+        if (renderer && pointerHandler) {
+            renderer.app.canvas.removeEventListener('pointerdown', pointerHandler)
+        }
+        if (renderer) {
+            rendererCleanup(renderer)
+            renderer = null
+        }
+        pointerHandler = null
+        container.innerHTML = ''
+    }
+
+    const render = () => {
+        if (renderer && game) {
+            renderGrid(renderer, game.getState(), CELL_SIZE)
+        }
+    }
+
+    const start = async (difficulty: Difficulty): Promise<void> => {
+        if (game) {
+            game.cleanup()
+        }
+        teardownRenderer()
+
+        const tier = DIFFICULTY_CONFIGS[difficulty]
+        renderer = await setupPixiJS(container, tier.rows, tier.cols, CELL_SIZE)
+
+        game = new CircuitHackerGame(
+            { difficulty, cellSize: CELL_SIZE },
+            {
+                onGameStart: () => {
+                    callbacks.onStart()
+                    render()
+                },
+                onTimeUpdate: t => callbacks.onTimeUpdate(t),
+                onRotation: n => {
+                    callbacks.onRotation(n)
+                    render()
+                },
+                onSolved: async (finalScore, stats) => {
+                    render()
+                    resetButtons()
+                    showOverlay('CIRCUIT POWERED!', stats)
+                    callbacks.onEnd(stats)
+                    await saveGameScore(
+                        GameID.CIRCUIT_HACKER,
+                        finalScore,
+                        result => {
+                            if (result.newAchievements?.length) {
+                                window.dispatchEvent(
+                                    new CustomEvent('achievementsEarned', {
+                                        detail: {
+                                            achievementIds:
+                                                result.newAchievements,
+                                        },
+                                    })
+                                )
+                            }
+                        },
+                        error => {
+                            // eslint-disable-next-line no-console
+                            console.error('Failed to submit score:', error)
+                        },
+                        {
+                            difficulty: stats.difficulty,
+                            secondsRemaining: stats.secondsRemaining,
+                            rotationsUsed: stats.rotationsUsed,
+                            solved: stats.solved,
+                        }
+                    )
+                },
+                onFail: stats => {
+                    render()
+                    resetButtons()
+                    showOverlay("TIME'S UP!", stats)
+                    callbacks.onEnd(stats)
+                },
+            }
+        )
+
+        pointerHandler = (event: PointerEvent) => {
+            if (!renderer || !game) {
+                return
+            }
+            const rect = renderer.app.canvas.getBoundingClientRect()
+            const scaleX = rect.width / (tier.cols * CELL_SIZE)
+            const scaleY = rect.height / (tier.rows * CELL_SIZE)
+            const x = (event.clientX - rect.left) / scaleX
+            const y = (event.clientY - rect.top) / scaleY
+            const cell = pointerToCell(x, y, CELL_SIZE, tier.rows, tier.cols)
+            if (cell) {
+                game.rotateTile(cell.row, cell.col)
+            }
+        }
+        renderer.app.canvas.addEventListener('pointerdown', pointerHandler)
+
+        game.startGame()
+        render()
+    }
+
+    const stop = () => {
+        game?.stopGame()
+    }
+
+    const cleanup = () => {
+        game?.cleanup()
+        game = null
+        teardownRenderer()
+    }
+
+    return { start, stop, cleanup, getGame: () => game }
+}
+```
+
+- [ ] **Step 4: Run the test, verify it passes**
+
+Run: `bun run test:run src/lib/games/circuit-hacker/init.test.ts`
+Expected: PASS (3 tests).
+
+- [ ] **Step 5: Commit**
+
+```bash
+git add src/lib/games/circuit-hacker/init.ts src/lib/games/circuit-hacker/init.test.ts
+git commit -m "feat(circuit-hacker): wire game, renderer, and score submission"
+```
+
+---
+
+### Task 8: Registry integration (home page + routing)
+
+**Files:**
+- Modify: `src/lib/games.ts` (enum ~line 14, `GAMES` array end ~line 173, `GAME_ICONS` ~line 233)
+- Modify: `src/components/ui/GameCard.astro:38-69` (`getGameUrl`)
+- Modify: `src/pages/index.astro:21-33` (`idMapping`)
+- Test: `src/lib/games.test.ts`
+
+**Interfaces:**
+- Consumes: existing `GameID` enum, `GAMES`, `getGameIcon`.
+- Produces: `GameID.CIRCUIT_HACKER = 'circuit_hacker'`; a `GAMES` entry named `'Circuit Hacker'`; icon `🔌`; route `/circuit-hacker`.
+
+- [ ] **Step 1: Write the failing test** (append to `src/lib/games.test.ts`)
+
+```typescript
+import { GameID, GAMES, getGameById, getGameIcon } from './games'
+
+describe('Circuit Hacker registration', () => {
+    it('has a GameID and registry entry', () => {
+        expect(GameID.CIRCUIT_HACKER).toBe('circuit_hacker')
+        const game = getGameById(GameID.CIRCUIT_HACKER)
+        expect(game).toBeDefined()
+        expect(game?.name).toBe('Circuit Hacker')
+        expect(game?.category).toBe('puzzle')
+        expect(game?.isActive).toBe(true)
+    })
+
+    it('has an icon', () => {
+        expect(getGameIcon(GameID.CIRCUIT_HACKER)).toBe('🔌')
+    })
+
+    it('is included in the GAMES list exactly once', () => {
+        expect(
+            GAMES.filter(g => g.id === GameID.CIRCUIT_HACKER)
+        ).toHaveLength(1)
+    })
+})
+```
+
+- [ ] **Step 2: Run the test, verify it fails**
+
+Run: `bun run test:run src/lib/games.test.ts`
+Expected: FAIL — `GameID.CIRCUIT_HACKER` is undefined / `getGameById` returns undefined.
+
+- [ ] **Step 3: Add the enum member** in `src/lib/games.ts` (inside `enum GameID`, after `GAME_2048`)
+
+```typescript
+    GAME_2048 = '2048',
+    CIRCUIT_HACKER = 'circuit_hacker',
+}
+```
+
+- [ ] **Step 4: Add the `GAMES` entry** in `src/lib/games.ts` (append as the last element of the `GAMES` array, after the 2048 entry)
+
+```typescript
+    {
+        id: GameID.CIRCUIT_HACKER,
+        name: 'Circuit Hacker',
+        description:
+            'Rotate circuit tiles to power a path from the source to the core before time runs out',
+        category: 'puzzle',
+        maxPlayers: 1,
+        estimatedDuration: '2-5 minutes',
+        difficulty: 'medium',
+        tags: ['puzzle', 'logic', 'circuit', 'single-player', 'rotation'],
+        isActive: true,
+    },
+```
+
+- [ ] **Step 5: Add the icon** in `src/lib/games.ts` (inside `GAME_ICONS`, after the `GAME_2048` line)
+
+```typescript
+    [GameID.GAME_2048]: '🎯',
+    [GameID.CIRCUIT_HACKER]: '🔌',
+}
+```
+
+- [ ] **Step 6: Add the route** in `src/components/ui/GameCard.astro` (inside `getGameUrl`, before `default:`)
+
+```typescript
+    case 'Circuit Hacker':
+      return '/circuit-hacker'
+    default:
+      return '#'
+```
+
+- [ ] **Step 7: Add the home-page id mapping** in `src/pages/index.astro` (inside `idMapping`, after `snake: 11,`)
+
+```typescript
+  snake: 11,
+  circuit_hacker: 12,
+}
+```
+
+- [ ] **Step 8: Run the test, verify it passes**
+
+Run: `bun run test:run src/lib/games.test.ts`
+Expected: PASS (including the 3 new tests).
+
+- [ ] **Step 9: Commit**
+
+```bash
+git add src/lib/games.ts src/components/ui/GameCard.astro src/pages/index.astro src/lib/games.test.ts
+git commit -m "feat(circuit-hacker): register game on home page and routing"
+```
+
+---
+
+### Task 9: Astro game page
+
+**Files:**
+- Create: `src/pages/circuit-hacker/index.astro`
+- Modify: `src/pages/game-board-markup.test.ts`
+
+**Interfaces:**
+- Consumes: `initializeCircuitHackerGame` (Task 7); `AppLayout`, `Button`, `Card`, `Badge`, `GameOverlay`, `AchievementAward` components.
+- Produces: the page route `/circuit-hacker`, with element IDs: `game-canvas-container`, `difficulty-select`, `time-remaining`, `rotation-count`, `start-btn`, `stop-btn`, `game-status`, `game-error`/`game-error-title`/`game-error-message`, and (via `GameOverlay`) `game-over-overlay`, `game-over-title`, `final-score`, plus custom `final-time`, `final-rotations`, and `play-again-btn`.
+
+- [ ] **Step 1: Create the page**
+
+```astro
+---
+import AppLayout from '@/layouts/AppLayout.astro'
+import Button from '@/components/ui/Button.astro'
+import Card from '@/components/ui/Card.astro'
+import Badge from '@/components/ui/Badge.astro'
+import GameOverlay from '@/components/GameOverlay.astro'
+import AchievementAward from '@/components/AchievementAward.astro'
+
+const gameNavigation = [
+  { href: '/', label: 'Home' },
+  { href: '#', label: 'Circuit Hacker' },
+]
+---
+
+<AppLayout
+  title="Circuit Hacker - Cetus Minigames"
+  description="Rotate circuit tiles to power a path from the source to the core before time runs out"
+  includeFooter={false}
+  navigation={gameNavigation}
+>
+  <div class="px-6 py-4 border-b border-slate-700/50">
+    <div class="max-w-7xl mx-auto">
+      <div class="flex items-center space-x-3">
+        <div class="text-cyan-400 text-sm">🔌 Circuit Hacker</div>
+      </div>
+    </div>
+  </div>
+
+  <div class="px-6 py-8">
+    <div class="max-w-6xl mx-auto">
+      <div class="text-center mb-8">
+        <h2 class="text-5xl font-orbitron font-bold text-holographic mb-4">
+          CIRCUIT HACKER
+        </h2>
+        <p class="text-gray-400 text-lg">
+          Rotate the tiles to connect the source to every core before the timer
+          expires!
+        </p>
+      </div>
+
+      <div class="flex flex-col lg:flex-row gap-8 items-start justify-center">
+        <Card variant="glass" class="p-6 flex-shrink-0">
+          <div class="flex flex-col items-center space-y-4">
+            <div class="flex space-x-4 mb-2">
+              <Badge variant="outline" class="px-4 py-2">
+                <span class="font-mono"
+                  >Time: <span id="time-remaining" class="text-cyan-400"
+                    >--</span
+                  >s</span
+                >
+              </Badge>
+              <Badge variant="outline" class="px-4 py-2">
+                <span class="font-mono"
+                  >Rotations: <span id="rotation-count" class="text-cyan-400"
+                    >0</span
+                  ></span
+                >
+              </Badge>
+            </div>
+
+            <div class="flex items-center space-x-2">
+              <span class="text-gray-400 text-sm">Difficulty:</span>
+              <select
+                id="difficulty-select"
+                class="bg-slate-800 border border-cyan-400/40 rounded-md px-3 py-1 text-sm text-white"
+              >
+                <option value="easy">Easy (5×5)</option>
+                <option value="medium" selected>Medium (7×7)</option>
+                <option value="hard">Hard (9×9)</option>
+                <option value="expert">Expert (11×11)</option>
+              </select>
+            </div>
+
+            <div class="relative">
+              <div
+                id="game-canvas-container"
+                class="bg-black/30 rounded-lg min-w-[240px] min-h-[240px]"
+              >
+              </div>
+
+              <div
+                id="game-status"
+                class="absolute inset-0 flex items-center justify-center bg-black/70 rounded-lg hidden"
+              >
+                <div class="text-center">
+                  <div class="text-6xl mb-4">🔌</div>
+                  <div class="text-xl text-cyan-400 font-orbitron font-bold mb-2">
+                    CIRCUIT HACKER
+                  </div>
+                  <div class="text-gray-400">Pick a difficulty and start!</div>
+                </div>
+              </div>
+
+              <div
+                id="game-error"
+                class="hidden absolute inset-0 items-center justify-center bg-black/70 rounded-lg"
+              >
+                <div class="text-center">
+                  <div id="game-error-title" class="text-red-400 text-xl mb-2">
+                  </div>
+                  <div id="game-error-message" class="text-gray-400 text-sm">
+                  </div>
+                </div>
+              </div>
+            </div>
+
+            <div class="flex space-x-3">
+              <Button id="start-btn" variant="primary">Start Game</Button>
+              <Button id="stop-btn" variant="outline" style="display: none;"
+                >End Game</Button
+              >
+            </div>
+
+            <GameOverlay defaultTitle="CIRCUIT POWERED!" buttonText="Play Again">
+              <div class="text-lg text-gray-300">
+                Time Left: <span id="final-time" class="text-cyan-400">0s</span>
+              </div>
+              <div class="text-lg text-gray-300">
+                Rotations: <span id="final-rotations" class="text-purple-400"
+                  >0</span
+                >
+              </div>
+            </GameOverlay>
+          </div>
+        </Card>
+
+        <div class="flex flex-col space-y-6">
+          <Card variant="glass" class="p-6">
+            <h3 class="text-lg font-orbitron font-bold text-cyan-400 mb-4">
+              HOW TO PLAY
+            </h3>
+            <ul class="space-y-2 text-sm text-gray-400">
+              <li>• Tap/click a tile to rotate it 90° clockwise</li>
+              <li>• Connect the source node to every core</li>
+              <li>• Powered wires glow cyan</li>
+              <li>• Solve before the timer runs out</li>
+              <li>• Fewer rotations and more time left = higher score</li>
+            </ul>
+          </Card>
+
+          <Card variant="glass" class="p-6">
+            <h3 class="text-lg font-orbitron font-bold text-cyan-400 mb-4">
+              SCORING
+            </h3>
+            <div class="space-y-2 text-sm text-gray-300">
+              <div class="flex justify-between">
+                <span class="text-gray-400">Base:</span><span>1000</span>
+              </div>
+              <div class="flex justify-between">
+                <span class="text-gray-400">Time bonus:</span
+                ><span>×15 / sec left</span>
+              </div>
+              <div class="flex justify-between">
+                <span class="text-gray-400">Harder tier:</span
+                ><span>bigger multiplier</span>
+              </div>
+            </div>
+          </Card>
+        </div>
+      </div>
+    </div>
+
+    <script>
+      import { initializeCircuitHackerGame } from '@/lib/games/circuit-hacker/init'
+      import type { Difficulty } from '@/lib/games/circuit-hacker/types'
+
+      let gameHandle: Awaited<
+        ReturnType<typeof initializeCircuitHackerGame>
+      > | null = null
+
+      const init = async () => {
+        const container = document.getElementById('game-canvas-container')!
+        const timeEl = document.getElementById('time-remaining')!
+        const rotationEl = document.getElementById('rotation-count')!
+        const statusEl = document.getElementById('game-status')!
+        const overlay = document.getElementById('game-over-overlay')!
+        const startBtn = document.getElementById('start-btn')!
+        const stopBtn = document.getElementById('stop-btn')!
+        const playAgainBtn = document.getElementById('play-again-btn')!
+        const difficultySelect = document.getElementById(
+          'difficulty-select'
+        ) as HTMLSelectElement
+
+        try {
+          gameHandle = await initializeCircuitHackerGame(container, {
+            onTimeUpdate: (t: number) => {
+              timeEl.textContent = t.toString()
+            },
+            onRotation: (n: number) => {
+              rotationEl.textContent = n.toString()
+            },
+            onStart: () => {
+              statusEl.classList.add('hidden')
+              overlay.classList.add('hidden')
+              startBtn.style.display = 'none'
+              stopBtn.style.display = 'inline-flex'
+            },
+            onEnd: () => {
+              difficultySelect.disabled = false
+            },
+          })
+
+          startBtn.addEventListener('click', async () => {
+            difficultySelect.disabled = true
+            rotationEl.textContent = '0'
+            await gameHandle!.start(difficultySelect.value as Difficulty)
+          })
+
+          stopBtn.addEventListener('click', () => {
+            gameHandle!.stop()
+          })
+
+          playAgainBtn.addEventListener('click', () => {
+            overlay.classList.add('hidden')
+            statusEl.classList.remove('hidden')
+            startBtn.style.display = 'inline-flex'
+            stopBtn.style.display = 'none'
+            difficultySelect.disabled = false
+          })
+        } catch (error) {
+          const errorContainer = document.getElementById('game-error')!
+          const errorTitle = document.getElementById('game-error-title')!
+          const errorMessage = document.getElementById('game-error-message')!
+          statusEl.classList.add('hidden')
+          errorTitle.textContent = 'Failed to Load Game'
+          errorMessage.textContent = String(error)
+          errorContainer.style.display = 'flex'
+        }
+      }
+
+      if (document.readyState === 'loading') {
+        document.addEventListener('DOMContentLoaded', init)
+      } else {
+        init()
+      }
+
+      window.addEventListener('beforeunload', () => {
+        gameHandle?.cleanup()
+      })
+    </script>
+  </div>
+  <AchievementAward />
+</AppLayout>
+```
+
+- [ ] **Step 2: Add a markup assertion** in `src/pages/game-board-markup.test.ts`
+
+Replace the file body with the version below (adds Circuit Hacker alongside the existing checks):
+
+```typescript
+import { readFileSync } from 'node:fs'
+import { resolve } from 'node:path'
+import { describe, expect, it } from 'vitest'
+
+const reflexMarkup = readFileSync(
+    resolve(process.cwd(), 'src/pages/reflex/index.astro'),
+    'utf-8'
+)
+const evaderMarkup = readFileSync(
+    resolve(process.cwd(), 'src/pages/evader/index.astro'),
+    'utf-8'
+)
+const circuitHackerMarkup = readFileSync(
+    resolve(process.cwd(), 'src/pages/circuit-hacker/index.astro'),
+    'utf-8'
+)
+
+describe('Game board page markup', () => {
+    it('keeps Reflex and Evader default boards visible before start', () => {
+        expect(reflexMarkup).toMatch(/id="game-status"[^>]*class="[^"]*hidden/)
+        expect(evaderMarkup).toMatch(/id="game-status"[^>]*class="[^"]*hidden/)
+    })
+
+    it('exposes the Circuit Hacker canvas container and difficulty select', () => {
+        expect(circuitHackerMarkup).toContain('id="game-canvas-container"')
+        expect(circuitHackerMarkup).toContain('id="difficulty-select"')
+    })
+})
+```
+
+- [ ] **Step 3: Run the markup test, verify it passes**
+
+Run: `bun run test:run src/pages/game-board-markup.test.ts`
+Expected: PASS (2 tests).
+
+- [ ] **Step 4: Type-check the page wiring**
+
+Run: `bun run astro check 2>&1 | tail -20`
+Expected: No new errors referencing `src/pages/circuit-hacker/index.astro` or `src/lib/games/circuit-hacker/*`.
+
+- [ ] **Step 5: Commit**
+
+```bash
+git add src/pages/circuit-hacker/index.astro src/pages/game-board-markup.test.ts
+git commit -m "feat(circuit-hacker): add game page"
+```
+
+---
+
+### Task 10: Achievements
+
+**Files:**
+- Modify: `src/lib/games/shared/types.ts` (add `CircuitHackerGameData`, add to `GameData` union ~line 104)
+- Modify: `src/lib/achievements.ts` (import type ~line 3, extend `AchievementCheckData` ~line 23, append achievement entries to `ACHIEVEMENTS`)
+- Test: `src/lib/achievements.test.ts`
+
+**Interfaces:**
+- Consumes: `GameID.CIRCUIT_HACKER` (Task 8); `Achievement`, `AchievementRarity`, `getAchievementsByGame` from `achievements.ts`.
+- Produces: achievements `circuit_hacker_welcome`, `circuit_hacker_hard`, `circuit_hacker_expert`, `circuit_hacker_speed`.
+
+- [ ] **Step 1: Write the failing test** (append to `src/lib/achievements.test.ts`)
+
+```typescript
+import { ACHIEVEMENTS, getAchievementsByGame } from './achievements'
+import { GameID } from './games'
+
+describe('Circuit Hacker achievements', () => {
+    it('registers achievements for circuit hacker', () => {
+        const list = getAchievementsByGame(GameID.CIRCUIT_HACKER)
+        expect(list.map(a => a.id)).toEqual(
+            expect.arrayContaining([
+                'circuit_hacker_welcome',
+                'circuit_hacker_hard',
+                'circuit_hacker_expert',
+                'circuit_hacker_speed',
+            ])
+        )
+    })
+
+    it('awards the hard achievement only for a solved hard run', () => {
+        const hard = ACHIEVEMENTS.find(a => a.id === 'circuit_hacker_hard')!
+        expect(hard.condition.check).toBeDefined()
+        expect(
+            hard.condition.check!(
+                { difficulty: 'hard', secondsRemaining: 5, rotationsUsed: 3, solved: true },
+                1000
+            )
+        ).toBe(true)
+        expect(
+            hard.condition.check!(
+                { difficulty: 'easy', secondsRemaining: 5, rotationsUsed: 3, solved: true },
+                1000
+            )
+        ).toBe(false)
+    })
+})
+```
+
+> If `getAchievementsByGame` is not already imported in this test file, add it to the existing import from `./achievements`.
+
+- [ ] **Step 2: Run the test, verify it fails**
+
+Run: `bun run test:run src/lib/achievements.test.ts`
+Expected: FAIL — the four ids are not found.
+
+- [ ] **Step 3: Add `CircuitHackerGameData`** in `src/lib/games/shared/types.ts` (after the `SnakeGameData` interface, then add to the `GameData` union)
+
+```typescript
+// Snake-specific game data
+export interface SnakeGameData {
+    applesEaten: number
+    maxLength: number
+}
+
+// Circuit Hacker-specific game data
+export interface CircuitHackerGameData {
+    difficulty: 'easy' | 'medium' | 'hard' | 'expert'
+    secondsRemaining: number
+    rotationsUsed: number
+    solved: boolean
+}
+```
+
+Then extend the union:
+
+```typescript
+export type GameData =
+    | TetrisGameData
+    | BubbleShooterGameData
+    | BejeweledGameData
+    | MemoryMatrixGameData
+    | WordScrambleGameData
+    | ReflexGameData
+    | QuickMathGameData
+    | SudokuGameData
+    | PathNavigatorGameData
+    | EvaderGameData
+    | Game2048Data
+    | SnakeGameData
+    | CircuitHackerGameData
+```
+
+- [ ] **Step 4: Wire the type into `achievements.ts`**
+
+Add to the type import block (near line 3-12):
+
+```typescript
+import type {
+    TetrisGameData,
+    BejeweledGameData,
+    ReflexGameData,
+    QuickMathGameData,
+    Game2048Data,
+    SnakeGameData,
+    WordScrambleGameData,
+    CircuitHackerGameData,
+    GameHistoryEntry,
+} from './games/shared/types'
+```
+
+Extend `AchievementCheckData` (near line 23):
+
+```typescript
+export type AchievementCheckData =
+    | TetrisGameData
+    | BejeweledGameData
+    | ReflexGameData
+    | QuickMathGameData
+    | Game2048Data
+    | SnakeGameData
+    | WordScrambleGameData
+    | CircuitHackerGameData
+    | Record<string, unknown>
+```
+
+- [ ] **Step 5: Append the achievement entries** to the `ACHIEVEMENTS` array in `src/lib/achievements.ts` (before the closing `]`)
+
+```typescript
+    {
+        id: 'circuit_hacker_welcome',
+        name: 'First Connection',
+        description: 'Welcome to Circuit Hacker! You powered your first circuit.',
+        logo: '🔌',
+        gameId: GameID.CIRCUIT_HACKER,
+        condition: {
+            type: 'score_threshold',
+            threshold: 1,
+        },
+        rarity: AchievementRarity.COMMON,
+    },
+    {
+        id: 'circuit_hacker_hard',
+        name: 'Hard Wired',
+        description: 'Solve a Circuit Hacker puzzle on Hard difficulty.',
+        logo: '⚡',
+        gameId: GameID.CIRCUIT_HACKER,
+        condition: {
+            type: 'in_game',
+            check: gameData => {
+                const data = gameData as CircuitHackerGameData
+                return data.difficulty === 'hard' && data.solved === true
+            },
+        },
+        rarity: AchievementRarity.EPIC,
+    },
+    {
+        id: 'circuit_hacker_expert',
+        name: 'Master Hacker',
+        description: 'Solve a Circuit Hacker puzzle on Expert difficulty.',
+        logo: '🧠',
+        gameId: GameID.CIRCUIT_HACKER,
+        condition: {
+            type: 'in_game',
+            check: gameData => {
+                const data = gameData as CircuitHackerGameData
+                return data.difficulty === 'expert' && data.solved === true
+            },
+        },
+        rarity: AchievementRarity.LEGENDARY,
+    },
+    {
+        id: 'circuit_hacker_speed',
+        name: 'Quick Hack',
+        description:
+            'Solve a Circuit Hacker puzzle with at least 60 seconds left.',
+        logo: '⏱️',
+        gameId: GameID.CIRCUIT_HACKER,
+        condition: {
+            type: 'in_game',
+            check: gameData => {
+                const data = gameData as CircuitHackerGameData
+                return data.solved === true && data.secondsRemaining >= 60
+            },
+        },
+        rarity: AchievementRarity.RARE,
+    },
+]
+```
+
+- [ ] **Step 6: Run the test, verify it passes**
+
+Run: `bun run test:run src/lib/achievements.test.ts`
+Expected: PASS (including the 2 new tests).
+
+- [ ] **Step 7: Commit**
+
+```bash
+git add src/lib/games/shared/types.ts src/lib/achievements.ts src/lib/achievements.test.ts
+git commit -m "feat(circuit-hacker): add achievements"
+```
+
+---
+
+### Task 11: Full verification
+
+**Files:** none (verification only).
+
+- [ ] **Step 1: Run the full circuit-hacker test suite**
+
+Run: `bun run test:run src/lib/games/circuit-hacker/`
+Expected: PASS (all files: utils, generator, game, renderer, init).
+
+- [ ] **Step 2: Run the full test suite**
+
+Run: `bun run test:run`
+Expected: PASS, no regressions in `games.test.ts`, `achievements.test.ts`, `game-board-markup.test.ts`.
+
+- [ ] **Step 3: Lint & format**
+
+Run: `bun run lint && bun run format:check`
+Expected: No errors. If `format:check` fails, run `bun run format` and re-commit.
+
+- [ ] **Step 4: Type-check**
+
+Run: `bun run astro check 2>&1 | tail -20`
+Expected: No new errors in circuit-hacker files.
+
+- [ ] **Step 5: Manual smoke test (optional but recommended)**
+
+Run: `bun run dev`, open `http://localhost:4325/`, confirm the Circuit Hacker card appears with the 🔌 icon and Play Now link, then play a full Easy puzzle: rotate tiles, watch wires glow, solve it, and confirm the win overlay shows score/time/rotations.
+
+- [ ] **Step 6: Commit any formatting fixes**
+
+```bash
+git add -A
+git commit -m "chore(circuit-hacker): lint and format fixes" || echo "nothing to commit"
+```
+
+---
+
+## Self-Review
+
+**1. Spec coverage** — every spec section maps to a task:
+- Gameplay/flow → Tasks 5, 7, 9
+- Difficulty tiers → Task 3 (`DIFFICULTY_CONFIGS`) + Task 9 (selector)
+- Circuit model (connectors, power, win) → Tasks 1, 2
+- Puzzle generation (solvable by construction) → Task 4
+- Scoring (formula + multiplier + gameData) → Tasks 3, 5, 7
+- Architecture/file structure → Tasks 1–7 (matches spec's file list)
+- Registry/integration → Task 8
+- Data flow / errors → Tasks 5, 7, 9 (generation always solvable; `saveGameScore` 401/error handled; taps on locked/blocker/out-of-bounds ignored)
+- Testing strategy → every task is TDD; Task 11 runs the full suite
+- Acceptance criteria → home page (Task 8), start/solve/fail/restart (Tasks 5,7,9), score submission (Task 7,10), desktop+mobile via pointer events (Task 7)
+
+**2. Placeholder scan** — no "TBD/TODO/handle edge cases"; every code step contains complete code.
+
+**3. Type consistency** — names verified across tasks: `CircuitHackerGame`, `CircuitHackerState`, `CircuitHackerStats`, `CircuitHackerConfig`, `CircuitHackerCallbacks`, `CircuitHackerGameData`; utils exports (`getConnectors`, `cellsConnect`, `computePoweredCells`, `isSolved`, `DIFFICULTY_CONFIGS`, `countRotatableTiles`, `computeFinalScore`); generator `generatePuzzle`/`GeneratedPuzzle`/`solutionOrientations`; renderer `setupPixiJS`/`renderGrid`/`pointerToCell`/`cleanup`/`RendererState`; init `initializeCircuitHackerGame`/`CircuitHackerHandle`/`CircuitHackerUICallbacks`/`CELL_SIZE`. `solveForTest` is defined in Task 5 and used in Tasks 5 & 7. DOM ids in `init.ts` (`final-score`, `final-time`, `final-rotations`, `game-over-title`, `game-over-overlay`, `start-btn`, `stop-btn`) match the page (Task 9) and the init test (Task 7).

--- a/docs/superpowers/specs/2026-06-19-circuit-hacker-design.md
+++ b/docs/superpowers/specs/2026-06-19-circuit-hacker-design.md
@@ -78,7 +78,15 @@ The generator guarantees solvability by construction (no separate solver):
 
 Because a valid solution exists by construction, the puzzle is always solvable.
 Generation retries with a capped attempt count if a step fails (e.g. cannot
-route all cores); on exhausting attempts it falls back to a simpler layout.
+route all cores). A randomized DFS builds winding paths for puzzle variety,
+with a guaranteed-complete BFS fallback so the search never fails spuriously.
+
+On exhausting all attempts the generator throws an `Error` rather than emitting
+a degenerate "simpler layout": the throw is caught by the page's `start()`
+handler, which surfaces a user-friendly error overlay and resets the start
+button. With the BFS fallback in place, exhaustion is astronomically unlikely
+for the shipped difficulty configs (validated by a 20,000-generation
+solvability sweep in the test suite).
 
 Rejected alternative: random fill + a solver to verify solvability. More code
 and can loop on unsolvable boards.
@@ -167,8 +175,11 @@ Astro page; TypeScript only manipulates dynamic content and the canvas.
 
 ## Error Handling
 
-- Puzzle generation retries with a capped attempt count; falls back to a simpler
-  layout if it cannot route all cores.
+- Puzzle generation retries with a capped attempt count; on exhaustion it
+  throws an `Error` (caught by the page's `start()` handler, which shows a
+  user-friendly error overlay and resets the start button) rather than emitting
+  a degenerate layout. A BFS fallback makes exhaustion astronomically unlikely
+  for shipped configs.
 - `saveGameScore` failures and the unauthenticated (401) case are handled
   non-blockingly, matching existing games — the game remains playable and the
   user is informed without an exception.

--- a/docs/superpowers/specs/2026-06-19-circuit-hacker-design.md
+++ b/docs/superpowers/specs/2026-06-19-circuit-hacker-design.md
@@ -1,0 +1,205 @@
+# Circuit Hacker — Design Spec
+
+- **Linear issue:** [HPA-69 — Minigame: Circuit Hacker](https://linear.app/cwchanap/issue/HPA-69/minigame-circuit-hacker)
+- **Date:** 2026-06-19
+- **Status:** Approved design, ready for implementation planning
+
+## Overview
+
+Circuit Hacker is a sci-fi tile-rotation puzzle, the 13th game on the Cetus
+platform. The player rotates circuit tiles to form a powered path from a fixed
+**source** node to one or more **core** nodes before a countdown timer expires.
+It is a single-puzzle-per-run game with four difficulty tiers chosen up front,
+rendered on a PixiJS canvas, and integrated into the existing leaderboard,
+achievement, and home-page systems.
+
+## Gameplay & Flow
+
+1. Player picks a difficulty (Easy / Medium / Hard / Expert).
+2. Player presses **Start** → a solvable, scrambled puzzle is generated and the
+   countdown timer begins.
+3. Player taps/clicks a tile → it rotates 90° clockwise → connectivity is
+   recomputed → powered segments glow.
+4. **Win:** all cores are powered → timer stops, final score is computed and
+   submitted (when logged in). Win overlay shows stats.
+5. **Fail:** timer reaches 0 before all cores are powered → fail overlay. No
+   score is submitted.
+6. **Restart / New Puzzle:** regenerates a fresh puzzle at the same difficulty.
+
+Locked tiles (source and core) are not rotatable. Taps on blockers or locked
+tiles are ignored.
+
+## Difficulty Tiers
+
+Starting values; tunable during implementation.
+
+| Tier   | Grid  | Cores | Blockers | Timer | Score Multiplier |
+|--------|-------|-------|----------|-------|------------------|
+| Easy   | 5×5   | 1     | 0        | 120s  | ×1               |
+| Medium | 7×7   | 1     | ~3       | 180s  | ×2               |
+| Hard   | 9×9   | 2     | ~6       | 240s  | ×3.5             |
+| Expert | 11×11 | 3     | ~10      | 300s  | ×5               |
+
+All four tiers share a single per-game leaderboard ranked by final score, so the
+multiplier lets harder tiers top the board.
+
+## Circuit Model
+
+- A tile has connectors on a subset of `{N, E, S, W}`.
+- Tile types:
+  - **straight** — 2 opposite connectors
+  - **elbow** — 2 adjacent connectors
+  - **T-junction** — 3 connectors
+  - **cross** — 4 connectors
+  - **source** — locked start node
+  - **core** — locked endpoint node
+- **Blockers** are empty cells with no tile.
+- Rotating a tile rotates its connector set 90° clockwise.
+- Two adjacent tiles **connect** only if both have connectors facing each other
+  (e.g. tile A has an E connector and the tile to its east has a W connector).
+- **Powered** = the set of cells reachable from the source via mutually-facing
+  connectors, computed by BFS/flood-fill from the source. Recomputed every time
+  a tile rotates.
+- **Win condition:** every core cell is in the powered set. Loose or dangling
+  tiles elsewhere on the board are allowed (path-to-core, not full-network).
+
+## Puzzle Generation
+
+The generator guarantees solvability by construction (no separate solver):
+
+1. Place the source and core(s) on the grid.
+2. Carve a guaranteed connecting path from the source to each core (e.g. random
+   walk / routing on the grid), assigning each path cell a tile type whose
+   connectors fit the path.
+3. Fill remaining non-path cells with random valid tiles.
+4. Drop blockers onto a selection of non-path cells (count per difficulty),
+   never on the source, cores, or required path cells.
+5. **Scramble**: randomly rotate every rotatable tile to a random orientation.
+
+Because a valid solution exists by construction, the puzzle is always solvable.
+Generation retries with a capped attempt count if a step fails (e.g. cannot
+route all cores); on exhausting attempts it falls back to a simpler layout.
+
+Rejected alternative: random fill + a solver to verify solvability. More code
+and can loop on unsolvable boards.
+
+## Scoring
+
+```
+finalScore = round( (base + timeBonus + rotationBonus) × tierMultiplier )
+```
+
+- `base = 1000`
+- `timeBonus = secondsRemaining × 15`
+- `rotationBonus = max(0, rotationBudget − rotationsUsed) × 25`
+  - `rotationBudget = rotatableTileCount × 2`
+- `tierMultiplier` per the difficulty table above.
+
+`gameData` submitted with the score carries
+`{ difficulty, secondsRemaining, rotationsUsed }` for history and future stats.
+The leaderboard ranks on `finalScore` only. Failed runs submit no score (the
+score service already skips submissions where `score <= 0`).
+
+## Architecture & File Structure
+
+Uses the core game framework (`BaseGame`, `BaseRenderer` + `RendererFactory`
+PixiJS path), consistent with Evader and Bejeweled.
+
+```
+src/lib/games/circuit-hacker/
+  types.ts       # tile types, connector directions, CircuitHackerState/Config/Stats, Difficulty enum
+  game.ts        # CircuitHackerGame extends BaseGame: rotateTile, flood-fill power, win check, scoring
+  generator.ts   # solvable puzzle generation + scramble
+  renderer.ts    # CircuitHackerRenderer extends BaseRenderer (PixiJS): draw grid/tiles, power glow, pointer→cell hit-testing
+  utils.ts       # connector rotation, opposite/adjacency helpers, scoring helpers
+  init.ts        # wire game + renderer + GameTimer, difficulty selection, score submission, button/overlay state
+  types.test.ts / game.test.ts / generator.test.ts / utils.test.ts / renderer.test.ts / init.test.ts
+src/pages/circuit-hacker/index.astro   # all HTML structure: difficulty selector, score/time/rotation badges, canvas container, GameOverlay, controls, how-to-play
+```
+
+Per the project's Astro–TypeScript pattern, all HTML structure lives in the
+Astro page; TypeScript only manipulates dynamic content and the canvas.
+
+### Component Responsibilities
+
+- **types.ts** — shared type definitions; no logic.
+- **generator.ts** — pure puzzle construction; given a difficulty config, returns
+  a solvable scrambled grid plus the known solution metadata used by tests.
+- **utils.ts** — pure connector math (rotate connector set, opposite direction,
+  do-two-cells-connect) and scoring helpers. Independently unit-testable.
+- **game.ts** — owns game state and rules: applying a rotation, recomputing the
+  powered set, detecting a win, tracking rotation count, computing final score.
+  Depends on utils and generator.
+- **renderer.ts** — pure presentation: draws the grid, tiles, and power glow, and
+  maps a pointer event to a grid cell. No game rules.
+- **init.ts** — wiring layer: difficulty selection, timer, event handlers,
+  overlay/button state, and score submission.
+
+## Integration Points
+
+- `src/lib/games.ts`:
+  - Add `CIRCUIT_HACKER = 'circuit_hacker'` to the `GameID` enum.
+  - Add a `GAMES` entry: category `puzzle`, difficulty `medium`,
+    `estimatedDuration: '2-5 minutes'`, appropriate tags, `isActive: true`.
+  - Add a `GAME_ICONS` entry (proposed 🔌).
+- `src/components/ui/GameCard.astro`: add
+  `case 'Circuit Hacker': return '/circuit-hacker'` to `getGameUrl`.
+- `src/pages/index.astro`: add an `idMapping` entry; optional
+  `difficultyLabels` / `durationLabels` entries.
+- `src/lib/server/validations.ts` and `scoreService.formatGameName` auto-derive
+  from `GameID` — no changes required.
+- `src/lib/achievements.ts`: add a small set of achievements — e.g. first solve,
+  solve on Hard, solve on Expert, and a fast-solve bonus.
+
+## Data Flow
+
+1. Page load → `init.ts` reads the selected difficulty.
+2. On **Start** → `generator` builds a solvable scrambled puzzle → game state
+   initialized → renderer draws → `GameTimer` starts counting down.
+3. Tap/click → renderer hit-tests pointer → cell → `game.rotateTile(row, col)` →
+   game recomputes the powered set via flood-fill → renderer updates power glow →
+   game checks win.
+4. **Win** → timer stops → `game` computes `finalScore` →
+   `saveGameScore(gameId, finalScore, onSuccess, onError, gameData)` →
+   win overlay with stats; achievement/challenge notifications via existing hooks.
+5. **Timer expiry** → timer stops → fail overlay; no score submitted.
+6. **Restart / New Puzzle** → regenerate at the same difficulty, reset counters.
+
+## Error Handling
+
+- Puzzle generation retries with a capped attempt count; falls back to a simpler
+  layout if it cannot route all cores.
+- `saveGameScore` failures and the unauthenticated (401) case are handled
+  non-blockingly, matching existing games — the game remains playable and the
+  user is informed without an exception.
+- Taps on blockers or locked (source/core) tiles are ignored.
+- Pointer-to-cell math is clamped to grid bounds; out-of-bounds taps are no-ops.
+
+## Testing Strategy
+
+- **generator.test.ts** — every generated puzzle is solvable (the known solution
+  connects source → all cores); grid dimensions, core count, and blocker count
+  match the tier; scramble actually changes orientations.
+- **utils.test.ts** — connector rotation, opposite direction, and the
+  do-two-adjacent-cells-connect predicate; scoring helpers.
+- **game.test.ts** — `rotateTile` updates orientation and increments the rotation
+  count; flood-fill marks the correct powered cells; win detected when all cores
+  are powered; final-score formula including tier multiplier; locked tiles do not
+  rotate.
+- **renderer.test.ts** — pointer→cell mapping; expected draw calls with PixiJS
+  mocked (following existing renderer test patterns).
+- **init.test.ts** — start/restart wiring; timer expiry → fail overlay and no
+  submission; solve → `saveGameScore` called with the correct args and
+  `gameData`; difficulty selection applies the right config.
+
+## Acceptance Criteria (from HPA-69)
+
+How this design satisfies each criterion:
+
+- **Appears on the home page** with icon, duration, difficulty, and Play Now link
+  → registry (`games.ts`) + `GameCard` route + `index.astro` wiring.
+- **Start / solve / fail / restart** a puzzle → gameplay flow + `init.ts`.
+- **Final score submitted** to the existing leaderboard/progress flow when logged
+  in → `saveGameScore` + achievements integration.
+- **Works on desktop and mobile controls** → tap/click rotation handled
+  identically via PixiJS pointer events.

--- a/package.json
+++ b/package.json
@@ -53,6 +53,7 @@
     "zod": "^4.2.1"
   },
   "devDependencies": {
+    "@astrojs/check": "^0.9.9",
     "@eslint/js": "^9.30.1",
     "@playwright/test": "^1.54.1",
     "@testing-library/dom": "^10.4.0",
@@ -70,6 +71,7 @@
     "prettier-plugin-astro": "^0.14.1",
     "turbo": "^2.1.3",
     "tw-animate-css": "^1.3.4",
+    "typescript": "^6.0.3",
     "typescript-eslint": "^8.35.1",
     "vitest": "^3.2.4"
   },

--- a/src/components/ui/GameCard.astro
+++ b/src/components/ui/GameCard.astro
@@ -63,6 +63,8 @@ const getGameUrl = (title: string) => {
       return '/evader'
     case 'Snake':
       return '/snake'
+    case 'Circuit Hacker':
+      return '/circuit-hacker'
     default:
       return '#'
   }

--- a/src/lib/achievements.test.ts
+++ b/src/lib/achievements.test.ts
@@ -696,4 +696,80 @@ describe('Circuit Hacker achievements', () => {
             )
         ).toBe(false)
     })
+
+    it('awards the expert achievement only for a solved expert run', () => {
+        const expert = ACHIEVEMENTS.find(a => a.id === 'circuit_hacker_expert')!
+        expect(expert.condition.check).toBeDefined()
+        expect(
+            expert.condition.check!(
+                {
+                    difficulty: 'expert',
+                    secondsRemaining: 5,
+                    rotationsUsed: 3,
+                    solved: true,
+                },
+                1000
+            )
+        ).toBe(true)
+        expect(
+            expert.condition.check!(
+                {
+                    difficulty: 'hard',
+                    secondsRemaining: 5,
+                    rotationsUsed: 3,
+                    solved: true,
+                },
+                1000
+            )
+        ).toBe(false)
+        expect(
+            expert.condition.check!(
+                {
+                    difficulty: 'expert',
+                    secondsRemaining: 5,
+                    rotationsUsed: 3,
+                    solved: false,
+                },
+                1000
+            )
+        ).toBe(false)
+    })
+
+    it('awards the speed achievement only when solved with at least 60 seconds left', () => {
+        const speed = ACHIEVEMENTS.find(a => a.id === 'circuit_hacker_speed')!
+        expect(speed.condition.check).toBeDefined()
+        expect(
+            speed.condition.check!(
+                {
+                    difficulty: 'easy',
+                    secondsRemaining: 60,
+                    rotationsUsed: 3,
+                    solved: true,
+                },
+                1000
+            )
+        ).toBe(true)
+        expect(
+            speed.condition.check!(
+                {
+                    difficulty: 'easy',
+                    secondsRemaining: 59,
+                    rotationsUsed: 3,
+                    solved: true,
+                },
+                1000
+            )
+        ).toBe(false)
+        expect(
+            speed.condition.check!(
+                {
+                    difficulty: 'easy',
+                    secondsRemaining: 120,
+                    rotationsUsed: 3,
+                    solved: false,
+                },
+                1000
+            )
+        ).toBe(false)
+    })
 })

--- a/src/lib/achievements.test.ts
+++ b/src/lib/achievements.test.ts
@@ -656,3 +656,44 @@ describe('Achievement in_game condition checks', () => {
         })
     })
 })
+
+describe('Circuit Hacker achievements', () => {
+    it('registers achievements for circuit hacker', () => {
+        const list = getAchievementsByGame(GameID.CIRCUIT_HACKER)
+        expect(list.map(a => a.id)).toEqual(
+            expect.arrayContaining([
+                'circuit_hacker_welcome',
+                'circuit_hacker_hard',
+                'circuit_hacker_expert',
+                'circuit_hacker_speed',
+            ])
+        )
+    })
+
+    it('awards the hard achievement only for a solved hard run', () => {
+        const hard = ACHIEVEMENTS.find(a => a.id === 'circuit_hacker_hard')!
+        expect(hard.condition.check).toBeDefined()
+        expect(
+            hard.condition.check!(
+                {
+                    difficulty: 'hard',
+                    secondsRemaining: 5,
+                    rotationsUsed: 3,
+                    solved: true,
+                },
+                1000
+            )
+        ).toBe(true)
+        expect(
+            hard.condition.check!(
+                {
+                    difficulty: 'easy',
+                    secondsRemaining: 5,
+                    rotationsUsed: 3,
+                    solved: true,
+                },
+                1000
+            )
+        ).toBe(false)
+    })
+})

--- a/src/lib/achievements.ts
+++ b/src/lib/achievements.ts
@@ -8,6 +8,7 @@ import type {
     Game2048Data,
     SnakeGameData,
     WordScrambleGameData,
+    CircuitHackerGameData,
     GameHistoryEntry,
 } from './games/shared/types'
 
@@ -28,6 +29,7 @@ export type AchievementCheckData =
     | Game2048Data
     | SnakeGameData
     | WordScrambleGameData
+    | CircuitHackerGameData
     | Record<string, unknown>
 
 export interface Achievement {
@@ -1221,6 +1223,67 @@ export const ACHIEVEMENTS: Achievement[] = [
             check: (gameData: { maxTile: number }) => gameData.maxTile >= 4096,
         },
         rarity: AchievementRarity.LEGENDARY,
+    },
+
+    // Circuit Hacker achievements
+    {
+        id: 'circuit_hacker_welcome',
+        name: 'First Connection',
+        description:
+            'Welcome to Circuit Hacker! You powered your first circuit.',
+        logo: '🔌',
+        gameId: GameID.CIRCUIT_HACKER,
+        condition: {
+            type: 'score_threshold',
+            threshold: 1,
+        },
+        rarity: AchievementRarity.COMMON,
+    },
+    {
+        id: 'circuit_hacker_hard',
+        name: 'Hard Wired',
+        description: 'Solve a Circuit Hacker puzzle on Hard difficulty.',
+        logo: '⚡',
+        gameId: GameID.CIRCUIT_HACKER,
+        condition: {
+            type: 'in_game',
+            check: gameData => {
+                const data = gameData as CircuitHackerGameData
+                return data.difficulty === 'hard' && data.solved === true
+            },
+        },
+        rarity: AchievementRarity.EPIC,
+    },
+    {
+        id: 'circuit_hacker_expert',
+        name: 'Master Hacker',
+        description: 'Solve a Circuit Hacker puzzle on Expert difficulty.',
+        logo: '🧠',
+        gameId: GameID.CIRCUIT_HACKER,
+        condition: {
+            type: 'in_game',
+            check: gameData => {
+                const data = gameData as CircuitHackerGameData
+                return data.difficulty === 'expert' && data.solved === true
+            },
+        },
+        rarity: AchievementRarity.LEGENDARY,
+    },
+    {
+        id: 'circuit_hacker_speed',
+        name: 'Quick Hack',
+        description:
+            'Solve a Circuit Hacker puzzle with at least 60 seconds left.',
+        logo: '⏱️',
+        gameId: GameID.CIRCUIT_HACKER,
+        condition: {
+            type: 'in_game',
+            check: gameData => {
+                const data = gameData as CircuitHackerGameData
+                return data.solved === true && data.secondsRemaining >= 60
+            },
+        },
+        rarity: AchievementRarity.RARE,
     },
 ]
 

--- a/src/lib/games.test.ts
+++ b/src/lib/games.test.ts
@@ -186,3 +186,24 @@ describe('Games System', () => {
         })
     })
 })
+
+describe('Circuit Hacker registration', () => {
+    it('has a GameID and registry entry', () => {
+        expect(GameID.CIRCUIT_HACKER).toBe('circuit_hacker')
+        const game = getGameById(GameID.CIRCUIT_HACKER)
+        expect(game).toBeDefined()
+        expect(game?.name).toBe('Circuit Hacker')
+        expect(game?.category).toBe('puzzle')
+        expect(game?.isActive).toBe(true)
+    })
+
+    it('has an icon', () => {
+        expect(getGameIcon(GameID.CIRCUIT_HACKER)).toBe('🔌')
+    })
+
+    it('is included in the GAMES list exactly once', () => {
+        expect(GAMES.filter(g => g.id === GameID.CIRCUIT_HACKER)).toHaveLength(
+            1
+        )
+    })
+})

--- a/src/lib/games.ts
+++ b/src/lib/games.ts
@@ -172,6 +172,18 @@ export const GAMES: Game[] = [
         tags: ['puzzle', 'numbers', 'strategy', 'single-player', 'classic'],
         isActive: true,
     },
+    {
+        id: GameID.CIRCUIT_HACKER,
+        name: 'Circuit Hacker',
+        description:
+            'Rotate circuit tiles to power a path from the source to the core before time runs out',
+        category: 'puzzle',
+        maxPlayers: 1,
+        estimatedDuration: '2-5 minutes',
+        difficulty: 'medium',
+        tags: ['puzzle', 'logic', 'circuit', 'single-player', 'rotation'],
+        isActive: true,
+    },
 ]
 
 // Helper functions

--- a/src/lib/games.ts
+++ b/src/lib/games.ts
@@ -232,7 +232,7 @@ const GAME_ICONS: Record<GameID, string> = {
     [GameID.EVADER]: '🏃',
     [GameID.SNAKE]: '🐍',
     [GameID.GAME_2048]: '🎯',
-    [GameID.CIRCUIT_HACKER]: '⚡',
+    [GameID.CIRCUIT_HACKER]: '🔌',
 }
 
 // Game icon helper function

--- a/src/lib/games.ts
+++ b/src/lib/games.ts
@@ -12,6 +12,7 @@ export enum GameID {
     EVADER = 'evader',
     SNAKE = 'snake',
     GAME_2048 = '2048',
+    CIRCUIT_HACKER = 'circuit_hacker',
 }
 
 // Game system types
@@ -231,6 +232,7 @@ const GAME_ICONS: Record<GameID, string> = {
     [GameID.EVADER]: '🏃',
     [GameID.SNAKE]: '🐍',
     [GameID.GAME_2048]: '🎯',
+    [GameID.CIRCUIT_HACKER]: '⚡',
 }
 
 // Game icon helper function

--- a/src/lib/games/circuit-hacker/game.test.ts
+++ b/src/lib/games/circuit-hacker/game.test.ts
@@ -2,14 +2,7 @@
 import { describe, it, expect, vi, beforeEach, afterEach } from 'vitest'
 import { CircuitHackerGame } from './game'
 import type { CircuitHackerCallbacks, CircuitHackerConfig } from './types'
-
-function seededRng(seed: number): () => number {
-    let s = seed >>> 0
-    return () => {
-        s = (s * 1664525 + 1013904223) >>> 0
-        return s / 0xffffffff
-    }
-}
+import { seededRng } from './test-utils'
 
 const config: CircuitHackerConfig = { difficulty: 'easy', cellSize: 48 }
 

--- a/src/lib/games/circuit-hacker/game.test.ts
+++ b/src/lib/games/circuit-hacker/game.test.ts
@@ -2,7 +2,11 @@
 import { describe, it, expect, vi, beforeEach, afterEach } from 'vitest'
 import { CircuitHackerGame } from './game'
 import type { CircuitHackerCallbacks, CircuitHackerConfig } from './types'
-import { seededRng } from './test-utils'
+import {
+    seededRng,
+    solveGameForTest,
+    getSolutionOrientationsForTest,
+} from './test-utils'
 
 const config: CircuitHackerConfig = { difficulty: 'easy', cellSize: 48 }
 
@@ -74,13 +78,74 @@ describe('CircuitHackerGame', () => {
         const cb = makeCallbacks()
         const game = new CircuitHackerGame(config, cb, seededRng(1))
         game.startGame()
-        game.solveForTest() // test helper applies solution orientations
+        solveGameForTest(game) // test helper applies solution orientations
         expect(cb.onSolved).toHaveBeenCalledTimes(1)
         const [score, stats] = (cb.onSolved as ReturnType<typeof vi.fn>).mock
             .calls[0]
         expect(score).toBeGreaterThan(0)
         expect(stats.solved).toBe(true)
         expect(game.getState().isGameActive).toBe(false)
+        game.cleanup()
+    })
+
+    it('solves via the real rotateTile() path (C1)', () => {
+        const cb = makeCallbacks()
+        const game = new CircuitHackerGame(config, cb, seededRng(1))
+        game.startGame()
+        const solution = getSolutionOrientationsForTest(game)
+        expect(solution).not.toBeNull()
+        const state = game.getState()
+        // Drive the production win path: rotate each tile until it matches
+        // the recorded solution orientation. Exercises rotateTile -> applyPower
+        // -> allCoresPowered -> solve, the same path a player takes.
+        for (let r = 0; r < state.rows; r++) {
+            for (let c = 0; c < state.cols; c++) {
+                const tile = state.grid[r][c]
+                if (tile.locked) {
+                    continue
+                }
+                const target = solution![r][c]
+                while (tile.orientation !== target) {
+                    game.rotateTile(r, c)
+                }
+            }
+        }
+        expect(cb.onSolved).toHaveBeenCalledTimes(1)
+        const [score, stats] = (cb.onSolved as ReturnType<typeof vi.fn>).mock
+            .calls[0]
+        expect(score).toBeGreaterThan(0)
+        expect(stats.solved).toBe(true)
+        expect(game.getState().solved).toBe(true)
+        expect(game.getState().isGameActive).toBe(false)
+        game.cleanup()
+    })
+
+    it('does not solve on a partial board (C2, hard 2-core)', () => {
+        const hardConfig: CircuitHackerConfig = {
+            difficulty: 'hard',
+            cellSize: 48,
+        }
+        const cb = makeCallbacks()
+        const game = new CircuitHackerGame(hardConfig, cb, seededRng(7))
+        game.startGame()
+        const state = game.getState()
+        expect(state.corePositions.length).toBe(2)
+        // Rotate exactly one rotatable tile once. A single rotation cannot
+        // complete a 2-core hard board, so the game must remain unsolved
+        // and active.
+        let rotated = false
+        for (let r = 0; r < state.rows && !rotated; r++) {
+            for (let c = 0; c < state.cols && !rotated; c++) {
+                if (!state.grid[r][c].locked) {
+                    game.rotateTile(r, c)
+                    rotated = true
+                }
+            }
+        }
+        expect(rotated).toBe(true)
+        expect(cb.onSolved).not.toHaveBeenCalled()
+        expect(game.getState().solved).toBe(false)
+        expect(game.getState().isGameActive).toBe(true)
         game.cleanup()
     })
 

--- a/src/lib/games/circuit-hacker/game.test.ts
+++ b/src/lib/games/circuit-hacker/game.test.ts
@@ -1,0 +1,103 @@
+// src/lib/games/circuit-hacker/game.test.ts
+import { describe, it, expect, vi, beforeEach, afterEach } from 'vitest'
+import { CircuitHackerGame } from './game'
+import type { CircuitHackerCallbacks, CircuitHackerConfig } from './types'
+
+function seededRng(seed: number): () => number {
+    let s = seed >>> 0
+    return () => {
+        s = (s * 1664525 + 1013904223) >>> 0
+        return s / 0xffffffff
+    }
+}
+
+const config: CircuitHackerConfig = { difficulty: 'easy', cellSize: 48 }
+
+function makeCallbacks(): CircuitHackerCallbacks {
+    return {
+        onTimeUpdate: vi.fn(),
+        onRotation: vi.fn(),
+        onSolved: vi.fn(),
+        onFail: vi.fn(),
+        onGameStart: vi.fn(),
+    }
+}
+
+describe('CircuitHackerGame', () => {
+    beforeEach(() => vi.useFakeTimers())
+    afterEach(() => vi.useRealTimers())
+
+    it('starts a game and builds a grid', () => {
+        const cb = makeCallbacks()
+        const game = new CircuitHackerGame(config, cb, seededRng(1))
+        game.startGame()
+        const state = game.getState()
+        expect(state.isGameActive).toBe(true)
+        expect(state.grid).toHaveLength(5)
+        expect(cb.onGameStart).toHaveBeenCalled()
+        game.cleanup()
+    })
+
+    it('rotates an unlocked tile and counts the rotation', () => {
+        const cb = makeCallbacks()
+        const game = new CircuitHackerGame(config, cb, seededRng(1))
+        game.startGame()
+        // find first unlocked tile
+        const state = game.getState()
+        let target = { row: 0, col: 0 }
+        outer: for (let r = 0; r < state.rows; r++) {
+            for (let c = 0; c < state.cols; c++) {
+                if (!state.grid[r][c].locked) {
+                    target = { row: r, col: c }
+                    break outer
+                }
+            }
+        }
+        const before = game.getState().grid[target.row][target.col].orientation
+        game.rotateTile(target.row, target.col)
+        const after = game.getState().grid[target.row][target.col].orientation
+        expect(after).toBe((before + 1) % 4)
+        expect(game.getState().rotationsUsed).toBe(1)
+        expect(cb.onRotation).toHaveBeenCalledWith(1)
+        game.cleanup()
+    })
+
+    it('does not rotate a locked tile', () => {
+        const cb = makeCallbacks()
+        const game = new CircuitHackerGame(config, cb, seededRng(1))
+        game.startGame()
+        const { sourcePos } = game.getState()
+        const before =
+            game.getState().grid[sourcePos.row][sourcePos.col].orientation
+        game.rotateTile(sourcePos.row, sourcePos.col)
+        const after =
+            game.getState().grid[sourcePos.row][sourcePos.col].orientation
+        expect(after).toBe(before)
+        expect(game.getState().rotationsUsed).toBe(0)
+        game.cleanup()
+    })
+
+    it('solves when the board is rotated into the solution', () => {
+        const cb = makeCallbacks()
+        const game = new CircuitHackerGame(config, cb, seededRng(1))
+        game.startGame()
+        game.solveForTest() // test helper applies solution orientations
+        expect(cb.onSolved).toHaveBeenCalledTimes(1)
+        const [score, stats] = (cb.onSolved as ReturnType<typeof vi.fn>).mock
+            .calls[0]
+        expect(score).toBeGreaterThan(0)
+        expect(stats.solved).toBe(true)
+        expect(game.getState().isGameActive).toBe(false)
+        game.cleanup()
+    })
+
+    it('fails when the timer runs out', () => {
+        const cb = makeCallbacks()
+        const game = new CircuitHackerGame(config, cb, seededRng(1))
+        game.startGame()
+        vi.advanceTimersByTime(121_000) // past the 120s easy timer
+        expect(cb.onFail).toHaveBeenCalledTimes(1)
+        expect(game.getState().isGameOver).toBe(true)
+        game.cleanup()
+    })
+})

--- a/src/lib/games/circuit-hacker/game.test.ts
+++ b/src/lib/games/circuit-hacker/game.test.ts
@@ -185,4 +185,112 @@ describe('CircuitHackerGame', () => {
         expect(cb.onFail).not.toHaveBeenCalled()
         game.cleanup()
     })
+
+    it('startGame is a no-op when a game is already active', () => {
+        const cb = makeCallbacks()
+        const game = new CircuitHackerGame(config, cb, seededRng(1))
+        game.startGame()
+        const firstGrid = game.getState().grid
+        // Second call should return early without rebuilding the puzzle
+        game.startGame()
+        expect(cb.onGameStart).toHaveBeenCalledTimes(1)
+        // Grid reference is unchanged (no rebuild)
+        expect(game.getState().grid).toBe(firstGrid)
+        game.cleanup()
+    })
+
+    it('timer callback is a no-op when game is no longer active', () => {
+        const cb = makeCallbacks()
+        const game = new CircuitHackerGame(config, cb, seededRng(1))
+        game.startGame()
+        // onTimeUpdate is called once during startGame (initial time)
+        expect(cb.onTimeUpdate).toHaveBeenCalledTimes(1)
+        // Simulate a race: deactivate without clearing the timer, then
+        // let the interval fire. The callback should return early.
+        const internals = game as unknown as {
+            state: { isGameActive: boolean }
+        }
+        internals.state.isGameActive = false
+        vi.advanceTimersByTime(1000)
+        // onTimeUpdate should NOT have been called again from the timer
+        expect(cb.onTimeUpdate).toHaveBeenCalledTimes(1)
+        expect(cb.onFail).not.toHaveBeenCalled()
+        game.cleanup()
+    })
+
+    it('rotateTile is a no-op when the game is not active', () => {
+        const cb = makeCallbacks()
+        const game = new CircuitHackerGame(config, cb, seededRng(1))
+        game.startGame()
+        game.stopGame() // sets isGameActive = false
+        const before = game.getState().rotationsUsed
+        // Find any rotatable tile and try to rotate it post-game
+        const state = game.getState()
+        let target = { row: 0, col: 0 }
+        outer: for (let r = 0; r < state.rows; r++) {
+            for (let c = 0; c < state.cols; c++) {
+                if (!state.grid[r][c].locked) {
+                    target = { row: r, col: c }
+                    break outer
+                }
+            }
+        }
+        game.rotateTile(target.row, target.col)
+        expect(game.getState().rotationsUsed).toBe(before)
+        expect(cb.onRotation).not.toHaveBeenCalled()
+        game.cleanup()
+    })
+
+    it('rotateTile ignores out-of-bounds coordinates', () => {
+        const cb = makeCallbacks()
+        const game = new CircuitHackerGame(config, cb, seededRng(1))
+        game.startGame()
+        const before = game.getState().rotationsUsed
+        game.rotateTile(-1, 0) // negative row
+        game.rotateTile(0, -1) // negative col
+        game.rotateTile(99, 0) // row out of bounds
+        game.rotateTile(0, 99) // col out of bounds
+        expect(game.getState().rotationsUsed).toBe(before)
+        expect(cb.onRotation).not.toHaveBeenCalled()
+        game.cleanup()
+    })
+
+    it('logs to console.error when onSolved rejects', async () => {
+        const consoleSpy = vi
+            .spyOn(console, 'error')
+            .mockImplementation(() => {})
+        const cb = makeCallbacks()
+        cb.onSolved = vi.fn().mockRejectedValue(new Error('submit failed'))
+        const game = new CircuitHackerGame(config, cb, seededRng(1))
+        game.startGame()
+        solveGameForTest(game)
+        // Flush the microtask queue so the rejected promise's .catch() runs
+        await vi.advanceTimersByTimeAsync(0)
+        expect(consoleSpy).toHaveBeenCalledWith(
+            'onSolved callback rejected:',
+            expect.any(Error)
+        )
+        consoleSpy.mockRestore()
+        game.cleanup()
+    })
+})
+
+describe('test-utils', () => {
+    it('solveGameForTest is a no-op when no puzzle exists (game not started)', () => {
+        const cb = makeCallbacks()
+        const game = new CircuitHackerGame(config, cb, seededRng(1))
+        // Game has not been started, so puzzle is null. The helper should
+        // return early without calling solve() or throwing.
+        expect(() => solveGameForTest(game)).not.toThrow()
+        expect(cb.onSolved).not.toHaveBeenCalled()
+        game.cleanup()
+    })
+
+    it('getSolutionOrientationsForTest returns null when no puzzle exists', () => {
+        const cb = makeCallbacks()
+        const game = new CircuitHackerGame(config, cb, seededRng(1))
+        // Game has not been started, so puzzle is null
+        expect(getSolutionOrientationsForTest(game)).toBeNull()
+        game.cleanup()
+    })
 })

--- a/src/lib/games/circuit-hacker/game.test.ts
+++ b/src/lib/games/circuit-hacker/game.test.ts
@@ -84,13 +84,40 @@ describe('CircuitHackerGame', () => {
         game.cleanup()
     })
 
-    it('fails when the timer runs out', () => {
+    it('fails with reason "timeout" when the timer runs out', () => {
         const cb = makeCallbacks()
         const game = new CircuitHackerGame(config, cb, seededRng(1))
         game.startGame()
         vi.advanceTimersByTime(121_000) // past the 120s easy timer
         expect(cb.onFail).toHaveBeenCalledTimes(1)
+        const [stats, reason] = (cb.onFail as ReturnType<typeof vi.fn>).mock
+            .calls[0]
+        expect(reason).toBe('timeout')
+        expect(stats.solved).toBe(false)
         expect(game.getState().isGameOver).toBe(true)
+        game.cleanup()
+    })
+
+    it('fails with reason "manual" when stopGame is called', () => {
+        const cb = makeCallbacks()
+        const game = new CircuitHackerGame(config, cb, seededRng(1))
+        game.startGame()
+        game.stopGame()
+        expect(cb.onFail).toHaveBeenCalledTimes(1)
+        const [stats, reason] = (cb.onFail as ReturnType<typeof vi.fn>).mock
+            .calls[0]
+        expect(reason).toBe('manual')
+        expect(stats.solved).toBe(false)
+        expect(game.getState().isGameActive).toBe(false)
+        expect(game.getState().isGameOver).toBe(true)
+        game.cleanup()
+    })
+
+    it('stopGame is a no-op when no game is active', () => {
+        const cb = makeCallbacks()
+        const game = new CircuitHackerGame(config, cb, seededRng(1))
+        game.stopGame()
+        expect(cb.onFail).not.toHaveBeenCalled()
         game.cleanup()
     })
 })

--- a/src/lib/games/circuit-hacker/game.ts
+++ b/src/lib/games/circuit-hacker/game.ts
@@ -4,7 +4,7 @@ import type {
     CircuitHackerConfig,
     CircuitHackerState,
     CircuitHackerStats,
-    FailReason,
+    RunEndReason,
 } from './types'
 import {
     DIFFICULTY_CONFIGS,
@@ -160,7 +160,7 @@ export class CircuitHackerGame {
         this.callbacks.onSolved(this.state.score, this.getStats())
     }
 
-    private fail(reason: FailReason): void {
+    private fail(reason: RunEndReason): void {
         this.clearTimer()
         this.state.isGameActive = false
         this.state.isGameOver = true

--- a/src/lib/games/circuit-hacker/game.ts
+++ b/src/lib/games/circuit-hacker/game.ts
@@ -11,7 +11,6 @@ import {
     computePoweredCells,
     countRotatableTiles,
     computeFinalScore,
-    isSolved,
 } from './utils'
 import { generatePuzzle, type GeneratedPuzzle } from './generator'
 
@@ -89,6 +88,12 @@ export class CircuitHackerGame {
         }
     }
 
+    // After applyPower() has stamped the .powered flags, cores are solved iff
+    // every core cell is powered. Avoids a second flood-fill per rotation.
+    private allCoresPowered(state: CircuitHackerState): boolean {
+        return state.corePositions.every(c => state.grid[c.row][c.col].powered)
+    }
+
     startGame(): void {
         if (this.state.isGameActive) {
             return
@@ -135,13 +140,7 @@ export class CircuitHackerGame {
         this.applyPower(this.state)
         this.callbacks.onRotation(this.state.rotationsUsed)
 
-        if (
-            isSolved(
-                this.state.grid,
-                this.state.sourcePos,
-                this.state.corePositions
-            )
-        ) {
+        if (this.allCoresPowered(this.state)) {
             this.solve()
         }
     }
@@ -213,13 +212,7 @@ export class CircuitHackerGame {
             }
         }
         this.applyPower(this.state)
-        if (
-            isSolved(
-                this.state.grid,
-                this.state.sourcePos,
-                this.state.corePositions
-            )
-        ) {
+        if (this.allCoresPowered(this.state)) {
             this.solve()
         }
     }

--- a/src/lib/games/circuit-hacker/game.ts
+++ b/src/lib/games/circuit-hacker/game.ts
@@ -156,6 +156,11 @@ export class CircuitHackerGame {
             rotatableTileCount: countRotatableTiles(this.state.grid),
             multiplier: DIFFICULTY_CONFIGS[this.config.difficulty].multiplier,
         })
+        // Fire-and-forget: onSolved is async (it submits the score and may
+        // dispatch achievement events) but we intentionally do not await it
+        // here. The game loop must not block on network I/O, and the result
+        // is handled via callbacks inside onSolved. Matches the codebase
+        // pattern used by other games (evader, tetris, etc.).
         this.callbacks.onSolved(this.state.score, this.getStats())
     }
 

--- a/src/lib/games/circuit-hacker/game.ts
+++ b/src/lib/games/circuit-hacker/game.ts
@@ -4,6 +4,7 @@ import type {
     CircuitHackerConfig,
     CircuitHackerState,
     CircuitHackerStats,
+    Orientation,
     RunEndReason,
 } from './types'
 import {
@@ -135,7 +136,7 @@ export class CircuitHackerGame {
             return
         }
 
-        tile.orientation = (tile.orientation + 1) % 4
+        tile.orientation = ((tile.orientation + 1) % 4) as Orientation
         this.state.rotationsUsed++
         this.applyPower(this.state)
         this.callbacks.onRotation(this.state.rotationsUsed)
@@ -160,8 +161,19 @@ export class CircuitHackerGame {
         // dispatch achievement events) but we intentionally do not await it
         // here. The game loop must not block on network I/O, and the result
         // is handled via callbacks inside onSolved. Matches the codebase
-        // pattern used by other games (evader, tetris, etc.).
-        this.callbacks.onSolved(this.state.score, this.getStats())
+        // pattern used by other games (evader, tetris, etc.). The defensive
+        // .catch() ensures an unhandled rejection can never escape even if
+        // synchronous work is later added before the saveGameScore try block.
+        const result = this.callbacks.onSolved(
+            this.state.score,
+            this.getStats()
+        ) as unknown
+        if (result && typeof (result as Promise<void>).catch === 'function') {
+            void (result as Promise<void>).catch(err => {
+                // eslint-disable-next-line no-console
+                console.error('onSolved callback rejected:', err)
+            })
+        }
     }
 
     private fail(reason: RunEndReason): void {
@@ -180,7 +192,7 @@ export class CircuitHackerGame {
         this.fail('manual')
     }
 
-    getState(): CircuitHackerState {
+    getState(): Readonly<CircuitHackerState> {
         return this.state
     }
 
@@ -203,22 +215,5 @@ export class CircuitHackerGame {
 
     cleanup(): void {
         this.clearTimer()
-    }
-
-    /** Test-only helper: rotate every tile into the known solution. */
-    solveForTest(): void {
-        if (!this.puzzle) {
-            return
-        }
-        for (let r = 0; r < this.state.rows; r++) {
-            for (let c = 0; c < this.state.cols; c++) {
-                this.state.grid[r][c].orientation =
-                    this.puzzle.solutionOrientations[r][c]
-            }
-        }
-        this.applyPower(this.state)
-        if (this.allCoresPowered(this.state)) {
-            this.solve()
-        }
     }
 }

--- a/src/lib/games/circuit-hacker/game.ts
+++ b/src/lib/games/circuit-hacker/game.ts
@@ -4,6 +4,7 @@ import type {
     CircuitHackerConfig,
     CircuitHackerState,
     CircuitHackerStats,
+    FailReason,
 } from './types'
 import {
     DIFFICULTY_CONFIGS,
@@ -19,7 +20,7 @@ export class CircuitHackerGame {
     private callbacks: CircuitHackerCallbacks
     private rng: () => number
     private state: CircuitHackerState
-    private puzzle: GeneratedPuzzle
+    private puzzle: GeneratedPuzzle | null = null
     private timer: number | null = null
 
     constructor(
@@ -30,8 +31,10 @@ export class CircuitHackerGame {
         this.config = config
         this.callbacks = callbacks
         this.rng = rng
-        this.puzzle = this.buildPuzzle()
-        this.state = this.buildInitialState()
+        // The puzzle is built lazily in startGame(); the constructor only
+        // sets up an empty placeholder state so getState() is safe to call
+        // before a run begins.
+        this.state = this.buildEmptyState()
     }
 
     private buildPuzzle(): GeneratedPuzzle {
@@ -41,12 +44,29 @@ export class CircuitHackerGame {
         )
     }
 
-    private buildInitialState(): CircuitHackerState {
+    private buildEmptyState(): CircuitHackerState {
+        const tier = DIFFICULTY_CONFIGS[this.config.difficulty]
+        return {
+            grid: [],
+            sourcePos: { row: 0, col: 0 },
+            corePositions: [],
+            rows: tier.rows,
+            cols: tier.cols,
+            score: 0,
+            timeRemaining: tier.duration,
+            rotationsUsed: 0,
+            isGameActive: false,
+            isGameOver: false,
+            solved: false,
+        }
+    }
+
+    private buildInitialState(puzzle: GeneratedPuzzle): CircuitHackerState {
         const tier = DIFFICULTY_CONFIGS[this.config.difficulty]
         const state: CircuitHackerState = {
-            grid: this.puzzle.grid,
-            sourcePos: this.puzzle.sourcePos,
-            corePositions: this.puzzle.corePositions,
+            grid: puzzle.grid,
+            sourcePos: puzzle.sourcePos,
+            corePositions: puzzle.corePositions,
             rows: tier.rows,
             cols: tier.cols,
             score: 0,
@@ -75,7 +95,7 @@ export class CircuitHackerGame {
         }
         // Fresh puzzle each run at the configured difficulty.
         this.puzzle = this.buildPuzzle()
-        this.state = this.buildInitialState()
+        this.state = this.buildInitialState(this.puzzle)
         this.state.isGameActive = true
 
         this.callbacks.onGameStart()
@@ -88,7 +108,7 @@ export class CircuitHackerGame {
             this.state.timeRemaining--
             this.callbacks.onTimeUpdate(this.state.timeRemaining)
             if (this.state.timeRemaining <= 0) {
-                this.fail()
+                this.fail('timeout')
             }
         }, 1000)
     }
@@ -140,20 +160,20 @@ export class CircuitHackerGame {
         this.callbacks.onSolved(this.state.score, this.getStats())
     }
 
-    private fail(): void {
+    private fail(reason: FailReason): void {
         this.clearTimer()
         this.state.isGameActive = false
         this.state.isGameOver = true
         this.state.solved = false
         this.state.timeRemaining = Math.max(0, this.state.timeRemaining)
-        this.callbacks.onFail(this.getStats())
+        this.callbacks.onFail(this.getStats(), reason)
     }
 
     stopGame(): void {
         if (!this.state.isGameActive) {
             return
         }
-        this.fail()
+        this.fail('manual')
     }
 
     getState(): CircuitHackerState {
@@ -183,6 +203,9 @@ export class CircuitHackerGame {
 
     /** Test-only helper: rotate every tile into the known solution. */
     solveForTest(): void {
+        if (!this.puzzle) {
+            return
+        }
         for (let r = 0; r < this.state.rows; r++) {
             for (let c = 0; c < this.state.cols; c++) {
                 this.state.grid[r][c].orientation =

--- a/src/lib/games/circuit-hacker/game.ts
+++ b/src/lib/games/circuit-hacker/game.ts
@@ -1,0 +1,203 @@
+// src/lib/games/circuit-hacker/game.ts
+import type {
+    CircuitHackerCallbacks,
+    CircuitHackerConfig,
+    CircuitHackerState,
+    CircuitHackerStats,
+} from './types'
+import {
+    DIFFICULTY_CONFIGS,
+    computePoweredCells,
+    countRotatableTiles,
+    computeFinalScore,
+    isSolved,
+} from './utils'
+import { generatePuzzle, type GeneratedPuzzle } from './generator'
+
+export class CircuitHackerGame {
+    private config: CircuitHackerConfig
+    private callbacks: CircuitHackerCallbacks
+    private rng: () => number
+    private state: CircuitHackerState
+    private puzzle: GeneratedPuzzle
+    private timer: number | null = null
+
+    constructor(
+        config: CircuitHackerConfig,
+        callbacks: CircuitHackerCallbacks,
+        rng: () => number = Math.random
+    ) {
+        this.config = config
+        this.callbacks = callbacks
+        this.rng = rng
+        this.puzzle = this.buildPuzzle()
+        this.state = this.buildInitialState()
+    }
+
+    private buildPuzzle(): GeneratedPuzzle {
+        return generatePuzzle(
+            DIFFICULTY_CONFIGS[this.config.difficulty],
+            this.rng
+        )
+    }
+
+    private buildInitialState(): CircuitHackerState {
+        const tier = DIFFICULTY_CONFIGS[this.config.difficulty]
+        const state: CircuitHackerState = {
+            grid: this.puzzle.grid,
+            sourcePos: this.puzzle.sourcePos,
+            corePositions: this.puzzle.corePositions,
+            rows: tier.rows,
+            cols: tier.cols,
+            score: 0,
+            timeRemaining: tier.duration,
+            rotationsUsed: 0,
+            isGameActive: false,
+            isGameOver: false,
+            solved: false,
+        }
+        this.applyPower(state)
+        return state
+    }
+
+    private applyPower(state: CircuitHackerState): void {
+        const powered = computePoweredCells(state.grid, state.sourcePos)
+        for (let r = 0; r < state.rows; r++) {
+            for (let c = 0; c < state.cols; c++) {
+                state.grid[r][c].powered = powered[r][c]
+            }
+        }
+    }
+
+    startGame(): void {
+        if (this.state.isGameActive) {
+            return
+        }
+        // Fresh puzzle each run at the configured difficulty.
+        this.puzzle = this.buildPuzzle()
+        this.state = this.buildInitialState()
+        this.state.isGameActive = true
+
+        this.callbacks.onGameStart()
+        this.callbacks.onTimeUpdate(this.state.timeRemaining)
+
+        this.timer = window.setInterval(() => {
+            if (!this.state.isGameActive) {
+                return
+            }
+            this.state.timeRemaining--
+            this.callbacks.onTimeUpdate(this.state.timeRemaining)
+            if (this.state.timeRemaining <= 0) {
+                this.fail()
+            }
+        }, 1000)
+    }
+
+    rotateTile(row: number, col: number): void {
+        if (!this.state.isGameActive) {
+            return
+        }
+        if (
+            row < 0 ||
+            row >= this.state.rows ||
+            col < 0 ||
+            col >= this.state.cols
+        ) {
+            return
+        }
+        const tile = this.state.grid[row][col]
+        if (tile.locked) {
+            return
+        }
+
+        tile.orientation = (tile.orientation + 1) % 4
+        this.state.rotationsUsed++
+        this.applyPower(this.state)
+        this.callbacks.onRotation(this.state.rotationsUsed)
+
+        if (
+            isSolved(
+                this.state.grid,
+                this.state.sourcePos,
+                this.state.corePositions
+            )
+        ) {
+            this.solve()
+        }
+    }
+
+    private solve(): void {
+        this.clearTimer()
+        this.state.isGameActive = false
+        this.state.isGameOver = true
+        this.state.solved = true
+        this.state.score = computeFinalScore({
+            secondsRemaining: this.state.timeRemaining,
+            rotationsUsed: this.state.rotationsUsed,
+            rotatableTileCount: countRotatableTiles(this.state.grid),
+            multiplier: DIFFICULTY_CONFIGS[this.config.difficulty].multiplier,
+        })
+        this.callbacks.onSolved(this.state.score, this.getStats())
+    }
+
+    private fail(): void {
+        this.clearTimer()
+        this.state.isGameActive = false
+        this.state.isGameOver = true
+        this.state.solved = false
+        this.state.timeRemaining = Math.max(0, this.state.timeRemaining)
+        this.callbacks.onFail(this.getStats())
+    }
+
+    stopGame(): void {
+        if (!this.state.isGameActive) {
+            return
+        }
+        this.fail()
+    }
+
+    getState(): CircuitHackerState {
+        return this.state
+    }
+
+    getStats(): CircuitHackerStats {
+        return {
+            finalScore: this.state.score,
+            difficulty: this.config.difficulty,
+            secondsRemaining: this.state.timeRemaining,
+            rotationsUsed: this.state.rotationsUsed,
+            solved: this.state.solved,
+        }
+    }
+
+    private clearTimer(): void {
+        if (this.timer !== null) {
+            clearInterval(this.timer)
+            this.timer = null
+        }
+    }
+
+    cleanup(): void {
+        this.clearTimer()
+    }
+
+    /** Test-only helper: rotate every tile into the known solution. */
+    solveForTest(): void {
+        for (let r = 0; r < this.state.rows; r++) {
+            for (let c = 0; c < this.state.cols; c++) {
+                this.state.grid[r][c].orientation =
+                    this.puzzle.solutionOrientations[r][c]
+            }
+        }
+        this.applyPower(this.state)
+        if (
+            isSolved(
+                this.state.grid,
+                this.state.sourcePos,
+                this.state.corePositions
+            )
+        ) {
+            this.solve()
+        }
+    }
+}

--- a/src/lib/games/circuit-hacker/generator.test.ts
+++ b/src/lib/games/circuit-hacker/generator.test.ts
@@ -59,6 +59,8 @@ describe('generatePuzzle', () => {
         // 5000 seeds/difficulty gives >99% chance of catching a bug that
         // occurs at ~1/1500 frequency (the rate observed before the
         // findPath/backtracking fix). 100 seeds only gave ~7%.
+        // Explicit 30s timeout: the sweep takes ~6s in isolation but can
+        // exceed the 5s default under the full suite's parallel load.
         for (const diff of ['easy', 'medium', 'hard', 'expert'] as const) {
             const cfg = DIFFICULTY_CONFIGS[diff]
             for (let seed = 1; seed <= 5000; seed++) {
@@ -76,7 +78,7 @@ describe('generatePuzzle', () => {
                 expect(allCoresPowered, `${diff} seed ${seed}`).toBe(true)
             }
         }
-    })
+    }, 30000)
 
     it('marks source, core and blocker tiles as locked', () => {
         const puzzle = generatePuzzle(DIFFICULTY_CONFIGS.hard, seededRng(3))

--- a/src/lib/games/circuit-hacker/generator.test.ts
+++ b/src/lib/games/circuit-hacker/generator.test.ts
@@ -1,0 +1,75 @@
+// src/lib/games/circuit-hacker/generator.test.ts
+import { describe, it, expect } from 'vitest'
+import { generatePuzzle } from './generator'
+import { DIFFICULTY_CONFIGS, computePoweredCells } from './utils'
+import type { Difficulty, Tile } from './types'
+
+// Deterministic LCG so tests are reproducible
+function seededRng(seed: number): () => number {
+    let s = seed >>> 0
+    return () => {
+        s = (s * 1664525 + 1013904223) >>> 0
+        return s / 0xffffffff
+    }
+}
+
+const difficulties: Difficulty[] = ['easy', 'medium', 'hard', 'expert']
+
+describe('generatePuzzle', () => {
+    it.each(difficulties)(
+        'produces a grid of the right shape and counts for %s',
+        difficulty => {
+            const config = DIFFICULTY_CONFIGS[difficulty]
+            const puzzle = generatePuzzle(config, seededRng(42))
+
+            expect(puzzle.grid).toHaveLength(config.rows)
+            for (const row of puzzle.grid) {
+                expect(row).toHaveLength(config.cols)
+            }
+
+            const flat = puzzle.grid.flat()
+            expect(flat.filter(t => t.type === 'source')).toHaveLength(1)
+            expect(flat.filter(t => t.type === 'core')).toHaveLength(
+                config.cores
+            )
+            expect(flat.filter(t => t.type === 'blocker')).toHaveLength(
+                config.blockers
+            )
+            expect(puzzle.corePositions).toHaveLength(config.cores)
+        }
+    )
+
+    it.each(difficulties)('is solvable by construction for %s', difficulty => {
+        const config = DIFFICULTY_CONFIGS[difficulty]
+        const puzzle = generatePuzzle(config, seededRng(7))
+
+        // Apply the recorded solution orientations
+        const solved: Tile[][] = puzzle.grid.map((row, r) =>
+            row.map((tile, c) => ({
+                ...tile,
+                orientation: puzzle.solutionOrientations[r][c],
+            }))
+        )
+        const powered = computePoweredCells(solved, puzzle.sourcePos)
+        for (const core of puzzle.corePositions) {
+            expect(powered[core.row][core.col]).toBe(true)
+        }
+    })
+
+    it('marks source, core and blocker tiles as locked', () => {
+        const puzzle = generatePuzzle(DIFFICULTY_CONFIGS.hard, seededRng(3))
+        for (const row of puzzle.grid) {
+            for (const tile of row) {
+                if (
+                    tile.type === 'source' ||
+                    tile.type === 'core' ||
+                    tile.type === 'blocker'
+                ) {
+                    expect(tile.locked).toBe(true)
+                } else {
+                    expect(tile.locked).toBe(false)
+                }
+            }
+        }
+    })
+})

--- a/src/lib/games/circuit-hacker/generator.test.ts
+++ b/src/lib/games/circuit-hacker/generator.test.ts
@@ -56,9 +56,12 @@ describe('generatePuzzle', () => {
                 return s / 0xffffffff
             }
         }
+        // 5000 seeds/difficulty gives >99% chance of catching a bug that
+        // occurs at ~1/1500 frequency (the rate observed before the
+        // findPath/backtracking fix). 100 seeds only gave ~7%.
         for (const diff of ['easy', 'medium', 'hard', 'expert'] as const) {
             const cfg = DIFFICULTY_CONFIGS[diff]
-            for (let seed = 1; seed <= 100; seed++) {
+            for (let seed = 1; seed <= 5000; seed++) {
                 const puzzle = generatePuzzle(cfg, lcg(seed))
                 const solved = puzzle.grid.map((row, r) =>
                     row.map((tile, c) => ({

--- a/src/lib/games/circuit-hacker/generator.test.ts
+++ b/src/lib/games/circuit-hacker/generator.test.ts
@@ -56,6 +56,33 @@ describe('generatePuzzle', () => {
         }
     })
 
+    it('generates solvable puzzles across many seeds for every difficulty', () => {
+        const lcg = (seed: number) => {
+            let s = seed >>> 0
+            return () => {
+                s = (1664525 * s + 1013904223) >>> 0
+                return s / 0xffffffff
+            }
+        }
+        for (const diff of ['easy', 'medium', 'hard', 'expert'] as const) {
+            const cfg = DIFFICULTY_CONFIGS[diff]
+            for (let seed = 1; seed <= 100; seed++) {
+                const puzzle = generatePuzzle(cfg, lcg(seed))
+                const solved = puzzle.grid.map((row, r) =>
+                    row.map((tile, c) => ({
+                        ...tile,
+                        orientation: puzzle.solutionOrientations[r][c],
+                    }))
+                )
+                const powered = computePoweredCells(solved, puzzle.sourcePos)
+                const allCoresPowered = puzzle.corePositions.every(
+                    cp => powered[cp.row][cp.col]
+                )
+                expect(allCoresPowered, `${diff} seed ${seed}`).toBe(true)
+            }
+        }
+    })
+
     it('marks source, core and blocker tiles as locked', () => {
         const puzzle = generatePuzzle(DIFFICULTY_CONFIGS.hard, seededRng(3))
         for (const row of puzzle.grid) {

--- a/src/lib/games/circuit-hacker/generator.test.ts
+++ b/src/lib/games/circuit-hacker/generator.test.ts
@@ -3,15 +3,7 @@ import { describe, it, expect } from 'vitest'
 import { generatePuzzle } from './generator'
 import { DIFFICULTY_CONFIGS, computePoweredCells } from './utils'
 import type { Difficulty, Tile } from './types'
-
-// Deterministic LCG so tests are reproducible
-function seededRng(seed: number): () => number {
-    let s = seed >>> 0
-    return () => {
-        s = (s * 1664525 + 1013904223) >>> 0
-        return s / 0xffffffff
-    }
-}
+import { seededRng } from './test-utils'
 
 const difficulties: Difficulty[] = ['easy', 'medium', 'hard', 'expert']
 
@@ -98,5 +90,20 @@ describe('generatePuzzle', () => {
                 }
             }
         }
+    })
+
+    it('throws when no source with a non-core neighbor can be placed', () => {
+        // A 1x1 grid has no neighbors, so the source invariant can never hold
+        // and the retry loop must give up after its attempt budget.
+        const tinyConfig = {
+            difficulty: 'easy' as Difficulty,
+            rows: 1,
+            cols: 1,
+            cores: 0,
+            blockers: 0,
+            duration: 1,
+            multiplier: 1,
+        }
+        expect(() => generatePuzzle(tinyConfig, seededRng(1))).toThrow()
     })
 })

--- a/src/lib/games/circuit-hacker/generator.test.ts
+++ b/src/lib/games/circuit-hacker/generator.test.ts
@@ -1,8 +1,8 @@
 // src/lib/games/circuit-hacker/generator.test.ts
 import { describe, it, expect } from 'vitest'
-import { generatePuzzle } from './generator'
+import { generatePuzzle, bfsPath, tileForDirections } from './generator'
 import { DIFFICULTY_CONFIGS, computePoweredCells } from './utils'
-import type { Difficulty, Tile } from './types'
+import type { Difficulty, Tile, Direction } from './types'
 import { seededRng } from './test-utils'
 
 const difficulties: Difficulty[] = ['easy', 'medium', 'hard', 'expert']
@@ -110,5 +110,78 @@ describe('generatePuzzle', () => {
             multiplier: 1,
         }
         expect(() => generatePuzzle(tinyConfig, seededRng(1))).toThrow()
+    })
+})
+
+describe('bfsPath fallback', () => {
+    it('finds a path when one exists', () => {
+        const start = { row: 0, col: 0 }
+        const goal = { row: 0, col: 2 }
+        const path = bfsPath(start, goal, 1, 3, new Set())
+        expect(path).not.toBeNull()
+        expect(path![0]).toEqual(start)
+        expect(path![path!.length - 1]).toEqual(goal)
+    })
+
+    it('returns null when the goal is unreachable (blocked)', () => {
+        const start = { row: 0, col: 0 }
+        const goal = { row: 0, col: 2 }
+        // Block the middle cell of a 1x3 row -> goal is unreachable
+        const blocked = new Set(['0,1'])
+        const path = bfsPath(start, goal, 1, 3, blocked)
+        expect(path).toBeNull()
+    })
+
+    it('returns a single-cell path when start === goal', () => {
+        const start = { row: 1, col: 1 }
+        const path = bfsPath(start, start, 3, 3, new Set())
+        expect(path).toEqual([start])
+    })
+
+    it('respects blocked cells as impassable walls', () => {
+        // 2x2 grid where the only path to (1,1) would go through (0,1) or
+        // (1,0), both blocked -> goal unreachable
+        const start = { row: 0, col: 0 }
+        const goal = { row: 1, col: 1 }
+        const blocked = new Set(['0,1', '1,0'])
+        const path = bfsPath(start, goal, 2, 2, blocked)
+        expect(path).toBeNull()
+    })
+})
+
+describe('tileForDirections', () => {
+    it('returns null for an empty direction set (degenerate layout)', () => {
+        expect(tileForDirections(new Set<Direction>())).toBeNull()
+    })
+
+    it('returns a cross for a single direction (hub stub)', () => {
+        const result = tileForDirections(new Set<Direction>(['N']))
+        expect(result).toEqual({ type: 'cross', orientation: 0 })
+    })
+
+    it('returns a straight tile for two opposite directions', () => {
+        const result = tileForDirections(new Set<Direction>(['N', 'S']))
+        expect(result).not.toBeNull()
+        expect(result!.type).toBe('straight')
+    })
+
+    it('returns an elbow tile for two adjacent directions', () => {
+        const result = tileForDirections(new Set<Direction>(['N', 'E']))
+        expect(result).not.toBeNull()
+        expect(result!.type).toBe('elbow')
+    })
+
+    it('returns a t-junction for three directions', () => {
+        const result = tileForDirections(new Set<Direction>(['N', 'E', 'S']))
+        expect(result).not.toBeNull()
+        expect(result!.type).toBe('t-junction')
+    })
+
+    it('returns a cross for all four directions', () => {
+        const result = tileForDirections(
+            new Set<Direction>(['N', 'E', 'S', 'W'])
+        )
+        expect(result).not.toBeNull()
+        expect(result!.type).toBe('cross')
     })
 })

--- a/src/lib/games/circuit-hacker/generator.ts
+++ b/src/lib/games/circuit-hacker/generator.ts
@@ -46,9 +46,10 @@ function findPath(
     goal: GridPosition,
     rows: number,
     cols: number,
-    rng: () => number
+    rng: () => number,
+    blocked: Set<string> = new Set()
 ): GridPosition[] | null {
-    const visited = new Set<string>([key(start)])
+    const visited = new Set<string>([key(start), ...blocked])
     const stack: GridPosition[][] = [[start]]
 
     while (stack.length > 0) {
@@ -146,9 +147,37 @@ export function generatePuzzle(
         return 'W'
     }
 
+    const coreKeys = new Set(corePositions.map(key))
+
+    // The source has a single connector, so it emits one trunk to a hub
+    // neighbor; every core path branches off that hub. Paths never route
+    // through the source or another core (those tiles have one connector).
+    const sourceNeighbors = shuffle(
+        ALL_DIRS.map(d => ({
+            row: sourcePos.row + DELTA[d].dr,
+            col: sourcePos.col + DELTA[d].dc,
+        })).filter(n => inBounds(n, rows, cols) && !coreKeys.has(key(n))),
+        rng
+    )
+    const hub = sourceNeighbors[0]
+    const hasHub = hub !== undefined
+
     const pathCells = new Set<string>([key(sourcePos)])
+    if (hasHub) {
+        pathCells.add(key(hub))
+        addDir(sourcePos, dirBetween(sourcePos, hub))
+        addDir(hub, dirBetween(hub, sourcePos))
+    }
+
     for (const core of corePositions) {
-        const path = findPath(sourcePos, core, rows, cols, rng)
+        const blocked = new Set<string>([key(sourcePos)])
+        for (const other of corePositions) {
+            if (key(other) !== key(core)) {
+                blocked.add(key(other))
+            }
+        }
+        const start = hasHub ? hub : sourcePos
+        const path = findPath(start, core, rows, cols, rng, blocked)
         if (!path) {
             continue
         }

--- a/src/lib/games/circuit-hacker/generator.ts
+++ b/src/lib/games/circuit-hacker/generator.ts
@@ -121,9 +121,30 @@ export function generatePuzzle(
         }
     }
 
-    const shuffled = shuffle(allCells, rng)
-    const sourcePos = shuffled[0]
-    const corePositions = shuffled.slice(1, 1 + cores)
+    const hasNonCoreNeighbor = (
+        source: GridPosition,
+        coreSet: GridPosition[]
+    ): boolean =>
+        ALL_DIRS.some(d => {
+            const n = {
+                row: source.row + DELTA[d].dr,
+                col: source.col + DELTA[d].dc,
+            }
+            return (
+                inBounds(n, rows, cols) &&
+                !coreSet.some(c => c.row === n.row && c.col === n.col)
+            )
+        })
+
+    let sourcePos: GridPosition
+    let corePositions: GridPosition[]
+    let attempts = 0
+    do {
+        const shuffled = shuffle(allCells, rng)
+        sourcePos = shuffled[0]
+        corePositions = shuffled.slice(1, 1 + cores)
+        attempts++
+    } while (attempts < 50 && !hasNonCoreNeighbor(sourcePos!, corePositions!))
 
     // Accumulate the directions each cell needs in the solved state.
     const required: Map<string, Set<Direction>> = new Map()

--- a/src/lib/games/circuit-hacker/generator.ts
+++ b/src/lib/games/circuit-hacker/generator.ts
@@ -16,6 +16,7 @@ export interface GeneratedPuzzle {
 }
 
 const ALL_DIRS: Direction[] = ['N', 'E', 'S', 'W']
+const MAX_GENERATE_ATTEMPTS = 50
 
 function key(pos: GridPosition): string {
     return `${pos.row},${pos.col}`
@@ -34,37 +35,109 @@ function shuffle<T>(arr: T[], rng: () => number): T[] {
     return copy
 }
 
-// Random simple path from start to goal via randomized DFS over a fresh grid.
+// Reconstruct a path from a parent map.
+function reconstructPath(
+    parent: Map<string, GridPosition | null>,
+    goal: GridPosition
+): GridPosition[] {
+    const path: GridPosition[] = []
+    let cur: GridPosition | null = goal
+    while (cur) {
+        path.unshift(cur)
+        cur = parent.get(key(cur)) ?? null
+    }
+    return path
+}
+
+// Randomized DFS path search. Produces winding paths, but the visited-once
+// strategy can spuriously fail when dead-end branches consume cells that a
+// different branch needed. O(rows*cols) with no per-step array copies.
+function dfsPath(
+    start: GridPosition,
+    goal: GridPosition,
+    rows: number,
+    cols: number,
+    rng: () => number,
+    blocked: Set<string>
+): GridPosition[] | null {
+    const visited = new Set<string>([key(start), ...blocked])
+    const parent = new Map<string, GridPosition | null>([[key(start), null]])
+    const stack: GridPosition[] = [start]
+
+    while (stack.length > 0) {
+        const current = stack.pop() as GridPosition
+        if (current.row === goal.row && current.col === goal.col) {
+            return reconstructPath(parent, current)
+        }
+        for (const dir of shuffle(ALL_DIRS, rng)) {
+            const next = {
+                row: current.row + DELTA[dir].dr,
+                col: current.col + DELTA[dir].dc,
+            }
+            const k = key(next)
+            if (!inBounds(next, rows, cols) || visited.has(k)) {
+                continue
+            }
+            visited.add(k)
+            parent.set(k, current)
+            stack.push(next)
+        }
+    }
+    return null
+}
+
+// BFS fallback — guaranteed to find a path if one exists. Used when the
+// randomized DFS spuriously misses one, so the generator never emits an
+// unsolvable puzzle due to a search artifact.
+function bfsPath(
+    start: GridPosition,
+    goal: GridPosition,
+    rows: number,
+    cols: number,
+    blocked: Set<string>
+): GridPosition[] | null {
+    const visited = new Set<string>([key(start), ...blocked])
+    const parent = new Map<string, GridPosition | null>([[key(start), null]])
+    const queue: GridPosition[] = [start]
+
+    while (queue.length > 0) {
+        const current = queue.shift() as GridPosition
+        if (current.row === goal.row && current.col === goal.col) {
+            return reconstructPath(parent, current)
+        }
+        for (const dir of ALL_DIRS) {
+            const next = {
+                row: current.row + DELTA[dir].dr,
+                col: current.col + DELTA[dir].dc,
+            }
+            const k = key(next)
+            if (!inBounds(next, rows, cols) || visited.has(k)) {
+                continue
+            }
+            visited.add(k)
+            parent.set(k, current)
+            queue.push(next)
+        }
+    }
+    return null
+}
+
+// Find a path from start to goal, preferring a winding randomized DFS and
+// falling back to BFS for completeness. Returns null only when the goal is
+// genuinely unreachable with the given blocked set.
 function findPath(
     start: GridPosition,
     goal: GridPosition,
     rows: number,
     cols: number,
     rng: () => number,
-    blocked: Set<string> = new Set()
+    blocked: Set<string>
 ): GridPosition[] | null {
-    const visited = new Set<string>([key(start), ...blocked])
-    const stack: GridPosition[][] = [[start]]
-
-    while (stack.length > 0) {
-        const path = stack.pop() as GridPosition[]
-        const head = path[path.length - 1]
-        if (head.row === goal.row && head.col === goal.col) {
-            return path
-        }
-        for (const dir of shuffle(ALL_DIRS, rng)) {
-            const next = {
-                row: head.row + DELTA[dir].dr,
-                col: head.col + DELTA[dir].dc,
-            }
-            if (!inBounds(next, rows, cols) || visited.has(key(next))) {
-                continue
-            }
-            visited.add(key(next))
-            stack.push([...path, next])
-        }
+    const dfsResult = dfsPath(start, goal, rows, cols, rng, blocked)
+    if (dfsResult) {
+        return dfsResult
     }
-    return null
+    return bfsPath(start, goal, rows, cols, blocked)
 }
 
 // Pick the tile type + orientation whose connectors equal a required dir set.
@@ -73,11 +146,18 @@ function tileForDirections(dirs: Set<Direction>): {
     orientation: number
 } {
     const required = ALL_DIRS.filter(d => dirs.has(d))
-    const candidates: TileType[] =
-        required.length === 1
-            ? [] // handled by source/core elsewhere
-            : ['straight', 'elbow', 't-junction', 'cross']
-
+    if (required.length === 0) {
+        throw new Error(
+            'tileForDirections: no connectors required for path cell'
+        )
+    }
+    if (required.length === 1) {
+        // Only occurs for the hub in a degenerate cores=0 layout: a stub off
+        // the source with no core to reach. A cross covers the one needed
+        // direction; the extra loose ends are harmless on a path cell.
+        return { type: 'cross', orientation: 0 }
+    }
+    const candidates: TileType[] = ['straight', 'elbow', 't-junction', 'cross']
     for (const type of candidates) {
         for (let orientation = 0; orientation < 4; orientation++) {
             const conn = rotateConnectors(getBaseConnectors(type), orientation)
@@ -102,10 +182,26 @@ function orientationForSingle(dir: Direction): number {
     return 0
 }
 
-export function generatePuzzle(
+function dirBetween(a: GridPosition, b: GridPosition): Direction {
+    if (b.row === a.row - 1) {
+        return 'N'
+    }
+    if (b.row === a.row + 1) {
+        return 'S'
+    }
+    if (b.col === a.col + 1) {
+        return 'E'
+    }
+    return 'W'
+}
+
+// One attempt at producing a fully-solvable puzzle. Returns null if any core
+// could not be reached from the hub, so the caller can retry with a fresh
+// layout instead of emitting an unwinnable puzzle.
+function tryGenerate(
     config: DifficultyConfig,
-    rng: () => number = Math.random
-): GeneratedPuzzle {
+    rng: () => number
+): GeneratedPuzzle | null {
     const { rows, cols, cores, blockers } = config
 
     const allCells: GridPosition[] = []
@@ -130,23 +226,21 @@ export function generatePuzzle(
             )
         })
 
-    let sourcePos: GridPosition
-    let corePositions: GridPosition[]
-    let attempts = 0
-    do {
+    // Pick a source with at least one non-core neighbor.
+    let sourcePos: GridPosition | null = null
+    let corePositions: GridPosition[] = []
+    for (let i = 0; i < 50; i++) {
         const shuffled = shuffle(allCells, rng)
-        sourcePos = shuffled[0]
-        corePositions = shuffled.slice(1, 1 + cores)
-        attempts++
-    } while (attempts < 50 && !hasNonCoreNeighbor(sourcePos!, corePositions!))
-
-    // Guard against the (extremely unlikely) case where no shuffled layout
-    // produced a source with a non-core neighbor. Failing loudly here beats
-    // silently emitting a puzzle with no valid hub, which would be unsolvable.
-    if (!hasNonCoreNeighbor(sourcePos, corePositions)) {
-        throw new Error(
-            'generatePuzzle: could not place a source tile with a non-core neighbor within the retry limit'
-        )
+        const candidateSource = shuffled[0]
+        const candidateCores = shuffled.slice(1, 1 + cores)
+        if (hasNonCoreNeighbor(candidateSource, candidateCores)) {
+            sourcePos = candidateSource
+            corePositions = candidateCores
+            break
+        }
+    }
+    if (!sourcePos) {
+        return null
     }
 
     // Accumulate the directions each cell needs in the solved state.
@@ -158,24 +252,14 @@ export function generatePuzzle(
         }
         required.get(k)!.add(dir)
     }
-    const dirBetween = (a: GridPosition, b: GridPosition): Direction => {
-        if (b.row === a.row - 1) {
-            return 'N'
-        }
-        if (b.row === a.row + 1) {
-            return 'S'
-        }
-        if (b.col === a.col + 1) {
-            return 'E'
-        }
-        return 'W'
-    }
 
     const coreKeys = new Set(corePositions.map(key))
 
     // The source has a single connector, so it emits one trunk to a hub
     // neighbor; every core path branches off that hub. Paths never route
     // through the source or another core (those tiles have one connector).
+    // hasNonCoreNeighbor guaranteed sourceNeighbors is non-empty, so the hub
+    // is always defined.
     const sourceNeighbors = shuffle(
         ALL_DIRS.map(d => ({
             row: sourcePos.row + DELTA[d].dr,
@@ -184,14 +268,10 @@ export function generatePuzzle(
         rng
     )
     const hub = sourceNeighbors[0]
-    const hasHub = hub !== undefined
 
-    const pathCells = new Set<string>([key(sourcePos)])
-    if (hasHub) {
-        pathCells.add(key(hub))
-        addDir(sourcePos, dirBetween(sourcePos, hub))
-        addDir(hub, dirBetween(hub, sourcePos))
-    }
+    const pathCells = new Set<string>([key(sourcePos), key(hub)])
+    addDir(sourcePos, dirBetween(sourcePos, hub))
+    addDir(hub, dirBetween(hub, sourcePos))
 
     for (const core of corePositions) {
         const blocked = new Set<string>([key(sourcePos)])
@@ -200,10 +280,12 @@ export function generatePuzzle(
                 blocked.add(key(other))
             }
         }
-        const start = hasHub ? hub : sourcePos
-        const path = findPath(start, core, rows, cols, rng, blocked)
+        const path = findPath(hub, core, rows, cols, rng, blocked)
         if (!path) {
-            continue
+            // This core is genuinely unreachable from the hub with this
+            // layout. Signal the caller to try a fresh layout rather than
+            // emitting an unsolvable puzzle.
+            return null
         }
         for (let i = 0; i < path.length; i++) {
             pathCells.add(key(path[i]))
@@ -288,4 +370,19 @@ export function generatePuzzle(
     }
 
     return { grid, sourcePos, corePositions, solutionOrientations }
+}
+
+export function generatePuzzle(
+    config: DifficultyConfig,
+    rng: () => number = Math.random
+): GeneratedPuzzle {
+    for (let attempt = 0; attempt < MAX_GENERATE_ATTEMPTS; attempt++) {
+        const puzzle = tryGenerate(config, rng)
+        if (puzzle) {
+            return puzzle
+        }
+    }
+    throw new Error(
+        'generatePuzzle: could not generate a solvable puzzle within retry limit'
+    )
 }

--- a/src/lib/games/circuit-hacker/generator.ts
+++ b/src/lib/games/circuit-hacker/generator.ts
@@ -22,6 +22,7 @@ export interface GeneratedPuzzle {
 
 const ALL_DIRS: Direction[] = ['N', 'E', 'S', 'W']
 const MAX_GENERATE_ATTEMPTS = 50
+const MAX_SOURCE_PLACEMENT_ATTEMPTS = 50
 
 function key(pos: GridPosition): string {
     return `${pos.row},${pos.col}`
@@ -235,7 +236,7 @@ function tryGenerate(
     // Pick a source with at least one non-core neighbor.
     let sourcePos: GridPosition | null = null
     let corePositions: GridPosition[] = []
-    for (let i = 0; i < 50; i++) {
+    for (let i = 0; i < MAX_SOURCE_PLACEMENT_ATTEMPTS; i++) {
         const shuffled = shuffle(allCells, rng)
         const candidateSource = shuffled[0]
         const candidateCores = shuffled.slice(1, 1 + cores)
@@ -253,10 +254,12 @@ function tryGenerate(
     const required: Map<string, Set<Direction>> = new Map()
     const addDir = (pos: GridPosition, dir: Direction) => {
         const k = key(pos)
-        if (!required.has(k)) {
-            required.set(k, new Set())
+        let dirs = required.get(k)
+        if (!dirs) {
+            dirs = new Set()
+            required.set(k, dirs)
         }
-        required.get(k)!.add(dir)
+        dirs.add(dir)
     }
 
     const coreKeys = new Set(corePositions.map(key))

--- a/src/lib/games/circuit-hacker/generator.ts
+++ b/src/lib/games/circuit-hacker/generator.ts
@@ -3,6 +3,7 @@ import type {
     DifficultyConfig,
     Direction,
     GridPosition,
+    Orientation,
     Tile,
     TileType,
 } from './types'
@@ -17,7 +18,7 @@ export interface GeneratedPuzzle {
     grid: Tile[][]
     sourcePos: GridPosition
     corePositions: GridPosition[]
-    solutionOrientations: number[][]
+    solutionOrientations: Orientation[][]
 }
 
 const ALL_DIRS: Direction[] = ['N', 'E', 'S', 'W']
@@ -94,8 +95,10 @@ function dfsPath(
 
 // BFS fallback — guaranteed to find a path if one exists. Used when the
 // randomized DFS spuriously misses one, so the generator never emits an
-// unsolvable puzzle due to a search artifact.
-function bfsPath(
+// unsolvable puzzle due to a search artifact. Exported for direct unit
+// testing of the fallback branch that the randomized DFS-only path may not
+// deterministically exercise.
+export function bfsPath(
     start: GridPosition,
     goal: GridPosition,
     rows: number,
@@ -149,10 +152,11 @@ function findPath(
 // Pick the tile type + orientation whose connectors equal a required dir set.
 // Returns null when no connectors are required (a degenerate layout the caller
 // should retry rather than emit), so defensive failures route through the
-// retry loop instead of bypassing it via a thrown exception.
-function tileForDirections(dirs: Set<Direction>): {
+// retry loop instead of bypassing it via a thrown exception. Exported for
+// direct unit testing of the degenerate (empty dirs) and fallback branches.
+export function tileForDirections(dirs: Set<Direction>): {
     type: TileType
-    orientation: number
+    orientation: Orientation
 } | null {
     const required = ALL_DIRS.filter(d => dirs.has(d))
     if (required.length === 0) {
@@ -167,12 +171,13 @@ function tileForDirections(dirs: Set<Direction>): {
     const candidates: TileType[] = ['straight', 'elbow', 't-junction', 'cross']
     for (const type of candidates) {
         for (let orientation = 0; orientation < 4; orientation++) {
-            const conn = rotateConnectors(getBaseConnectors(type), orientation)
+            const o = orientation as Orientation
+            const conn = rotateConnectors(getBaseConnectors(type), o)
             if (
                 conn.length === required.length &&
                 required.every(d => conn.includes(d))
             ) {
-                return { type, orientation }
+                return { type, orientation: o }
             }
         }
     }
@@ -180,10 +185,11 @@ function tileForDirections(dirs: Set<Direction>): {
     return { type: 'cross', orientation: 0 }
 }
 
-function orientationForSingle(dir: Direction): number {
+function orientationForSingle(dir: Direction): Orientation {
     for (let orientation = 0; orientation < 4; orientation++) {
-        if (rotateConnectors(['N'], orientation)[0] === dir) {
-            return orientation
+        const o = orientation as Orientation
+        if (rotateConnectors(['N'], o)[0] === dir) {
+            return o
         }
     }
     return 0
@@ -310,17 +316,17 @@ function tryGenerate(
 
     // Build the solved grid.
     const grid: Tile[][] = []
-    const solutionOrientations: number[][] = []
+    const solutionOrientations: Orientation[][] = []
     for (let r = 0; r < rows; r++) {
         const gridRow: Tile[] = []
-        const solRow: number[] = []
+        const solRow: Orientation[] = []
         for (let c = 0; c < cols; c++) {
             const pos = { row: r, col: c }
             const k = key(pos)
             const dirs = required.get(k) ?? new Set<Direction>()
 
             let type: TileType
-            let orientation: number
+            let orientation: Orientation
             let locked = false
 
             if (pos.row === sourcePos.row && pos.col === sourcePos.col) {
@@ -350,7 +356,7 @@ function tryGenerate(
                     'cross',
                 ]
                 type = decoys[Math.floor(rng() * decoys.length)]
-                orientation = Math.floor(rng() * 4)
+                orientation = Math.floor(rng() * 4) as Orientation
             }
 
             gridRow.push({ type, orientation, locked, powered: false })
@@ -379,7 +385,7 @@ function tryGenerate(
     for (let r = 0; r < rows; r++) {
         for (let c = 0; c < cols; c++) {
             if (!grid[r][c].locked) {
-                grid[r][c].orientation = Math.floor(rng() * 4)
+                grid[r][c].orientation = Math.floor(rng() * 4) as Orientation
             }
         }
     }

--- a/src/lib/games/circuit-hacker/generator.ts
+++ b/src/lib/games/circuit-hacker/generator.ts
@@ -182,7 +182,9 @@ export function tileForDirections(dirs: Set<Direction>): {
         }
     }
     // Fallback (should not happen for size 2..4): a cross covers any set
+    /* c8 ignore start -- unreachable: cross matches every direction set */
     return { type: 'cross', orientation: 0 }
+    /* c8 ignore end */
 }
 
 function orientationForSingle(dir: Direction): Orientation {
@@ -192,7 +194,10 @@ function orientationForSingle(dir: Direction): Orientation {
             return o
         }
     }
+    /* c8 ignore start -- unreachable: all 4 orientations of 'N' cover all
+       directions */
     return 0
+    /* c8 ignore end */
 }
 
 function dirBetween(a: GridPosition, b: GridPosition): Direction {
@@ -343,7 +348,11 @@ function tryGenerate(
                     // Degenerate layout (path cell with no required
                     // connectors). Signal the caller to retry with a fresh
                     // layout rather than emitting an unsolvable tile.
+                    /* c8 ignore start -- unreachable: path cells always have
+                       2+ directions, so tileForDirections never returns
+                       null for them */
                     return null
+                    /* c8 ignore end */
                 }
                 type = t.type
                 orientation = t.orientation

--- a/src/lib/games/circuit-hacker/generator.ts
+++ b/src/lib/games/circuit-hacker/generator.ts
@@ -1,0 +1,238 @@
+// src/lib/games/circuit-hacker/generator.ts
+import type {
+    DifficultyConfig,
+    Direction,
+    GridPosition,
+    Tile,
+    TileType,
+} from './types'
+import { getBaseConnectors, rotateConnectors } from './utils'
+
+export interface GeneratedPuzzle {
+    grid: Tile[][]
+    sourcePos: GridPosition
+    corePositions: GridPosition[]
+    solutionOrientations: number[][]
+}
+
+const ALL_DIRS: Direction[] = ['N', 'E', 'S', 'W']
+const DELTA: Record<Direction, { dr: number; dc: number }> = {
+    N: { dr: -1, dc: 0 },
+    E: { dr: 0, dc: 1 },
+    S: { dr: 1, dc: 0 },
+    W: { dr: 0, dc: -1 },
+}
+
+function key(pos: GridPosition): string {
+    return `${pos.row},${pos.col}`
+}
+
+function inBounds(pos: GridPosition, rows: number, cols: number): boolean {
+    return pos.row >= 0 && pos.row < rows && pos.col >= 0 && pos.col < cols
+}
+
+function shuffle<T>(arr: T[], rng: () => number): T[] {
+    const copy = [...arr]
+    for (let i = copy.length - 1; i > 0; i--) {
+        const j = Math.floor(rng() * (i + 1))
+        ;[copy[i], copy[j]] = [copy[j], copy[i]]
+    }
+    return copy
+}
+
+// Random simple path from start to goal via randomized DFS over a fresh grid.
+function findPath(
+    start: GridPosition,
+    goal: GridPosition,
+    rows: number,
+    cols: number,
+    rng: () => number
+): GridPosition[] | null {
+    const visited = new Set<string>([key(start)])
+    const stack: GridPosition[][] = [[start]]
+
+    while (stack.length > 0) {
+        const path = stack.pop() as GridPosition[]
+        const head = path[path.length - 1]
+        if (head.row === goal.row && head.col === goal.col) {
+            return path
+        }
+        for (const dir of shuffle(ALL_DIRS, rng)) {
+            const next = {
+                row: head.row + DELTA[dir].dr,
+                col: head.col + DELTA[dir].dc,
+            }
+            if (!inBounds(next, rows, cols) || visited.has(key(next))) {
+                continue
+            }
+            visited.add(key(next))
+            stack.push([...path, next])
+        }
+    }
+    return null
+}
+
+// Pick the tile type + orientation whose connectors equal a required dir set.
+function tileForDirections(dirs: Set<Direction>): {
+    type: TileType
+    orientation: number
+} {
+    const required = ALL_DIRS.filter(d => dirs.has(d))
+    const candidates: TileType[] =
+        required.length === 1
+            ? [] // handled by source/core elsewhere
+            : ['straight', 'elbow', 't-junction', 'cross']
+
+    for (const type of candidates) {
+        for (let orientation = 0; orientation < 4; orientation++) {
+            const conn = rotateConnectors(getBaseConnectors(type), orientation)
+            if (
+                conn.length === required.length &&
+                required.every(d => conn.includes(d))
+            ) {
+                return { type, orientation }
+            }
+        }
+    }
+    // Fallback (should not happen for size 2..4): a cross covers any set
+    return { type: 'cross', orientation: 0 }
+}
+
+function orientationForSingle(dir: Direction): number {
+    for (let orientation = 0; orientation < 4; orientation++) {
+        if (rotateConnectors(['N'], orientation)[0] === dir) {
+            return orientation
+        }
+    }
+    return 0
+}
+
+export function generatePuzzle(
+    config: DifficultyConfig,
+    rng: () => number = Math.random
+): GeneratedPuzzle {
+    const { rows, cols, cores, blockers } = config
+
+    const allCells: GridPosition[] = []
+    for (let r = 0; r < rows; r++) {
+        for (let c = 0; c < cols; c++) {
+            allCells.push({ row: r, col: c })
+        }
+    }
+
+    const shuffled = shuffle(allCells, rng)
+    const sourcePos = shuffled[0]
+    const corePositions = shuffled.slice(1, 1 + cores)
+
+    // Accumulate the directions each cell needs in the solved state.
+    const required: Map<string, Set<Direction>> = new Map()
+    const addDir = (pos: GridPosition, dir: Direction) => {
+        const k = key(pos)
+        if (!required.has(k)) {
+            required.set(k, new Set())
+        }
+        required.get(k)!.add(dir)
+    }
+    const dirBetween = (a: GridPosition, b: GridPosition): Direction => {
+        if (b.row === a.row - 1) {
+            return 'N'
+        }
+        if (b.row === a.row + 1) {
+            return 'S'
+        }
+        if (b.col === a.col + 1) {
+            return 'E'
+        }
+        return 'W'
+    }
+
+    const pathCells = new Set<string>([key(sourcePos)])
+    for (const core of corePositions) {
+        const path = findPath(sourcePos, core, rows, cols, rng)
+        if (!path) {
+            continue
+        }
+        for (let i = 0; i < path.length; i++) {
+            pathCells.add(key(path[i]))
+            if (i > 0) {
+                addDir(path[i], dirBetween(path[i], path[i - 1]))
+            }
+            if (i < path.length - 1) {
+                addDir(path[i], dirBetween(path[i], path[i + 1]))
+            }
+        }
+        pathCells.add(key(core))
+    }
+
+    // Build the solved grid.
+    const grid: Tile[][] = []
+    const solutionOrientations: number[][] = []
+    for (let r = 0; r < rows; r++) {
+        const gridRow: Tile[] = []
+        const solRow: number[] = []
+        for (let c = 0; c < cols; c++) {
+            const pos = { row: r, col: c }
+            const k = key(pos)
+            const dirs = required.get(k) ?? new Set<Direction>()
+
+            let type: TileType
+            let orientation: number
+            let locked = false
+
+            if (pos.row === sourcePos.row && pos.col === sourcePos.col) {
+                type = 'source'
+                orientation = orientationForSingle([...dirs][0] ?? 'N')
+                locked = true
+            } else if (corePositions.some(p => key(p) === k)) {
+                type = 'core'
+                orientation = orientationForSingle([...dirs][0] ?? 'N')
+                locked = true
+            } else if (pathCells.has(k)) {
+                const t = tileForDirections(dirs)
+                type = t.type
+                orientation = t.orientation
+            } else {
+                // Decoy cell: random pipe tile (loose ends are allowed).
+                const decoys: TileType[] = [
+                    'straight',
+                    'elbow',
+                    't-junction',
+                    'cross',
+                ]
+                type = decoys[Math.floor(rng() * decoys.length)]
+                orientation = Math.floor(rng() * 4)
+            }
+
+            gridRow.push({ type, orientation, locked, powered: false })
+            solRow.push(orientation)
+        }
+        grid.push(gridRow)
+        solutionOrientations.push(solRow)
+    }
+
+    // Place blockers on non-path, non-source/core cells.
+    const blockerCandidates = shuffle(
+        allCells.filter(p => !pathCells.has(key(p))),
+        rng
+    ).slice(0, blockers)
+    for (const pos of blockerCandidates) {
+        grid[pos.row][pos.col] = {
+            type: 'blocker',
+            orientation: 0,
+            locked: true,
+            powered: false,
+        }
+        solutionOrientations[pos.row][pos.col] = 0
+    }
+
+    // Scramble every rotatable tile to a random orientation.
+    for (let r = 0; r < rows; r++) {
+        for (let c = 0; c < cols; c++) {
+            if (!grid[r][c].locked) {
+                grid[r][c].orientation = Math.floor(rng() * 4)
+            }
+        }
+    }
+
+    return { grid, sourcePos, corePositions, solutionOrientations }
+}

--- a/src/lib/games/circuit-hacker/generator.ts
+++ b/src/lib/games/circuit-hacker/generator.ts
@@ -141,15 +141,16 @@ function findPath(
 }
 
 // Pick the tile type + orientation whose connectors equal a required dir set.
+// Returns null when no connectors are required (a degenerate layout the caller
+// should retry rather than emit), so defensive failures route through the
+// retry loop instead of bypassing it via a thrown exception.
 function tileForDirections(dirs: Set<Direction>): {
     type: TileType
     orientation: number
-} {
+} | null {
     const required = ALL_DIRS.filter(d => dirs.has(d))
     if (required.length === 0) {
-        throw new Error(
-            'tileForDirections: no connectors required for path cell'
-        )
+        return null
     }
     if (required.length === 1) {
         // Only occurs for the hub in a degenerate cores=0 layout: a stub off
@@ -324,6 +325,12 @@ function tryGenerate(
                 locked = true
             } else if (pathCells.has(k)) {
                 const t = tileForDirections(dirs)
+                if (!t) {
+                    // Degenerate layout (path cell with no required
+                    // connectors). Signal the caller to retry with a fresh
+                    // layout rather than emitting an unsolvable tile.
+                    return null
+                }
                 type = t.type
                 orientation = t.orientation
             } else {

--- a/src/lib/games/circuit-hacker/generator.ts
+++ b/src/lib/games/circuit-hacker/generator.ts
@@ -6,7 +6,7 @@ import type {
     Tile,
     TileType,
 } from './types'
-import { getBaseConnectors, rotateConnectors } from './utils'
+import { DELTA, getBaseConnectors, rotateConnectors } from './utils'
 
 export interface GeneratedPuzzle {
     grid: Tile[][]
@@ -16,12 +16,6 @@ export interface GeneratedPuzzle {
 }
 
 const ALL_DIRS: Direction[] = ['N', 'E', 'S', 'W']
-const DELTA: Record<Direction, { dr: number; dc: number }> = {
-    N: { dr: -1, dc: 0 },
-    E: { dr: 0, dc: 1 },
-    S: { dr: 1, dc: 0 },
-    W: { dr: 0, dc: -1 },
-}
 
 function key(pos: GridPosition): string {
     return `${pos.row},${pos.col}`
@@ -145,6 +139,15 @@ export function generatePuzzle(
         corePositions = shuffled.slice(1, 1 + cores)
         attempts++
     } while (attempts < 50 && !hasNonCoreNeighbor(sourcePos!, corePositions!))
+
+    // Guard against the (extremely unlikely) case where no shuffled layout
+    // produced a source with a non-core neighbor. Failing loudly here beats
+    // silently emitting a puzzle with no valid hub, which would be unsolvable.
+    if (!hasNonCoreNeighbor(sourcePos, corePositions)) {
+        throw new Error(
+            'generatePuzzle: could not place a source tile with a non-core neighbor within the retry limit'
+        )
+    }
 
     // Accumulate the directions each cell needs in the solved state.
     const required: Map<string, Set<Direction>> = new Map()

--- a/src/lib/games/circuit-hacker/generator.ts
+++ b/src/lib/games/circuit-hacker/generator.ts
@@ -6,7 +6,12 @@ import type {
     Tile,
     TileType,
 } from './types'
-import { DELTA, getBaseConnectors, rotateConnectors } from './utils'
+import {
+    DELTA,
+    computePoweredCells,
+    getBaseConnectors,
+    rotateConnectors,
+} from './utils'
 
 export interface GeneratedPuzzle {
     grid: Tile[][]
@@ -374,6 +379,16 @@ function tryGenerate(
                 grid[r][c].orientation = Math.floor(rng() * 4)
             }
         }
+    }
+
+    // Defensive re-scramble guard: if the random scramble happened to leave
+    // every core powered, the puzzle would be trivially pre-solved. The
+    // probability is astronomically low (~1/4^rotatableTiles), but returning
+    // null here routes it back through the retry loop for an airtight
+    // guarantee rather than emitting a no-op board.
+    const powered = computePoweredCells(grid, sourcePos)
+    if (corePositions.every(c => powered[c.row][c.col])) {
+        return null
     }
 
     return { grid, sourcePos, corePositions, solutionOrientations }

--- a/src/lib/games/circuit-hacker/init.test.ts
+++ b/src/lib/games/circuit-hacker/init.test.ts
@@ -214,4 +214,133 @@ describe('initializeCircuitHackerGame', () => {
         expect(onError.mock.calls[0][1]).toContain('not logged in')
         handle.cleanup()
     })
+
+    it('cleans up the previous game when start is called again', async () => {
+        const container = setupDom()
+        const handle = await initializeCircuitHackerGame(container, {
+            onTimeUpdate: vi.fn(),
+            onRotation: vi.fn(),
+            onStart: vi.fn(),
+            onEnd: vi.fn(),
+        })
+        await handle.start('easy')
+        const firstGame = handle.getGame()
+        expect(firstGame).not.toBeNull()
+        // Restart with a different difficulty; the previous game must be
+        // cleaned up and a fresh one created.
+        await handle.start('medium')
+        const secondGame = handle.getGame()
+        expect(secondGame).not.toBe(firstGame)
+        expect(secondGame?.getState().rows).toBe(7) // medium is 7x7
+        handle.cleanup()
+    })
+
+    it('rotates a tile when the canvas receives a pointerdown', async () => {
+        const container = setupDom()
+        const onRotation = vi.fn()
+        const handle = await initializeCircuitHackerGame(container, {
+            onTimeUpdate: vi.fn(),
+            onRotation,
+            onStart: vi.fn(),
+            onEnd: vi.fn(),
+        })
+        await handle.start('easy')
+        const game = handle.getGame()!
+        const state = game.getState()
+        // Find an unlocked tile to target
+        let target: { row: number; col: number } | null = null
+        outer: for (let r = 0; r < state.rows; r++) {
+            for (let c = 0; c < state.cols; c++) {
+                if (!state.grid[r][c].locked) {
+                    target = { row: r, col: c }
+                    break outer
+                }
+            }
+        }
+        expect(target).not.toBeNull()
+        const canvas = container.querySelector('canvas') as HTMLCanvasElement
+        // Mock canvas getBoundingClientRect returns { left: 0, top: 0,
+        // width: 240, height: 240 }. Easy is 5x5 at CELL_SIZE=48 => 240x240,
+        // so scale = 1. Click at the cell's centre.
+        const x = target!.col * 48 + 24
+        const y = target!.row * 48 + 24
+        const before = state.grid[target!.row][target!.col].orientation
+        canvas.dispatchEvent(
+            new MouseEvent('pointerdown', { clientX: x, clientY: y })
+        )
+        expect(game.getState().grid[target!.row][target!.col].orientation).toBe(
+            (before + 1) % 4
+        )
+        expect(onRotation).toHaveBeenCalledWith(1)
+        handle.cleanup()
+    })
+
+    it('dispatches achievementsEarned event when saveGameScore returns new achievements', async () => {
+        const container = setupDom()
+        const achievementSpy = vi.fn()
+        window.addEventListener('achievementsEarned', achievementSpy)
+        saveGameScore.mockImplementationOnce(
+            async (
+                _gameId: unknown,
+                _score: unknown,
+                onResult: (result: { newAchievements?: string[] }) => void
+            ) => {
+                onResult({ newAchievements: ['ach-1', 'ach-2'] })
+                return undefined
+            }
+        )
+        const handle = await initializeCircuitHackerGame(container, {
+            onTimeUpdate: vi.fn(),
+            onRotation: vi.fn(),
+            onStart: vi.fn(),
+            onEnd: vi.fn(),
+        })
+        await handle.start('easy')
+        solveGameForTest(handle.getGame()!)
+        await vi.runAllTimersAsync()
+        expect(achievementSpy).toHaveBeenCalledTimes(1)
+        const event = achievementSpy.mock.calls[0][0] as CustomEvent
+        expect(event.detail.achievementIds).toEqual(['ach-1', 'ach-2'])
+        window.removeEventListener('achievementsEarned', achievementSpy)
+        handle.cleanup()
+    })
+
+    it('surfaces string errors from saveGameScore rejection via onError', async () => {
+        const container = setupDom()
+        const onError = vi.fn()
+        saveGameScore.mockRejectedValueOnce('string error')
+        const handle = await initializeCircuitHackerGame(container, {
+            onTimeUpdate: vi.fn(),
+            onRotation: vi.fn(),
+            onStart: vi.fn(),
+            onEnd: vi.fn(),
+            onError,
+        })
+        await handle.start('easy')
+        solveGameForTest(handle.getGame()!)
+        await vi.runAllTimersAsync()
+        expect(onError).toHaveBeenCalledTimes(1)
+        expect(onError.mock.calls[0][1]).toContain('string error')
+        handle.cleanup()
+    })
+
+    it('surfaces unknown error type from saveGameScore rejection via onError', async () => {
+        const container = setupDom()
+        const onError = vi.fn()
+        // Neither Error nor string — triggers the "Unknown error" fallback
+        saveGameScore.mockRejectedValueOnce(42)
+        const handle = await initializeCircuitHackerGame(container, {
+            onTimeUpdate: vi.fn(),
+            onRotation: vi.fn(),
+            onStart: vi.fn(),
+            onEnd: vi.fn(),
+            onError,
+        })
+        await handle.start('easy')
+        solveGameForTest(handle.getGame()!)
+        await vi.runAllTimersAsync()
+        expect(onError).toHaveBeenCalledTimes(1)
+        expect(onError.mock.calls[0][1]).toContain('Unknown error')
+        handle.cleanup()
+    })
 })

--- a/src/lib/games/circuit-hacker/init.test.ts
+++ b/src/lib/games/circuit-hacker/init.test.ts
@@ -122,4 +122,46 @@ describe('initializeCircuitHackerGame', () => {
         expect(saveGameScore).not.toHaveBeenCalled()
         handle.cleanup()
     })
+
+    it('shows "GAME OVER" overlay and does not submit on manual stop', async () => {
+        const onEnd = vi.fn()
+        const container = setupDom()
+        const handle = await initializeCircuitHackerGame(container, {
+            onTimeUpdate: vi.fn(),
+            onRotation: vi.fn(),
+            onStart: vi.fn(),
+            onEnd,
+        })
+        await handle.start('easy')
+        handle.stop()
+        await vi.runAllTimersAsync()
+        expect(saveGameScore).not.toHaveBeenCalled()
+        expect(onEnd).toHaveBeenCalledTimes(1)
+        const titleEl = document.getElementById('game-over-title')
+        expect(titleEl?.textContent).toBe('GAME OVER')
+        const overlay = document.getElementById('game-over-overlay')
+        expect(overlay?.classList.contains('hidden')).toBe(false)
+        // Button state reset: start visible, stop hidden
+        const startBtn = document.getElementById('start-btn') as HTMLElement
+        const stopBtn = document.getElementById('stop-btn') as HTMLElement
+        expect(startBtn.style.display).toBe('inline-flex')
+        expect(stopBtn.style.display).toBe('none')
+        handle.cleanup()
+    })
+
+    it('shows "TIME\'S UP!" overlay on timeout failure', async () => {
+        const container = setupDom()
+        const handle = await initializeCircuitHackerGame(container, {
+            onTimeUpdate: vi.fn(),
+            onRotation: vi.fn(),
+            onStart: vi.fn(),
+            onEnd: vi.fn(),
+        })
+        await handle.start('easy')
+        vi.advanceTimersByTime(121_000)
+        await vi.runAllTimersAsync()
+        const titleEl = document.getElementById('game-over-title')
+        expect(titleEl?.textContent).toBe("TIME'S UP!")
+        handle.cleanup()
+    })
 })

--- a/src/lib/games/circuit-hacker/init.test.ts
+++ b/src/lib/games/circuit-hacker/init.test.ts
@@ -49,6 +49,7 @@ vi.mock('@/lib/services/scoreService', () => ({
 
 import { initializeCircuitHackerGame } from './init'
 import { GameID } from '@/lib/games'
+import { solveGameForTest } from './test-utils'
 
 function setupDom(): HTMLElement {
     document.body.innerHTML = `
@@ -96,9 +97,7 @@ describe('initializeCircuitHackerGame', () => {
         })
         await handle.start('easy')
         // Force a solve via the game's test helper
-        ;(
-            handle.getGame() as unknown as { solveForTest: () => void }
-        ).solveForTest()
+        solveGameForTest(handle.getGame()!)
         await vi.runAllTimersAsync()
         expect(saveGameScore).toHaveBeenCalledTimes(1)
         const [gameId, score, , , gameData] = saveGameScore.mock.calls[0]
@@ -162,6 +161,59 @@ describe('initializeCircuitHackerGame', () => {
         await vi.runAllTimersAsync()
         const titleEl = document.getElementById('game-over-title')
         expect(titleEl?.textContent).toBe("TIME'S UP!")
+        handle.cleanup()
+    })
+
+    it('surfaces score-save failure via onError instead of console.error', async () => {
+        const container = setupDom()
+        const onError = vi.fn()
+        saveGameScore.mockRejectedValueOnce(new Error('network down'))
+        const handle = await initializeCircuitHackerGame(container, {
+            onTimeUpdate: vi.fn(),
+            onRotation: vi.fn(),
+            onStart: vi.fn(),
+            onEnd: vi.fn(),
+            onError,
+        })
+        await handle.start('easy')
+        solveGameForTest(handle.getGame()!)
+        await vi.runAllTimersAsync()
+        expect(onError).toHaveBeenCalledTimes(1)
+        const [title, message] = onError.mock.calls[0]
+        expect(title).toBe('Score Not Saved')
+        expect(message).toContain('network down')
+        handle.cleanup()
+    })
+
+    it('surfaces score-save error-callback via onError', async () => {
+        const container = setupDom()
+        const onError = vi.fn()
+        // saveGameScore resolves but invokes its error callback (e.g. 401).
+        // The real onError callback receives a string, not an Error.
+        saveGameScore.mockImplementationOnce(
+            async (
+                _gameId: unknown,
+                _score: unknown,
+                _onResult: unknown,
+                onErrorCb: (e: string) => void
+            ) => {
+                onErrorCb('not logged in')
+                return undefined
+            }
+        )
+        const handle = await initializeCircuitHackerGame(container, {
+            onTimeUpdate: vi.fn(),
+            onRotation: vi.fn(),
+            onStart: vi.fn(),
+            onEnd: vi.fn(),
+            onError,
+        })
+        await handle.start('easy')
+        solveGameForTest(handle.getGame()!)
+        await vi.runAllTimersAsync()
+        expect(onError).toHaveBeenCalledTimes(1)
+        expect(onError.mock.calls[0][0]).toBe('Score Not Saved')
+        expect(onError.mock.calls[0][1]).toContain('not logged in')
         handle.cleanup()
     })
 })

--- a/src/lib/games/circuit-hacker/init.test.ts
+++ b/src/lib/games/circuit-hacker/init.test.ts
@@ -1,0 +1,125 @@
+// src/lib/games/circuit-hacker/init.test.ts
+import { describe, it, expect, vi, beforeEach, afterEach } from 'vitest'
+
+vi.mock('pixi.js', () => {
+    const makeGraphics = () => {
+        const g: Record<string, unknown> = { alpha: 1, x: 0, y: 0 }
+        for (const m of [
+            'clear',
+            'rect',
+            'fill',
+            'stroke',
+            'circle',
+            'moveTo',
+            'lineTo',
+            'roundRect',
+        ]) {
+            g[m] = vi.fn(() => g)
+        }
+        g['destroy'] = vi.fn()
+        return g
+    }
+    const makeApp = () => {
+        const canvas = document.createElement('canvas')
+        Object.defineProperty(canvas, 'style', {
+            value: { border: '', borderRadius: '', boxShadow: '' },
+            writable: true,
+        })
+        // getBoundingClientRect is used to translate pointer coords
+        canvas.getBoundingClientRect = () =>
+            ({ left: 0, top: 0, width: 240, height: 240 }) as DOMRect
+        return {
+            init: vi.fn().mockResolvedValue(undefined),
+            canvas,
+            stage: { addChild: vi.fn() },
+            destroy: vi.fn(),
+        }
+    }
+    return {
+        Application: vi.fn(makeApp),
+        Container: vi.fn(() => ({ addChild: vi.fn(), destroy: vi.fn() })),
+        Graphics: vi.fn(makeGraphics),
+    }
+})
+
+const saveGameScore = vi.fn().mockResolvedValue(undefined)
+vi.mock('@/lib/services/scoreService', () => ({
+    saveGameScore: (...args: unknown[]) => saveGameScore(...args),
+}))
+
+import { initializeCircuitHackerGame } from './init'
+import { GameID } from '@/lib/games'
+
+function setupDom(): HTMLElement {
+    document.body.innerHTML = `
+        <div id="game-canvas-container"></div>
+        <span id="final-score">0</span>
+        <span id="final-time">0</span>
+        <span id="final-rotations">0</span>
+        <span id="game-over-title"></span>
+        <div id="game-over-overlay" class="hidden"></div>
+        <button id="start-btn"></button>
+        <button id="stop-btn" style="display:none"></button>
+    `
+    return document.getElementById('game-canvas-container') as HTMLElement
+}
+
+describe('initializeCircuitHackerGame', () => {
+    beforeEach(() => {
+        vi.useFakeTimers()
+        saveGameScore.mockClear()
+    })
+    afterEach(() => vi.useRealTimers())
+
+    it('starts a game of the chosen difficulty', async () => {
+        const container = setupDom()
+        const onStart = vi.fn()
+        const handle = await initializeCircuitHackerGame(container, {
+            onTimeUpdate: vi.fn(),
+            onRotation: vi.fn(),
+            onStart,
+            onEnd: vi.fn(),
+        })
+        await handle.start('easy')
+        expect(onStart).toHaveBeenCalled()
+        expect(handle.getGame()?.getState().rows).toBe(5)
+        handle.cleanup()
+    })
+
+    it('submits the score with gameData when solved', async () => {
+        const container = setupDom()
+        const handle = await initializeCircuitHackerGame(container, {
+            onTimeUpdate: vi.fn(),
+            onRotation: vi.fn(),
+            onStart: vi.fn(),
+            onEnd: vi.fn(),
+        })
+        await handle.start('easy')
+        // Force a solve via the game's test helper
+        ;(
+            handle.getGame() as unknown as { solveForTest: () => void }
+        ).solveForTest()
+        await vi.runAllTimersAsync()
+        expect(saveGameScore).toHaveBeenCalledTimes(1)
+        const [gameId, score, , , gameData] = saveGameScore.mock.calls[0]
+        expect(gameId).toBe(GameID.CIRCUIT_HACKER)
+        expect(score).toBeGreaterThan(0)
+        expect(gameData).toMatchObject({ difficulty: 'easy', solved: true })
+        handle.cleanup()
+    })
+
+    it('does not submit a score when the run fails', async () => {
+        const container = setupDom()
+        const handle = await initializeCircuitHackerGame(container, {
+            onTimeUpdate: vi.fn(),
+            onRotation: vi.fn(),
+            onStart: vi.fn(),
+            onEnd: vi.fn(),
+        })
+        await handle.start('easy')
+        vi.advanceTimersByTime(121_000)
+        await vi.runAllTimersAsync()
+        expect(saveGameScore).not.toHaveBeenCalled()
+        handle.cleanup()
+    })
+})

--- a/src/lib/games/circuit-hacker/init.test.ts
+++ b/src/lib/games/circuit-hacker/init.test.ts
@@ -50,6 +50,7 @@ vi.mock('@/lib/services/scoreService', () => ({
 import { initializeCircuitHackerGame } from './init'
 import { GameID } from '@/lib/games'
 import { solveGameForTest } from './test-utils'
+import { screen } from '@testing-library/dom'
 
 function setupDom(): HTMLElement {
     document.body.innerHTML = `
@@ -58,9 +59,9 @@ function setupDom(): HTMLElement {
         <span id="final-time">0</span>
         <span id="final-rotations">0</span>
         <span id="game-over-title"></span>
-        <div id="game-over-overlay" class="hidden"></div>
-        <button id="start-btn"></button>
-        <button id="stop-btn" style="display:none"></button>
+        <div id="game-over-overlay" class="hidden" data-testid="game-over-overlay"></div>
+        <button id="start-btn" data-testid="start-btn"></button>
+        <button id="stop-btn" style="display:none" data-testid="stop-btn"></button>
     `
     return document.getElementById('game-canvas-container') as HTMLElement
 }
@@ -136,15 +137,13 @@ describe('initializeCircuitHackerGame', () => {
         await vi.runAllTimersAsync()
         expect(saveGameScore).not.toHaveBeenCalled()
         expect(onEnd).toHaveBeenCalledTimes(1)
-        const titleEl = document.getElementById('game-over-title')
-        expect(titleEl?.textContent).toBe('GAME OVER')
-        const overlay = document.getElementById('game-over-overlay')
-        expect(overlay?.classList.contains('hidden')).toBe(false)
+        expect(screen.getByText('GAME OVER')).toBeInTheDocument()
+        expect(screen.getByTestId('game-over-overlay')).not.toHaveClass(
+            'hidden'
+        )
         // Button state reset: start visible, stop hidden
-        const startBtn = document.getElementById('start-btn') as HTMLElement
-        const stopBtn = document.getElementById('stop-btn') as HTMLElement
-        expect(startBtn.style.display).toBe('inline-flex')
-        expect(stopBtn.style.display).toBe('none')
+        expect(screen.getByTestId('start-btn')).toBeVisible()
+        expect(screen.getByTestId('stop-btn')).not.toBeVisible()
         handle.cleanup()
     })
 
@@ -159,8 +158,7 @@ describe('initializeCircuitHackerGame', () => {
         await handle.start('easy')
         vi.advanceTimersByTime(121_000)
         await vi.runAllTimersAsync()
-        const titleEl = document.getElementById('game-over-title')
-        expect(titleEl?.textContent).toBe("TIME'S UP!")
+        expect(screen.getByText("TIME'S UP!")).toBeInTheDocument()
         handle.cleanup()
     })
 

--- a/src/lib/games/circuit-hacker/init.ts
+++ b/src/lib/games/circuit-hacker/init.ts
@@ -19,6 +19,11 @@ export interface CircuitHackerUICallbacks {
     onRotation: (rotationsUsed: number) => void
     onStart: () => void
     onEnd: (stats: CircuitHackerStats) => void
+    // Surfaces non-fatal failures (e.g. score submission rejected by the
+    // server) to the page so the player is informed rather than seeing a
+    // misleading success overlay. Fatal failures (start/load) still throw
+    // and are caught by the page's try/catch.
+    onError?: (title: string, message: string) => void
 }
 
 export interface CircuitHackerHandle {
@@ -114,32 +119,53 @@ export async function initializeCircuitHackerGame(
                     resetButtons()
                     showOverlay('CIRCUIT POWERED!', stats)
                     callbacks.onEnd(stats)
-                    await saveGameScore(
-                        GameID.CIRCUIT_HACKER,
-                        finalScore,
-                        result => {
-                            if (result.newAchievements?.length) {
-                                window.dispatchEvent(
-                                    new CustomEvent('achievementsEarned', {
-                                        detail: {
-                                            achievementIds:
-                                                result.newAchievements,
-                                        },
-                                    })
-                                )
+                    const surfaceError = (message: string) => {
+                        callbacks.onError?.(
+                            'Score Not Saved',
+                            `Your win was recorded locally but could not be submitted: ${message}`
+                        )
+                    }
+                    try {
+                        await saveGameScore(
+                            GameID.CIRCUIT_HACKER,
+                            finalScore,
+                            result => {
+                                if (result.newAchievements?.length) {
+                                    window.dispatchEvent(
+                                        new CustomEvent('achievementsEarned', {
+                                            detail: {
+                                                achievementIds:
+                                                    result.newAchievements,
+                                            },
+                                        })
+                                    )
+                                }
+                            },
+                            error => {
+                                // Surface to the player via the page's
+                                // error UI rather than only console.error.
+                                // The win itself still stands; only the
+                                // score submission failed.
+                                surfaceError(error)
+                            },
+                            {
+                                difficulty: stats.difficulty,
+                                secondsRemaining: stats.secondsRemaining,
+                                rotationsUsed: stats.rotationsUsed,
+                                solved: stats.solved,
                             }
-                        },
-                        error => {
-                            // eslint-disable-next-line no-console
-                            console.error('Failed to submit score:', error)
-                        },
-                        {
-                            difficulty: stats.difficulty,
-                            secondsRemaining: stats.secondsRemaining,
-                            rotationsUsed: stats.rotationsUsed,
-                            solved: stats.solved,
-                        }
-                    )
+                        )
+                    } catch (error) {
+                        // saveGameScore threw synchronously (e.g. network
+                        // unreachable). Mirror the error-callback path.
+                        const message =
+                            error instanceof Error
+                                ? error.message
+                                : typeof error === 'string'
+                                  ? error
+                                  : 'Unknown error'
+                        surfaceError(message)
+                    }
                 },
                 onFail: (stats, reason) => {
                     render()

--- a/src/lib/games/circuit-hacker/init.ts
+++ b/src/lib/games/circuit-hacker/init.ts
@@ -1,0 +1,182 @@
+// src/lib/games/circuit-hacker/init.ts
+import { CircuitHackerGame } from './game'
+import {
+    setupPixiJS,
+    renderGrid,
+    pointerToCell,
+    cleanup as rendererCleanup,
+    type RendererState,
+} from './renderer'
+import { DIFFICULTY_CONFIGS } from './utils'
+import type { Difficulty, CircuitHackerStats } from './types'
+import { saveGameScore } from '@/lib/services/scoreService'
+import { GameID } from '@/lib/games'
+
+export const CELL_SIZE = 48
+
+export interface CircuitHackerUICallbacks {
+    onTimeUpdate: (timeRemaining: number) => void
+    onRotation: (rotationsUsed: number) => void
+    onStart: () => void
+    onEnd: (stats: CircuitHackerStats) => void
+}
+
+export interface CircuitHackerHandle {
+    start: (difficulty: Difficulty) => Promise<void>
+    stop: () => void
+    cleanup: () => void
+    getGame: () => CircuitHackerGame | null
+}
+
+function setText(id: string, value: string): void {
+    const el = document.getElementById(id)
+    if (el) {
+        el.textContent = value
+    }
+}
+
+function resetButtons(): void {
+    const startBtn = document.getElementById('start-btn')
+    const stopBtn = document.getElementById('stop-btn')
+    if (startBtn) {
+        startBtn.style.display = 'inline-flex'
+    }
+    if (stopBtn) {
+        stopBtn.style.display = 'none'
+    }
+}
+
+function showOverlay(title: string, stats: CircuitHackerStats): void {
+    setText('game-over-title', title)
+    setText('final-score', stats.finalScore.toString())
+    setText('final-time', `${stats.secondsRemaining}s`)
+    setText('final-rotations', stats.rotationsUsed.toString())
+    const overlay = document.getElementById('game-over-overlay')
+    if (overlay) {
+        overlay.classList.remove('hidden')
+    }
+}
+
+export async function initializeCircuitHackerGame(
+    container: HTMLElement,
+    callbacks: CircuitHackerUICallbacks
+): Promise<CircuitHackerHandle> {
+    let game: CircuitHackerGame | null = null
+    let renderer: RendererState | null = null
+    let pointerHandler: ((event: PointerEvent) => void) | null = null
+
+    const teardownRenderer = () => {
+        if (renderer && pointerHandler) {
+            renderer.app.canvas.removeEventListener(
+                'pointerdown',
+                pointerHandler
+            )
+        }
+        if (renderer) {
+            rendererCleanup(renderer)
+            renderer = null
+        }
+        pointerHandler = null
+        container.innerHTML = ''
+    }
+
+    const render = () => {
+        if (renderer && game) {
+            renderGrid(renderer, game.getState(), CELL_SIZE)
+        }
+    }
+
+    const start = async (difficulty: Difficulty): Promise<void> => {
+        if (game) {
+            game.cleanup()
+        }
+        teardownRenderer()
+
+        const tier = DIFFICULTY_CONFIGS[difficulty]
+        renderer = await setupPixiJS(container, tier.rows, tier.cols, CELL_SIZE)
+
+        game = new CircuitHackerGame(
+            { difficulty, cellSize: CELL_SIZE },
+            {
+                onGameStart: () => {
+                    callbacks.onStart()
+                    render()
+                },
+                onTimeUpdate: t => callbacks.onTimeUpdate(t),
+                onRotation: n => {
+                    callbacks.onRotation(n)
+                    render()
+                },
+                onSolved: async (finalScore, stats) => {
+                    render()
+                    resetButtons()
+                    showOverlay('CIRCUIT POWERED!', stats)
+                    callbacks.onEnd(stats)
+                    await saveGameScore(
+                        GameID.CIRCUIT_HACKER,
+                        finalScore,
+                        result => {
+                            if (result.newAchievements?.length) {
+                                window.dispatchEvent(
+                                    new CustomEvent('achievementsEarned', {
+                                        detail: {
+                                            achievementIds:
+                                                result.newAchievements,
+                                        },
+                                    })
+                                )
+                            }
+                        },
+                        error => {
+                            // eslint-disable-next-line no-console
+                            console.error('Failed to submit score:', error)
+                        },
+                        {
+                            difficulty: stats.difficulty,
+                            secondsRemaining: stats.secondsRemaining,
+                            rotationsUsed: stats.rotationsUsed,
+                            solved: stats.solved,
+                        }
+                    )
+                },
+                onFail: stats => {
+                    render()
+                    resetButtons()
+                    showOverlay("TIME'S UP!", stats)
+                    callbacks.onEnd(stats)
+                },
+            }
+        )
+
+        pointerHandler = (event: PointerEvent) => {
+            if (!renderer || !game) {
+                return
+            }
+            const rect = renderer.app.canvas.getBoundingClientRect()
+            const scaleX = rect.width / (tier.cols * CELL_SIZE)
+            const scaleY = rect.height / (tier.rows * CELL_SIZE)
+            const x = (event.clientX - rect.left) / scaleX
+            const y = (event.clientY - rect.top) / scaleY
+            const cell = pointerToCell(x, y, CELL_SIZE, tier.rows, tier.cols)
+            if (cell) {
+                game.rotateTile(cell.row, cell.col)
+            }
+        }
+        renderer.app.canvas.addEventListener('pointerdown', pointerHandler)
+
+        game.startGame()
+        render()
+    }
+
+    const stop = () => {
+        game?.stopGame()
+    }
+
+    const cleanup = () => {
+        game?.cleanup()
+        game = null
+        teardownRenderer()
+    }
+
+    return { start, stop, cleanup, getGame: () => game }
+}

--- a/src/lib/games/circuit-hacker/init.ts
+++ b/src/lib/games/circuit-hacker/init.ts
@@ -139,10 +139,13 @@ export async function initializeCircuitHackerGame(
                         }
                     )
                 },
-                onFail: stats => {
+                onFail: (stats, reason) => {
                     render()
                     resetButtons()
-                    showOverlay("TIME'S UP!", stats)
+                    showOverlay(
+                        reason === 'manual' ? 'GAME OVER' : "TIME'S UP!",
+                        stats
+                    )
                     callbacks.onEnd(stats)
                 },
             }

--- a/src/lib/games/circuit-hacker/init.ts
+++ b/src/lib/games/circuit-hacker/init.ts
@@ -181,8 +181,12 @@ export async function initializeCircuitHackerGame(
 
         pointerHandler = (event: PointerEvent) => {
             if (!renderer || !game) {
+                /* c8 ignore start -- defensive: listener is removed before
+                   renderer/game are nulled, so this guard is never reached
+                   in normal flow */
                 return
             }
+            /* c8 ignore end */
             const rect = renderer.app.canvas.getBoundingClientRect()
             const scaleX = rect.width / (tier.cols * CELL_SIZE)
             const scaleY = rect.height / (tier.rows * CELL_SIZE)

--- a/src/lib/games/circuit-hacker/init.ts
+++ b/src/lib/games/circuit-hacker/init.ts
@@ -77,7 +77,9 @@ export async function initializeCircuitHackerGame(
             renderer = null
         }
         pointerHandler = null
-        container.innerHTML = ''
+        while (container.firstChild) {
+            container.removeChild(container.firstChild)
+        }
     }
 
     const render = () => {

--- a/src/lib/games/circuit-hacker/renderer.test.ts
+++ b/src/lib/games/circuit-hacker/renderer.test.ts
@@ -1,5 +1,5 @@
 // src/lib/games/circuit-hacker/renderer.test.ts
-import { describe, it, expect, vi, beforeEach } from 'vitest'
+import { describe, it, expect, vi, beforeEach, afterEach } from 'vitest'
 
 vi.mock('pixi.js', () => {
     const makeGraphics = () => {
@@ -55,6 +55,10 @@ describe('circuit-hacker renderer', () => {
     beforeEach(() => {
         container = document.createElement('div')
         document.body.appendChild(container)
+    })
+
+    afterEach(() => {
+        container.remove()
     })
 
     it('initializes a PixiJS app sized to the grid', async () => {

--- a/src/lib/games/circuit-hacker/renderer.test.ts
+++ b/src/lib/games/circuit-hacker/renderer.test.ts
@@ -39,6 +39,7 @@ vi.mock('pixi.js', () => {
     }
 })
 
+import { Application } from 'pixi.js'
 import { setupPixiJS, renderGrid, pointerToCell, cleanup } from './renderer'
 import type { CircuitHackerState, Tile } from './types'
 
@@ -95,5 +96,39 @@ describe('circuit-hacker renderer', () => {
         expect(rs.tileGraphic.clear).toHaveBeenCalled()
         cleanup(rs)
         expect(rs.app.destroy).toHaveBeenCalled()
+    })
+
+    it('throws a wrapped error and cleans the container when PixiJS init fails', async () => {
+        // Append a dummy child to verify the catch block clears the container
+        container.appendChild(document.createElement('div'))
+        vi.mocked(Application).mockImplementationOnce(() => {
+            throw new Error('pixi exploded')
+        })
+        await expect(setupPixiJS(container, 1, 1, 48)).rejects.toThrow(
+            'Failed to initialize PixiJS'
+        )
+        // The catch block removes all children from the container
+        expect(container.children).toHaveLength(0)
+    })
+
+    it('renders a blocker tile without throwing', async () => {
+        const rs = await setupPixiJS(container, 1, 2, 48)
+        const state = {
+            grid: [[tile({ type: 'blocker', locked: true }), tile()]],
+            sourcePos: { row: 0, col: 0 },
+            corePositions: [],
+            rows: 1,
+            cols: 2,
+            score: 0,
+            timeRemaining: 10,
+            rotationsUsed: 0,
+            isGameActive: true,
+            isGameOver: false,
+            solved: false,
+        } as CircuitHackerState
+        expect(() => renderGrid(rs, state, 48)).not.toThrow()
+        // COLOR_BLOCKER = 0x1e293b; the blocker fill call uses it directly
+        expect(rs.tileGraphic.fill).toHaveBeenCalledWith(0x1e293b)
+        cleanup(rs)
     })
 })

--- a/src/lib/games/circuit-hacker/renderer.test.ts
+++ b/src/lib/games/circuit-hacker/renderer.test.ts
@@ -1,0 +1,95 @@
+// src/lib/games/circuit-hacker/renderer.test.ts
+import { describe, it, expect, vi, beforeEach } from 'vitest'
+
+vi.mock('pixi.js', () => {
+    const makeGraphics = () => {
+        const g: Record<string, unknown> = { alpha: 1, x: 0, y: 0 }
+        for (const m of [
+            'clear',
+            'rect',
+            'fill',
+            'stroke',
+            'circle',
+            'moveTo',
+            'lineTo',
+            'roundRect',
+        ]) {
+            g[m] = vi.fn(() => g)
+        }
+        g['destroy'] = vi.fn()
+        return g
+    }
+    const makeApp = () => {
+        const canvas = document.createElement('canvas')
+        Object.defineProperty(canvas, 'style', {
+            value: { border: '', borderRadius: '', boxShadow: '' },
+            writable: true,
+        })
+        return {
+            init: vi.fn().mockResolvedValue(undefined),
+            canvas,
+            stage: { addChild: vi.fn() },
+            destroy: vi.fn(),
+        }
+    }
+    return {
+        Application: vi.fn(makeApp),
+        Container: vi.fn(() => ({ addChild: vi.fn(), destroy: vi.fn() })),
+        Graphics: vi.fn(makeGraphics),
+    }
+})
+
+import { setupPixiJS, renderGrid, pointerToCell, cleanup } from './renderer'
+import type { CircuitHackerState, Tile } from './types'
+
+const tile = (over: Partial<Tile> = {}): Tile => ({
+    type: 'straight',
+    orientation: 0,
+    locked: false,
+    powered: false,
+    ...over,
+})
+
+describe('circuit-hacker renderer', () => {
+    let container: HTMLElement
+    beforeEach(() => {
+        container = document.createElement('div')
+        document.body.appendChild(container)
+    })
+
+    it('initializes a PixiJS app sized to the grid', async () => {
+        const rs = await setupPixiJS(container, 5, 5, 48)
+        expect(rs.app.init).toHaveBeenCalledWith(
+            expect.objectContaining({ width: 240, height: 240 })
+        )
+        expect(container.contains(rs.app.canvas)).toBe(true)
+    })
+
+    it('maps pointer coordinates to a cell', () => {
+        expect(pointerToCell(10, 10, 48, 5, 5)).toEqual({ row: 0, col: 0 })
+        expect(pointerToCell(100, 50, 48, 5, 5)).toEqual({ row: 1, col: 2 })
+        expect(pointerToCell(-5, 10, 48, 5, 5)).toBeNull()
+        expect(pointerToCell(10, 9999, 48, 5, 5)).toBeNull()
+    })
+
+    it('renders without throwing', async () => {
+        const rs = await setupPixiJS(container, 1, 2, 48)
+        const state = {
+            grid: [[tile({ type: 'source', locked: true }), tile()]],
+            sourcePos: { row: 0, col: 0 },
+            corePositions: [],
+            rows: 1,
+            cols: 2,
+            score: 0,
+            timeRemaining: 10,
+            rotationsUsed: 0,
+            isGameActive: true,
+            isGameOver: false,
+            solved: false,
+        } as CircuitHackerState
+        expect(() => renderGrid(rs, state, 48)).not.toThrow()
+        expect(rs.tileGraphic.clear).toHaveBeenCalled()
+        cleanup(rs)
+        expect(rs.app.destroy).toHaveBeenCalled()
+    })
+})

--- a/src/lib/games/circuit-hacker/renderer.ts
+++ b/src/lib/games/circuit-hacker/renderer.ts
@@ -37,6 +37,7 @@ export async function setupPixiJS(
         app.canvas.style.border = '2px solid rgba(6, 182, 212, 0.3)'
         app.canvas.style.borderRadius = '12px'
         app.canvas.style.boxShadow = '0 0 30px rgba(6, 182, 212, 0.3)'
+        app.canvas.style.touchAction = 'none'
 
         const tileGraphic = new Graphics()
         app.stage.addChild(tileGraphic)

--- a/src/lib/games/circuit-hacker/renderer.ts
+++ b/src/lib/games/circuit-hacker/renderer.ts
@@ -38,6 +38,12 @@ export async function setupPixiJS(
         app.canvas.style.borderRadius = '12px'
         app.canvas.style.boxShadow = '0 0 30px rgba(6, 182, 212, 0.3)'
         app.canvas.style.touchAction = 'none'
+        // Responsive scaling: keep the PixiJS resolution at cols*cellSize but
+        // let the browser shrink the displayed canvas to fit narrow viewports.
+        // Pointer math in init.ts uses getBoundingClientRect(), so CSS scaling
+        // stays in sync without coordinate changes.
+        app.canvas.style.maxWidth = '100%'
+        app.canvas.style.height = 'auto'
 
         const tileGraphic = new Graphics()
         app.stage.addChild(tileGraphic)

--- a/src/lib/games/circuit-hacker/renderer.ts
+++ b/src/lib/games/circuit-hacker/renderer.ts
@@ -44,7 +44,9 @@ export async function setupPixiJS(
 
         return { app, tileGraphic }
     } catch (error) {
-        container.innerHTML = ''
+        while (container.firstChild) {
+            container.removeChild(container.firstChild)
+        }
         throw new Error(`Failed to initialize PixiJS: ${error}`)
     }
 }

--- a/src/lib/games/circuit-hacker/renderer.ts
+++ b/src/lib/games/circuit-hacker/renderer.ts
@@ -1,0 +1,145 @@
+// src/lib/games/circuit-hacker/renderer.ts
+import { Application, Graphics } from 'pixi.js'
+import type { CircuitHackerState, Direction, GridPosition, Tile } from './types'
+import { getConnectors } from './utils'
+
+export interface RendererState {
+    app: Application
+    tileGraphic: Graphics
+}
+
+const BACKGROUND = '#000a14'
+const COLOR_WIRE_OFF = 0x335577
+const COLOR_WIRE_ON = 0x22d3ee
+const COLOR_SOURCE = 0x22c55e
+const COLOR_CORE_OFF = 0x9333ea
+const COLOR_CORE_ON = 0xf472b6
+const COLOR_BLOCKER = 0x1e293b
+
+export async function setupPixiJS(
+    container: HTMLElement,
+    rows: number,
+    cols: number,
+    cellSize: number
+): Promise<RendererState> {
+    try {
+        const app = new Application()
+        await app.init({
+            width: cols * cellSize,
+            height: rows * cellSize,
+            backgroundColor: BACKGROUND,
+            antialias: true,
+            resolution: window.devicePixelRatio || 1,
+            autoDensity: true,
+        })
+
+        container.appendChild(app.canvas)
+        app.canvas.style.border = '2px solid rgba(6, 182, 212, 0.3)'
+        app.canvas.style.borderRadius = '12px'
+        app.canvas.style.boxShadow = '0 0 30px rgba(6, 182, 212, 0.3)'
+
+        const tileGraphic = new Graphics()
+        app.stage.addChild(tileGraphic)
+
+        return { app, tileGraphic }
+    } catch (error) {
+        container.innerHTML = ''
+        throw new Error(`Failed to initialize PixiJS: ${error}`)
+    }
+}
+
+function dirOffset(dir: Direction): { dx: number; dy: number } {
+    switch (dir) {
+        case 'N':
+            return { dx: 0, dy: -1 }
+        case 'S':
+            return { dx: 0, dy: 1 }
+        case 'E':
+            return { dx: 1, dy: 0 }
+        case 'W':
+            return { dx: -1, dy: 0 }
+    }
+}
+
+function drawTile(
+    g: Graphics,
+    tile: Tile,
+    x: number,
+    y: number,
+    cellSize: number
+): void {
+    const cx = x + cellSize / 2
+    const cy = y + cellSize / 2
+    const half = cellSize / 2
+
+    // Cell background
+    g.rect(x + 1, y + 1, cellSize - 2, cellSize - 2).fill({
+        color: 0x001122,
+        alpha: 0.5,
+    })
+    g.rect(x + 1, y + 1, cellSize - 2, cellSize - 2).stroke({
+        color: 0x0ea5e9,
+        width: 1,
+        alpha: 0.15,
+    })
+
+    if (tile.type === 'blocker') {
+        g.rect(x + 6, y + 6, cellSize - 12, cellSize - 12).fill(COLOR_BLOCKER)
+        return
+    }
+
+    const wireColor = tile.powered ? COLOR_WIRE_ON : COLOR_WIRE_OFF
+    const wireWidth = tile.powered ? 6 : 4
+
+    // Draw a wire segment from the centre out to each connector edge.
+    for (const dir of getConnectors(tile)) {
+        const { dx, dy } = dirOffset(dir)
+        g.moveTo(cx, cy)
+            .lineTo(cx + dx * half, cy + dy * half)
+            .stroke({ color: wireColor, width: wireWidth })
+    }
+
+    // Centre hub / node
+    if (tile.type === 'source') {
+        g.circle(cx, cy, half * 0.35).fill(COLOR_SOURCE)
+    } else if (tile.type === 'core') {
+        g.circle(cx, cy, half * 0.35).fill(
+            tile.powered ? COLOR_CORE_ON : COLOR_CORE_OFF
+        )
+    } else {
+        g.circle(cx, cy, wireWidth * 0.9).fill(wireColor)
+    }
+}
+
+export function renderGrid(
+    rendererState: RendererState,
+    state: CircuitHackerState,
+    cellSize: number
+): void {
+    const g = rendererState.tileGraphic
+    g.clear()
+    for (let r = 0; r < state.rows; r++) {
+        for (let c = 0; c < state.cols; c++) {
+            drawTile(g, state.grid[r][c], c * cellSize, r * cellSize, cellSize)
+        }
+    }
+}
+
+export function pointerToCell(
+    x: number,
+    y: number,
+    cellSize: number,
+    rows: number,
+    cols: number
+): GridPosition | null {
+    const col = Math.floor(x / cellSize)
+    const row = Math.floor(y / cellSize)
+    if (row < 0 || row >= rows || col < 0 || col >= cols) {
+        return null
+    }
+    return { row, col }
+}
+
+export function cleanup(rendererState: RendererState): void {
+    rendererState.app.destroy(true, { children: true, texture: true })
+}

--- a/src/lib/games/circuit-hacker/test-utils.ts
+++ b/src/lib/games/circuit-hacker/test-utils.ts
@@ -2,7 +2,7 @@
 
 import type { CircuitHackerGame } from './game'
 import type { GeneratedPuzzle } from './generator'
-import type { CircuitHackerState } from './types'
+import type { CircuitHackerState, Orientation } from './types'
 
 // Deterministic LCG so tests are reproducible.
 export function seededRng(seed: number): () => number {
@@ -51,7 +51,7 @@ export function solveGameForTest(game: CircuitHackerGame): void {
  */
 export function getSolutionOrientationsForTest(
     game: CircuitHackerGame
-): number[][] | null {
+): Orientation[][] | null {
     const internals = game as unknown as CircuitHackerGameInternals
     return internals.puzzle?.solutionOrientations ?? null
 }

--- a/src/lib/games/circuit-hacker/test-utils.ts
+++ b/src/lib/games/circuit-hacker/test-utils.ts
@@ -1,5 +1,9 @@
 // Shared test utilities for circuit-hacker tests.
 
+import type { CircuitHackerGame } from './game'
+import type { GeneratedPuzzle } from './generator'
+import type { CircuitHackerState } from './types'
+
 // Deterministic LCG so tests are reproducible.
 export function seededRng(seed: number): () => number {
     let s = seed >>> 0
@@ -7,4 +11,47 @@ export function seededRng(seed: number): () => number {
         s = (s * 1664525 + 1013904223) >>> 0
         return s / 0xffffffff
     }
+}
+
+// Test-only access to the game's private internals. Defined here (not on the
+// production class) so the public API shipped in the production bundle does
+// not include a solve backdoor. Tests are co-located with the game source,
+// so any private-field rename will surface as a test compile error here
+// rather than silently shipping a callable solver.
+interface CircuitHackerGameInternals {
+    puzzle: GeneratedPuzzle | null
+    state: CircuitHackerState
+    applyPower(state: CircuitHackerState): void
+    allCoresPowered(state: CircuitHackerState): boolean
+    solve(): void
+}
+
+/** Test-only helper: rotate every tile into the known solution. */
+export function solveGameForTest(game: CircuitHackerGame): void {
+    const internals = game as unknown as CircuitHackerGameInternals
+    const puzzle = internals.puzzle
+    if (!puzzle) {
+        return
+    }
+    for (let r = 0; r < internals.state.rows; r++) {
+        for (let c = 0; c < internals.state.cols; c++) {
+            internals.state.grid[r][c].orientation =
+                puzzle.solutionOrientations[r][c]
+        }
+    }
+    internals.applyPower(internals.state)
+    if (internals.allCoresPowered(internals.state)) {
+        internals.solve()
+    }
+}
+
+/**
+ * Test-only helper: returns the recorded solution orientations so tests can
+ * drive the real rotateTile() path to a win without using the solve backdoor.
+ */
+export function getSolutionOrientationsForTest(
+    game: CircuitHackerGame
+): number[][] | null {
+    const internals = game as unknown as CircuitHackerGameInternals
+    return internals.puzzle?.solutionOrientations ?? null
 }

--- a/src/lib/games/circuit-hacker/test-utils.ts
+++ b/src/lib/games/circuit-hacker/test-utils.ts
@@ -1,0 +1,10 @@
+// Shared test utilities for circuit-hacker tests.
+
+// Deterministic LCG so tests are reproducible.
+export function seededRng(seed: number): () => number {
+    let s = seed >>> 0
+    return () => {
+        s = (s * 1664525 + 1013904223) >>> 0
+        return s / 0xffffffff
+    }
+}

--- a/src/lib/games/circuit-hacker/types.ts
+++ b/src/lib/games/circuit-hacker/types.ts
@@ -1,6 +1,10 @@
 // Edge direction of a tile connector
 export type Direction = 'N' | 'E' | 'S' | 'W'
 
+// Number of 90° clockwise rotations from the base orientation. Constraining
+// this to 0..3 makes illegal rotations unrepresentable at zero runtime cost.
+export type Orientation = 0 | 1 | 2 | 3
+
 // Difficulty tiers (chosen up front)
 export type Difficulty = 'easy' | 'medium' | 'hard' | 'expert'
 
@@ -18,7 +22,7 @@ export type TileType =
 export interface Tile {
     type: TileType
     // number of 90° clockwise rotations from the base orientation (0..3)
-    orientation: number
+    orientation: Orientation
     // locked tiles (source, core, blocker) cannot be rotated by the player
     locked: boolean
     // currently reachable from the source through matching connectors
@@ -86,7 +90,15 @@ export type RunEndReason = 'timeout' | 'manual'
 export interface CircuitHackerCallbacks {
     onTimeUpdate: (timeRemaining: number) => void
     onRotation: (rotationsUsed: number) => void
-    onSolved: (finalScore: number, stats: CircuitHackerStats) => void
+    // onSolved may be async (the page submits the score over the network).
+    // The game loop does not await it; callers are responsible for their
+    // own error handling. The void | Promise<void> return lets the game
+    // attach a defensive .catch() so an unhandled rejection can never
+    // escape the fire-and-forget call site.
+    onSolved: (
+        finalScore: number,
+        stats: CircuitHackerStats
+    ) => void | Promise<void>
     onFail: (stats: CircuitHackerStats, reason: RunEndReason) => void
     onGameStart: () => void
 }

--- a/src/lib/games/circuit-hacker/types.ts
+++ b/src/lib/games/circuit-hacker/types.ts
@@ -78,10 +78,13 @@ export interface CircuitHackerState {
     solved: boolean
 }
 
+// Why a run ended in failure: the timer expired or the player stopped early.
+export type FailReason = 'timeout' | 'manual'
+
 export interface CircuitHackerCallbacks {
     onTimeUpdate: (timeRemaining: number) => void
     onRotation: (rotationsUsed: number) => void
     onSolved: (finalScore: number, stats: CircuitHackerStats) => void
-    onFail: (stats: CircuitHackerStats) => void
+    onFail: (stats: CircuitHackerStats, reason: FailReason) => void
     onGameStart: () => void
 }

--- a/src/lib/games/circuit-hacker/types.ts
+++ b/src/lib/games/circuit-hacker/types.ts
@@ -1,0 +1,87 @@
+// Edge direction of a tile connector
+export type Direction = 'N' | 'E' | 'S' | 'W'
+
+// Difficulty tiers (chosen up front)
+export type Difficulty = 'easy' | 'medium' | 'hard' | 'expert'
+
+// Shapes a tile can take
+export type TileType =
+    | 'straight'
+    | 'elbow'
+    | 't-junction'
+    | 'cross'
+    | 'source'
+    | 'core'
+    | 'blocker'
+
+// A single grid cell
+export interface Tile {
+    type: TileType
+    // number of 90° clockwise rotations from the base orientation (0..3)
+    orientation: number
+    // locked tiles (source, core, blocker) cannot be rotated by the player
+    locked: boolean
+    // currently reachable from the source through matching connectors
+    powered: boolean
+}
+
+export interface GridPosition {
+    row: number
+    col: number
+}
+
+// Per-difficulty configuration
+export interface DifficultyConfig {
+    difficulty: Difficulty
+    rows: number
+    cols: number
+    cores: number
+    blockers: number
+    duration: number // seconds
+    multiplier: number
+}
+
+// Runtime game configuration
+export interface CircuitHackerConfig {
+    difficulty: Difficulty
+    cellSize: number // pixels per tile on the canvas
+}
+
+// Submitted with the score and used for achievement checks
+export interface CircuitHackerGameData {
+    difficulty: Difficulty
+    secondsRemaining: number
+    rotationsUsed: number
+    solved: boolean
+}
+
+// Returned at game end
+export interface CircuitHackerStats {
+    finalScore: number
+    difficulty: Difficulty
+    secondsRemaining: number
+    rotationsUsed: number
+    solved: boolean
+}
+
+export interface CircuitHackerState {
+    grid: Tile[][]
+    sourcePos: GridPosition
+    corePositions: GridPosition[]
+    rows: number
+    cols: number
+    score: number
+    timeRemaining: number
+    rotationsUsed: number
+    isGameActive: boolean
+    isGameOver: boolean
+    solved: boolean
+}
+
+export interface CircuitHackerCallbacks {
+    onTimeUpdate: (timeRemaining: number) => void
+    onRotation: (rotationsUsed: number) => void
+    onSolved: (finalScore: number, stats: CircuitHackerStats) => void
+    onFail: (stats: CircuitHackerStats) => void
+    onGameStart: () => void
+}

--- a/src/lib/games/circuit-hacker/types.ts
+++ b/src/lib/games/circuit-hacker/types.ts
@@ -78,13 +78,15 @@ export interface CircuitHackerState {
     solved: boolean
 }
 
-// Why a run ended in failure: the timer expired or the player stopped early.
-export type FailReason = 'timeout' | 'manual'
+// Why a run ended without being solved: the timer expired (`timeout`) or the
+// player stopped the game early (`manual`). This describes run-end causes only
+// — puzzle *generation* failures surface as a thrown Error, not this type.
+export type RunEndReason = 'timeout' | 'manual'
 
 export interface CircuitHackerCallbacks {
     onTimeUpdate: (timeRemaining: number) => void
     onRotation: (rotationsUsed: number) => void
     onSolved: (finalScore: number, stats: CircuitHackerStats) => void
-    onFail: (stats: CircuitHackerStats, reason: FailReason) => void
+    onFail: (stats: CircuitHackerStats, reason: RunEndReason) => void
     onGameStart: () => void
 }

--- a/src/lib/games/circuit-hacker/utils.test.ts
+++ b/src/lib/games/circuit-hacker/utils.test.ts
@@ -5,13 +5,22 @@ import {
     getBaseConnectors,
     getConnectors,
     cellsConnect,
+    computePoweredCells,
+    isSolved,
 } from './utils'
-import type { Tile } from './types'
+import type { Tile, GridPosition } from './types'
 
 const tile = (type: Tile['type'], orientation = 0): Tile => ({
     type,
     orientation,
     locked: false,
+    powered: false,
+})
+
+const t = (type: Tile['type'], orientation = 0, locked = false): Tile => ({
+    type,
+    orientation,
+    locked,
     powered: false,
 })
 
@@ -56,5 +65,36 @@ describe('connector math', () => {
         ).toBe(false)
         // blocker never connects
         expect(cellsConnect(tile('cross'), 'E', tile('blocker'))).toBe(false)
+    })
+})
+
+describe('power flood-fill', () => {
+    // 1x3 row: source(→E) — straight(horizontal) — core(←W)
+    // source base 'N' rotated to 'E' = orientation 1
+    // core base 'N' rotated to 'W' = orientation 3
+    const source: GridPosition = { row: 0, col: 0 }
+    const cores: GridPosition[] = [{ row: 0, col: 2 }]
+
+    it('powers a fully connected line', () => {
+        const grid: Tile[][] = [
+            [t('source', 1, true), t('straight', 1), t('core', 3, true)],
+        ]
+        const powered = computePoweredCells(grid, source)
+        expect(powered[0][0]).toBe(true)
+        expect(powered[0][1]).toBe(true)
+        expect(powered[0][2]).toBe(true)
+        expect(isSolved(grid, source, cores)).toBe(true)
+    })
+
+    it('does not power past a broken connection', () => {
+        // middle straight left vertical (orientation 0 -> N,S) breaks the row
+        const grid: Tile[][] = [
+            [t('source', 1, true), t('straight', 0), t('core', 3, true)],
+        ]
+        const powered = computePoweredCells(grid, source)
+        expect(powered[0][0]).toBe(true)
+        expect(powered[0][1]).toBe(false)
+        expect(powered[0][2]).toBe(false)
+        expect(isSolved(grid, source, cores)).toBe(false)
     })
 })

--- a/src/lib/games/circuit-hacker/utils.test.ts
+++ b/src/lib/games/circuit-hacker/utils.test.ts
@@ -7,6 +7,9 @@ import {
     cellsConnect,
     computePoweredCells,
     isSolved,
+    DIFFICULTY_CONFIGS,
+    countRotatableTiles,
+    computeFinalScore,
 } from './utils'
 import type { Tile, GridPosition } from './types'
 
@@ -96,5 +99,59 @@ describe('power flood-fill', () => {
         expect(powered[0][1]).toBe(false)
         expect(powered[0][2]).toBe(false)
         expect(isSolved(grid, source, cores)).toBe(false)
+    })
+})
+
+describe('difficulty configs & scoring', () => {
+    it('defines all four tiers with the agreed constants', () => {
+        expect(DIFFICULTY_CONFIGS.easy).toMatchObject({
+            rows: 5,
+            cols: 5,
+            cores: 1,
+            blockers: 0,
+            duration: 120,
+            multiplier: 1,
+        })
+        expect(DIFFICULTY_CONFIGS.expert).toMatchObject({
+            rows: 11,
+            cols: 11,
+            cores: 3,
+            blockers: 10,
+            duration: 300,
+            multiplier: 5,
+        })
+    })
+
+    it('counts only unlocked tiles as rotatable', () => {
+        const grid: Tile[][] = [
+            [t('source', 0, true), t('straight'), t('blocker', 0, true)],
+            [t('elbow'), t('core', 0, true), t('cross')],
+        ]
+        expect(countRotatableTiles(grid)).toBe(3)
+    })
+
+    it('computes final score with the agreed formula', () => {
+        // base 1000 + time 30*15=450 + rotationBonus max(0, 10*2 - 8)*25 = 300
+        // sum 1750 * multiplier 2 = 3500
+        expect(
+            computeFinalScore({
+                secondsRemaining: 30,
+                rotationsUsed: 8,
+                rotatableTileCount: 10,
+                multiplier: 2,
+            })
+        ).toBe(3500)
+    })
+
+    it('floors rotation bonus at zero when over budget', () => {
+        // base 1000 + 0 time + max(0, 2*2 - 99)*25 = 0 -> 1000 * 1
+        expect(
+            computeFinalScore({
+                secondsRemaining: 0,
+                rotationsUsed: 99,
+                rotatableTileCount: 2,
+                multiplier: 1,
+            })
+        ).toBe(1000)
     })
 })

--- a/src/lib/games/circuit-hacker/utils.test.ts
+++ b/src/lib/games/circuit-hacker/utils.test.ts
@@ -1,0 +1,60 @@
+import { describe, it, expect } from 'vitest'
+import {
+    oppositeDirection,
+    rotateConnectors,
+    getBaseConnectors,
+    getConnectors,
+    cellsConnect,
+} from './utils'
+import type { Tile } from './types'
+
+const tile = (type: Tile['type'], orientation = 0): Tile => ({
+    type,
+    orientation,
+    locked: false,
+    powered: false,
+})
+
+describe('connector math', () => {
+    it('returns opposite directions', () => {
+        expect(oppositeDirection('N')).toBe('S')
+        expect(oppositeDirection('S')).toBe('N')
+        expect(oppositeDirection('E')).toBe('W')
+        expect(oppositeDirection('W')).toBe('E')
+    })
+
+    it('rotates connectors clockwise', () => {
+        expect(rotateConnectors(['N'], 1)).toEqual(['E'])
+        expect(rotateConnectors(['N'], 2)).toEqual(['S'])
+        expect(rotateConnectors(['N', 'E'], 1).sort()).toEqual(['E', 'S'])
+        expect(rotateConnectors(['N'], 4)).toEqual(['N'])
+    })
+
+    it('defines base connectors per tile type', () => {
+        expect(getBaseConnectors('straight').sort()).toEqual(['N', 'S'])
+        expect(getBaseConnectors('elbow').sort()).toEqual(['E', 'N'])
+        expect(getBaseConnectors('t-junction').sort()).toEqual(['E', 'N', 'S'])
+        expect(getBaseConnectors('cross').sort()).toEqual(['E', 'N', 'S', 'W'])
+        expect(getBaseConnectors('source')).toEqual(['N'])
+        expect(getBaseConnectors('core')).toEqual(['N'])
+        expect(getBaseConnectors('blocker')).toEqual([])
+    })
+
+    it('applies orientation to connectors', () => {
+        expect(getConnectors(tile('straight', 1)).sort()).toEqual(['E', 'W'])
+        expect(getConnectors(tile('source', 1))).toEqual(['E'])
+    })
+
+    it('connects two tiles only when both face each other', () => {
+        // straight vertical (N,S) above a straight vertical: A's S meets B's N
+        expect(
+            cellsConnect(tile('straight', 0), 'S', tile('straight', 0))
+        ).toBe(true)
+        // straight horizontal has no S connector
+        expect(
+            cellsConnect(tile('straight', 1), 'S', tile('straight', 0))
+        ).toBe(false)
+        // blocker never connects
+        expect(cellsConnect(tile('cross'), 'E', tile('blocker'))).toBe(false)
+    })
+})

--- a/src/lib/games/circuit-hacker/utils.test.ts
+++ b/src/lib/games/circuit-hacker/utils.test.ts
@@ -10,16 +10,20 @@ import {
     countRotatableTiles,
     computeFinalScore,
 } from './utils'
-import type { Tile, GridPosition } from './types'
+import type { Tile, GridPosition, Orientation } from './types'
 
-const tile = (type: Tile['type'], orientation = 0): Tile => ({
+const tile = (type: Tile['type'], orientation: Orientation = 0): Tile => ({
     type,
     orientation,
     locked: false,
     powered: false,
 })
 
-const t = (type: Tile['type'], orientation = 0, locked = false): Tile => ({
+const t = (
+    type: Tile['type'],
+    orientation: Orientation = 0,
+    locked = false
+): Tile => ({
     type,
     orientation,
     locked,

--- a/src/lib/games/circuit-hacker/utils.test.ts
+++ b/src/lib/games/circuit-hacker/utils.test.ts
@@ -6,7 +6,6 @@ import {
     getConnectors,
     cellsConnect,
     computePoweredCells,
-    isSolved,
     DIFFICULTY_CONFIGS,
     countRotatableTiles,
     computeFinalScore,
@@ -76,7 +75,6 @@ describe('power flood-fill', () => {
     // source base 'N' rotated to 'E' = orientation 1
     // core base 'N' rotated to 'W' = orientation 3
     const source: GridPosition = { row: 0, col: 0 }
-    const cores: GridPosition[] = [{ row: 0, col: 2 }]
 
     it('powers a fully connected line', () => {
         const grid: Tile[][] = [
@@ -86,7 +84,6 @@ describe('power flood-fill', () => {
         expect(powered[0][0]).toBe(true)
         expect(powered[0][1]).toBe(true)
         expect(powered[0][2]).toBe(true)
-        expect(isSolved(grid, source, cores)).toBe(true)
     })
 
     it('does not power past a broken connection', () => {
@@ -98,7 +95,6 @@ describe('power flood-fill', () => {
         expect(powered[0][0]).toBe(true)
         expect(powered[0][1]).toBe(false)
         expect(powered[0][2]).toBe(false)
-        expect(isSolved(grid, source, cores)).toBe(false)
     })
 })
 

--- a/src/lib/games/circuit-hacker/utils.ts
+++ b/src/lib/games/circuit-hacker/utils.ts
@@ -1,4 +1,11 @@
-import type { Direction, GridPosition, Tile, TileType } from './types'
+import type {
+    Direction,
+    GridPosition,
+    Tile,
+    TileType,
+    Difficulty,
+    DifficultyConfig,
+} from './types'
 
 const CLOCKWISE: Direction[] = ['N', 'E', 'S', 'W']
 
@@ -103,4 +110,69 @@ export function isSolved(
 ): boolean {
     const powered = computePoweredCells(grid, source)
     return cores.every(core => powered[core.row][core.col])
+}
+
+export const DIFFICULTY_CONFIGS: Record<Difficulty, DifficultyConfig> = {
+    easy: {
+        difficulty: 'easy',
+        rows: 5,
+        cols: 5,
+        cores: 1,
+        blockers: 0,
+        duration: 120,
+        multiplier: 1,
+    },
+    medium: {
+        difficulty: 'medium',
+        rows: 7,
+        cols: 7,
+        cores: 1,
+        blockers: 3,
+        duration: 180,
+        multiplier: 2,
+    },
+    hard: {
+        difficulty: 'hard',
+        rows: 9,
+        cols: 9,
+        cores: 2,
+        blockers: 6,
+        duration: 240,
+        multiplier: 3.5,
+    },
+    expert: {
+        difficulty: 'expert',
+        rows: 11,
+        cols: 11,
+        cores: 3,
+        blockers: 10,
+        duration: 300,
+        multiplier: 5,
+    },
+}
+
+export function countRotatableTiles(grid: Tile[][]): number {
+    let count = 0
+    for (const row of grid) {
+        for (const tile of row) {
+            if (!tile.locked) {
+                count++
+            }
+        }
+    }
+    return count
+}
+
+export function computeFinalScore(params: {
+    secondsRemaining: number
+    rotationsUsed: number
+    rotatableTileCount: number
+    multiplier: number
+}): number {
+    const base = 1000
+    const timeBonus = params.secondsRemaining * 15
+    const rotationBudget = params.rotatableTileCount * 2
+    const rotationBonus =
+        Math.max(0, rotationBudget - params.rotationsUsed) * 25
+    return Math.round((base + timeBonus + rotationBonus) * params.multiplier)
 }

--- a/src/lib/games/circuit-hacker/utils.ts
+++ b/src/lib/games/circuit-hacker/utils.ts
@@ -1,4 +1,4 @@
-import type { Direction, Tile, TileType } from './types'
+import type { Direction, GridPosition, Tile, TileType } from './types'
 
 const CLOCKWISE: Direction[] = ['N', 'E', 'S', 'W']
 
@@ -54,4 +54,53 @@ export function cellsConnect(from: Tile, dir: Direction, to: Tile): boolean {
         getConnectors(from).includes(dir) &&
         getConnectors(to).includes(oppositeDirection(dir))
     )
+}
+
+const DELTA: Record<Direction, { dr: number; dc: number }> = {
+    N: { dr: -1, dc: 0 },
+    E: { dr: 0, dc: 1 },
+    S: { dr: 1, dc: 0 },
+    W: { dr: 0, dc: -1 },
+}
+
+export function computePoweredCells(
+    grid: Tile[][],
+    source: GridPosition
+): boolean[][] {
+    const rows = grid.length
+    const cols = rows > 0 ? grid[0].length : 0
+    const powered: boolean[][] = grid.map(row => row.map(() => false))
+
+    const queue: GridPosition[] = [source]
+    powered[source.row][source.col] = true
+
+    while (queue.length > 0) {
+        const { row, col } = queue.shift() as GridPosition
+        const from = grid[row][col]
+        for (const dir of ['N', 'E', 'S', 'W'] as Direction[]) {
+            const nr = row + DELTA[dir].dr
+            const nc = col + DELTA[dir].dc
+            if (nr < 0 || nr >= rows || nc < 0 || nc >= cols) {
+                continue
+            }
+            if (powered[nr][nc]) {
+                continue
+            }
+            if (cellsConnect(from, dir, grid[nr][nc])) {
+                powered[nr][nc] = true
+                queue.push({ row: nr, col: nc })
+            }
+        }
+    }
+
+    return powered
+}
+
+export function isSolved(
+    grid: Tile[][],
+    source: GridPosition,
+    cores: GridPosition[]
+): boolean {
+    const powered = computePoweredCells(grid, source)
+    return cores.every(core => powered[core.row][core.col])
 }

--- a/src/lib/games/circuit-hacker/utils.ts
+++ b/src/lib/games/circuit-hacker/utils.ts
@@ -63,7 +63,7 @@ export function cellsConnect(from: Tile, dir: Direction, to: Tile): boolean {
     )
 }
 
-const DELTA: Record<Direction, { dr: number; dc: number }> = {
+export const DELTA: Record<Direction, { dr: number; dc: number }> = {
     N: { dr: -1, dc: 0 },
     E: { dr: 0, dc: 1 },
     S: { dr: 1, dc: 0 },

--- a/src/lib/games/circuit-hacker/utils.ts
+++ b/src/lib/games/circuit-hacker/utils.ts
@@ -1,0 +1,57 @@
+import type { Direction, Tile, TileType } from './types'
+
+const CLOCKWISE: Direction[] = ['N', 'E', 'S', 'W']
+
+export function oppositeDirection(dir: Direction): Direction {
+    switch (dir) {
+        case 'N':
+            return 'S'
+        case 'S':
+            return 'N'
+        case 'E':
+            return 'W'
+        case 'W':
+            return 'E'
+    }
+}
+
+export function rotateConnectors(
+    connectors: Direction[],
+    times: number
+): Direction[] {
+    const steps = ((times % 4) + 4) % 4
+    return connectors.map(dir => {
+        const idx = CLOCKWISE.indexOf(dir)
+        return CLOCKWISE[(idx + steps) % 4]
+    })
+}
+
+export function getBaseConnectors(type: TileType): Direction[] {
+    switch (type) {
+        case 'straight':
+            return ['N', 'S']
+        case 'elbow':
+            return ['N', 'E']
+        case 't-junction':
+            return ['N', 'E', 'S']
+        case 'cross':
+            return ['N', 'E', 'S', 'W']
+        case 'source':
+            return ['N']
+        case 'core':
+            return ['N']
+        case 'blocker':
+            return []
+    }
+}
+
+export function getConnectors(tile: Tile): Direction[] {
+    return rotateConnectors(getBaseConnectors(tile.type), tile.orientation)
+}
+
+export function cellsConnect(from: Tile, dir: Direction, to: Tile): boolean {
+    return (
+        getConnectors(from).includes(dir) &&
+        getConnectors(to).includes(oppositeDirection(dir))
+    )
+}

--- a/src/lib/games/circuit-hacker/utils.ts
+++ b/src/lib/games/circuit-hacker/utils.ts
@@ -103,15 +103,6 @@ export function computePoweredCells(
     return powered
 }
 
-export function isSolved(
-    grid: Tile[][],
-    source: GridPosition,
-    cores: GridPosition[]
-): boolean {
-    const powered = computePoweredCells(grid, source)
-    return cores.every(core => powered[core.row][core.col])
-}
-
 export const DIFFICULTY_CONFIGS: Record<Difficulty, DifficultyConfig> = {
     easy: {
         difficulty: 'easy',

--- a/src/lib/games/shared/types.ts
+++ b/src/lib/games/shared/types.ts
@@ -100,6 +100,14 @@ export interface SnakeGameData {
     maxLength: number
 }
 
+// Circuit Hacker-specific game data
+export interface CircuitHackerGameData {
+    difficulty: 'easy' | 'medium' | 'hard' | 'expert'
+    secondsRemaining: number
+    rotationsUsed: number
+    solved: boolean
+}
+
 // Union type for all game data
 export type GameData =
     | TetrisGameData
@@ -114,6 +122,7 @@ export type GameData =
     | EvaderGameData
     | Game2048Data
     | SnakeGameData
+    | CircuitHackerGameData
 
 // Common game stats returned from games
 export interface GameStats {

--- a/src/lib/games/shared/types.ts
+++ b/src/lib/games/shared/types.ts
@@ -102,7 +102,7 @@ export interface SnakeGameData {
 
 // Circuit Hacker-specific game data
 export interface CircuitHackerGameData {
-    difficulty: 'easy' | 'medium' | 'hard' | 'expert'
+    difficulty: import('../circuit-hacker/types').Difficulty
     secondsRemaining: number
     rotationsUsed: number
     solved: boolean

--- a/src/pages/circuit-hacker/index.astro
+++ b/src/pages/circuit-hacker/index.astro
@@ -251,6 +251,11 @@ const gameNavigation = [
 
           startBtn.addEventListener('click', async () => {
             hideError()
+            // Hide start button before awaiting start() to prevent a
+            // double-click from entering start() twice while setupPixiJS
+            // is still pending. onStart keeps it hidden on success;
+            // resetButtonState() restores it on error.
+            startBtn.style.display = 'none'
             difficultySelect.disabled = true
             rotationEl.textContent = '0'
             try {

--- a/src/pages/circuit-hacker/index.astro
+++ b/src/pages/circuit-hacker/index.astro
@@ -187,6 +187,22 @@ const gameNavigation = [
         const difficultySelect = document.getElementById(
           'difficulty-select'
         ) as HTMLSelectElement
+        const errorContainer = document.getElementById('game-error')!
+        const errorTitle = document.getElementById('game-error-title')!
+        const errorMessage = document.getElementById('game-error-message')!
+
+        const showError = (title: string, message: string) => {
+          statusEl.classList.add('hidden')
+          errorTitle.textContent = title
+          errorMessage.textContent = message
+          errorContainer.style.display = 'flex'
+        }
+
+        const resetButtonState = () => {
+          startBtn.style.display = 'inline-flex'
+          stopBtn.style.display = 'none'
+          difficultySelect.disabled = false
+        }
 
         try {
           gameHandle = await initializeCircuitHackerGame(container, {
@@ -210,7 +226,12 @@ const gameNavigation = [
           startBtn.addEventListener('click', async () => {
             difficultySelect.disabled = true
             rotationEl.textContent = '0'
-            await gameHandle!.start(difficultySelect.value as Difficulty)
+            try {
+              await gameHandle!.start(difficultySelect.value as Difficulty)
+            } catch (error) {
+              showError('Failed to Start Game', String(error))
+              resetButtonState()
+            }
           })
 
           stopBtn.addEventListener('click', () => {
@@ -225,13 +246,7 @@ const gameNavigation = [
             difficultySelect.disabled = false
           })
         } catch (error) {
-          const errorContainer = document.getElementById('game-error')!
-          const errorTitle = document.getElementById('game-error-title')!
-          const errorMessage = document.getElementById('game-error-message')!
-          statusEl.classList.add('hidden')
-          errorTitle.textContent = 'Failed to Load Game'
-          errorMessage.textContent = String(error)
-          errorContainer.style.display = 'flex'
+          showError('Failed to Load Game', String(error))
         }
       }
 

--- a/src/pages/circuit-hacker/index.astro
+++ b/src/pages/circuit-hacker/index.astro
@@ -39,7 +39,7 @@ const gameNavigation = [
       </div>
 
       <div class="flex flex-col lg:flex-row gap-8 items-start justify-center">
-        <Card variant="glass" class="p-6 flex-shrink-0">
+        <Card variant="glass" class="p-6 flex-shrink-0 w-full lg:w-auto">
           <div class="flex flex-col items-center space-y-4">
             <div class="flex space-x-4 mb-2">
               <Badge variant="outline" class="px-4 py-2">
@@ -71,10 +71,10 @@ const gameNavigation = [
               </select>
             </div>
 
-            <div class="relative">
+            <div class="relative w-full">
               <div
                 id="game-canvas-container"
-                class="bg-black/30 rounded-lg min-w-[240px] min-h-[240px]"
+                class="bg-black/30 rounded-lg min-w-[240px] min-h-[240px] w-full"
               >
               </div>
 

--- a/src/pages/circuit-hacker/index.astro
+++ b/src/pages/circuit-hacker/index.astro
@@ -1,0 +1,250 @@
+---
+import AppLayout from '@/layouts/AppLayout.astro'
+import Button from '@/components/ui/Button.astro'
+import Card from '@/components/ui/Card.astro'
+import Badge from '@/components/ui/Badge.astro'
+import GameOverlay from '@/components/GameOverlay.astro'
+import AchievementAward from '@/components/AchievementAward.astro'
+
+const gameNavigation = [
+  { href: '/', label: 'Home' },
+  { href: '#', label: 'Circuit Hacker' },
+]
+---
+
+<AppLayout
+  title="Circuit Hacker - Cetus Minigames"
+  description="Rotate circuit tiles to power a path from the source to the core before time runs out"
+  includeFooter={false}
+  navigation={gameNavigation}
+>
+  <div class="px-6 py-4 border-b border-slate-700/50">
+    <div class="max-w-7xl mx-auto">
+      <div class="flex items-center space-x-3">
+        <div class="text-cyan-400 text-sm">🔌 Circuit Hacker</div>
+      </div>
+    </div>
+  </div>
+
+  <div class="px-6 py-8">
+    <div class="max-w-6xl mx-auto">
+      <div class="text-center mb-8">
+        <h2 class="text-5xl font-orbitron font-bold text-holographic mb-4">
+          CIRCUIT HACKER
+        </h2>
+        <p class="text-gray-400 text-lg">
+          Rotate the tiles to connect the source to every core before the timer
+          expires!
+        </p>
+      </div>
+
+      <div class="flex flex-col lg:flex-row gap-8 items-start justify-center">
+        <Card variant="glass" class="p-6 flex-shrink-0">
+          <div class="flex flex-col items-center space-y-4">
+            <div class="flex space-x-4 mb-2">
+              <Badge variant="outline" class="px-4 py-2">
+                <span class="font-mono"
+                  >Time: <span id="time-remaining" class="text-cyan-400"
+                    >--</span
+                  >s</span
+                >
+              </Badge>
+              <Badge variant="outline" class="px-4 py-2">
+                <span class="font-mono"
+                  >Rotations: <span id="rotation-count" class="text-cyan-400"
+                    >0</span
+                  ></span
+                >
+              </Badge>
+            </div>
+
+            <div class="flex items-center space-x-2">
+              <span class="text-gray-400 text-sm">Difficulty:</span>
+              <select
+                id="difficulty-select"
+                class="bg-slate-800 border border-cyan-400/40 rounded-md px-3 py-1 text-sm text-white"
+              >
+                <option value="easy">Easy (5×5)</option>
+                <option value="medium" selected>Medium (7×7)</option>
+                <option value="hard">Hard (9×9)</option>
+                <option value="expert">Expert (11×11)</option>
+              </select>
+            </div>
+
+            <div class="relative">
+              <div
+                id="game-canvas-container"
+                class="bg-black/30 rounded-lg min-w-[240px] min-h-[240px]"
+              >
+              </div>
+
+              <div
+                id="game-status"
+                class="absolute inset-0 flex items-center justify-center bg-black/70 rounded-lg hidden"
+              >
+                <div class="text-center">
+                  <div class="text-6xl mb-4">🔌</div>
+                  <div
+                    class="text-xl text-cyan-400 font-orbitron font-bold mb-2"
+                  >
+                    CIRCUIT HACKER
+                  </div>
+                  <div class="text-gray-400">Pick a difficulty and start!</div>
+                </div>
+              </div>
+
+              <div
+                id="game-error"
+                class="hidden absolute inset-0 items-center justify-center bg-black/70 rounded-lg"
+              >
+                <div class="text-center">
+                  <div id="game-error-title" class="text-red-400 text-xl mb-2">
+                  </div>
+                  <div id="game-error-message" class="text-gray-400 text-sm">
+                  </div>
+                </div>
+              </div>
+            </div>
+
+            <div class="flex space-x-3">
+              <Button id="start-btn" variant="primary">Start Game</Button>
+              <Button id="stop-btn" variant="outline" style="display: none;"
+                >End Game</Button
+              >
+            </div>
+
+            <GameOverlay
+              defaultTitle="CIRCUIT POWERED!"
+              buttonText="Play Again"
+            >
+              <div class="text-lg text-gray-300">
+                Time Left: <span id="final-time" class="text-cyan-400">0s</span>
+              </div>
+              <div class="text-lg text-gray-300">
+                Rotations: <span id="final-rotations" class="text-purple-400"
+                  >0</span
+                >
+              </div>
+            </GameOverlay>
+          </div>
+        </Card>
+
+        <div class="flex flex-col space-y-6">
+          <Card variant="glass" class="p-6">
+            <h3 class="text-lg font-orbitron font-bold text-cyan-400 mb-4">
+              HOW TO PLAY
+            </h3>
+            <ul class="space-y-2 text-sm text-gray-400">
+              <li>• Tap/click a tile to rotate it 90° clockwise</li>
+              <li>• Connect the source node to every core</li>
+              <li>• Powered wires glow cyan</li>
+              <li>• Solve before the timer runs out</li>
+              <li>• Fewer rotations and more time left = higher score</li>
+            </ul>
+          </Card>
+
+          <Card variant="glass" class="p-6">
+            <h3 class="text-lg font-orbitron font-bold text-cyan-400 mb-4">
+              SCORING
+            </h3>
+            <div class="space-y-2 text-sm text-gray-300">
+              <div class="flex justify-between">
+                <span class="text-gray-400">Base:</span><span>1000</span>
+              </div>
+              <div class="flex justify-between">
+                <span class="text-gray-400">Time bonus:</span><span
+                  >×15 / sec left</span
+                >
+              </div>
+              <div class="flex justify-between">
+                <span class="text-gray-400">Harder tier:</span><span
+                  >bigger multiplier</span
+                >
+              </div>
+            </div>
+          </Card>
+        </div>
+      </div>
+    </div>
+
+    <script>
+      import { initializeCircuitHackerGame } from '@/lib/games/circuit-hacker/init'
+      import type { Difficulty } from '@/lib/games/circuit-hacker/types'
+
+      let gameHandle: Awaited<
+        ReturnType<typeof initializeCircuitHackerGame>
+      > | null = null
+
+      const init = async () => {
+        const container = document.getElementById('game-canvas-container')!
+        const timeEl = document.getElementById('time-remaining')!
+        const rotationEl = document.getElementById('rotation-count')!
+        const statusEl = document.getElementById('game-status')!
+        const overlay = document.getElementById('game-over-overlay')!
+        const startBtn = document.getElementById('start-btn')!
+        const stopBtn = document.getElementById('stop-btn')!
+        const playAgainBtn = document.getElementById('play-again-btn')!
+        const difficultySelect = document.getElementById(
+          'difficulty-select'
+        ) as HTMLSelectElement
+
+        try {
+          gameHandle = await initializeCircuitHackerGame(container, {
+            onTimeUpdate: (t: number) => {
+              timeEl.textContent = t.toString()
+            },
+            onRotation: (n: number) => {
+              rotationEl.textContent = n.toString()
+            },
+            onStart: () => {
+              statusEl.classList.add('hidden')
+              overlay.classList.add('hidden')
+              startBtn.style.display = 'none'
+              stopBtn.style.display = 'inline-flex'
+            },
+            onEnd: () => {
+              difficultySelect.disabled = false
+            },
+          })
+
+          startBtn.addEventListener('click', async () => {
+            difficultySelect.disabled = true
+            rotationEl.textContent = '0'
+            await gameHandle!.start(difficultySelect.value as Difficulty)
+          })
+
+          stopBtn.addEventListener('click', () => {
+            gameHandle!.stop()
+          })
+
+          playAgainBtn.addEventListener('click', () => {
+            overlay.classList.add('hidden')
+            statusEl.classList.remove('hidden')
+            startBtn.style.display = 'inline-flex'
+            stopBtn.style.display = 'none'
+            difficultySelect.disabled = false
+          })
+        } catch (error) {
+          const errorContainer = document.getElementById('game-error')!
+          const errorTitle = document.getElementById('game-error-title')!
+          const errorMessage = document.getElementById('game-error-message')!
+          statusEl.classList.add('hidden')
+          errorTitle.textContent = 'Failed to Load Game'
+          errorMessage.textContent = String(error)
+          errorContainer.style.display = 'flex'
+        }
+      }
+
+      if (document.readyState === 'loading') {
+        document.addEventListener('DOMContentLoaded', init)
+      } else {
+        init()
+      }
+
+      window.addEventListener('beforeunload', () => {
+        gameHandle?.cleanup()
+      })
+    </script>
+  </div>
+  <AchievementAward />
+</AppLayout>

--- a/src/pages/circuit-hacker/index.astro
+++ b/src/pages/circuit-hacker/index.astro
@@ -157,6 +157,11 @@ const gameNavigation = [
                 >
               </div>
               <div class="flex justify-between">
+                <span class="text-gray-400">Rotation bonus:</span><span
+                  >×25 / unused rotation</span
+                >
+              </div>
+              <div class="flex justify-between">
                 <span class="text-gray-400">Harder tier:</span><span
                   >bigger multiplier</span
                 >
@@ -193,9 +198,26 @@ const gameNavigation = [
 
         const showError = (title: string, message: string) => {
           statusEl.classList.add('hidden')
+          overlay.classList.add('hidden')
           errorTitle.textContent = title
           errorMessage.textContent = message
+          errorContainer.classList.remove('hidden')
           errorContainer.style.display = 'flex'
+        }
+
+        const hideError = () => {
+          errorContainer.classList.add('hidden')
+          errorContainer.style.display = 'none'
+        }
+
+        const formatError = (error: unknown): string => {
+          if (error instanceof Error) {
+            return error.message
+          }
+          if (typeof error === 'string') {
+            return error
+          }
+          return 'Unexpected error. Please try again.'
         }
 
         const resetButtonState = () => {
@@ -215,23 +237,26 @@ const gameNavigation = [
             onStart: () => {
               statusEl.classList.add('hidden')
               overlay.classList.add('hidden')
-              errorContainer.style.display = 'none'
+              hideError()
               startBtn.style.display = 'none'
               stopBtn.style.display = 'inline-flex'
             },
             onEnd: () => {
               difficultySelect.disabled = false
             },
+            onError: (title, message) => {
+              showError(title, message)
+            },
           })
 
           startBtn.addEventListener('click', async () => {
-            errorContainer.style.display = 'none'
+            hideError()
             difficultySelect.disabled = true
             rotationEl.textContent = '0'
             try {
               await gameHandle!.start(difficultySelect.value as Difficulty)
             } catch (error) {
-              showError('Failed to Start Game', String(error))
+              showError('Failed to Start Game', formatError(error))
               resetButtonState()
             }
           })
@@ -248,7 +273,7 @@ const gameNavigation = [
             difficultySelect.disabled = false
           })
         } catch (error) {
-          showError('Failed to Load Game', String(error))
+          showError('Failed to Load Game', formatError(error))
         }
       }
 

--- a/src/pages/circuit-hacker/index.astro
+++ b/src/pages/circuit-hacker/index.astro
@@ -80,7 +80,7 @@ const gameNavigation = [
 
               <div
                 id="game-status"
-                class="absolute inset-0 flex items-center justify-center bg-black/70 rounded-lg hidden"
+                class="absolute inset-0 flex items-center justify-center bg-black/70 rounded-lg"
               >
                 <div class="text-center">
                   <div class="text-6xl mb-4">🔌</div>

--- a/src/pages/circuit-hacker/index.astro
+++ b/src/pages/circuit-hacker/index.astro
@@ -215,6 +215,7 @@ const gameNavigation = [
             onStart: () => {
               statusEl.classList.add('hidden')
               overlay.classList.add('hidden')
+              errorContainer.style.display = 'none'
               startBtn.style.display = 'none'
               stopBtn.style.display = 'inline-flex'
             },
@@ -224,6 +225,7 @@ const gameNavigation = [
           })
 
           startBtn.addEventListener('click', async () => {
+            errorContainer.style.display = 'none'
             difficultySelect.disabled = true
             rotationEl.textContent = '0'
             try {

--- a/src/pages/game-board-markup.test.ts
+++ b/src/pages/game-board-markup.test.ts
@@ -10,10 +10,19 @@ const evaderMarkup = readFileSync(
     resolve(process.cwd(), 'src/pages/evader/index.astro'),
     'utf-8'
 )
+const circuitHackerMarkup = readFileSync(
+    resolve(process.cwd(), 'src/pages/circuit-hacker/index.astro'),
+    'utf-8'
+)
 
 describe('Game board page markup', () => {
     it('keeps Reflex and Evader default boards visible before start', () => {
         expect(reflexMarkup).toMatch(/id="game-status"[^>]*class="[^"]*hidden/)
         expect(evaderMarkup).toMatch(/id="game-status"[^>]*class="[^"]*hidden/)
+    })
+
+    it('exposes the Circuit Hacker canvas container and difficulty select', () => {
+        expect(circuitHackerMarkup).toContain('id="game-canvas-container"')
+        expect(circuitHackerMarkup).toContain('id="difficulty-select"')
     })
 })

--- a/src/pages/index.astro
+++ b/src/pages/index.astro
@@ -30,6 +30,7 @@ const idMapping: Record<string, number> = {
   path_navigator: 9,
   evader: 10,
   snake: 11,
+  circuit_hacker: 12,
 }
 
 const difficultyLabels: Partial<Record<GameID, string>> = {

--- a/src/pages/index.astro
+++ b/src/pages/index.astro
@@ -31,6 +31,7 @@ const idMapping: Record<string, number> = {
   evader: 10,
   snake: 11,
   circuit_hacker: 12,
+  '2048': 13,
 }
 
 const difficultyLabels: Partial<Record<GameID, string>> = {

--- a/src/pages/index.astro
+++ b/src/pages/index.astro
@@ -45,6 +45,8 @@ const difficultyLabels: Partial<Record<GameID, string>> = {
   [GameID.PATH_NAVIGATOR]: 'Medium',
   [GameID.EVADER]: 'Medium',
   [GameID.SNAKE]: 'Easy',
+  [GameID.GAME_2048]: 'Medium',
+  [GameID.CIRCUIT_HACKER]: 'Medium',
 }
 
 const durationLabels: Partial<Record<GameID, string>> = {
@@ -58,6 +60,8 @@ const durationLabels: Partial<Record<GameID, string>> = {
   [GameID.REFLEX]: '1 minute',
   [GameID.PATH_NAVIGATOR]: '1-2 minutes',
   [GameID.EVADER]: '1 minute',
+  [GameID.GAME_2048]: '5-10 minutes',
+  [GameID.CIRCUIT_HACKER]: '2-5 minutes',
 }
 
 // Convert Games system data to GameCard format


### PR DESCRIPTION
## Summary
- Implement new Circuit Hacker sci-fi puzzle game with power-flood-fill mechanics and win checks.
- Add game state machine, PixiJS renderer, solvable puzzle generator, and connector math utilities.
- Add difficulty configs and scoring; integrate with the centralized score submission service.
- Add the game page, register on the home page, and configure routing.
- Add Circuit Hacker achievements and integrate with the achievements registry.
- Add unit tests for game logic, generator, renderer, utilities, and init wiring.
- Verified: `bun run test:run` passes (103 files, 2556 tests).

#### Test plan
- [ ] `bun run test:run` passes
- [ ] Game starts and ends correctly on `/circuit-hacker`
- [ ] Score submission works on game over
- [ ] Achievements unlock when thresholds are met
- [ ] Home page and navigation link to the new game

Generated with [Devin](https://devin.ai)

<!-- This is an auto-generated comment: release notes by coderabbit.ai -->
## Summary by CodeRabbit

* **New Features**
  * Launched **“Circuit Hacker”** as a new tile-rotation puzzle with **Easy/Medium/Hard/Expert** modes.
  * Added a dedicated game page with **difficulty selection**, **timer**, **rotation counter**, and start/stop/game-over overlays.
  * Implemented **leaderboard scoring** and end-of-run handling (success submits score; failures do not).
  * Added **four Circuit Hacker achievements** tied to difficulty and speed.
  * Included the game in listings with the correct **icon** and metadata.
  * Added supporting documentation for gameplay rules and implementation plan.
* **Tests**
  * Expanded automated coverage for the game, puzzle generation, renderer behavior, scoring, and achievements.
<!-- end of auto-generated comment: release notes by coderabbit.ai -->