### PR TITLE
fix: consolidate window globals and align game renderer tests

### DIFF
--- a/astro.config.mjs
+++ b/astro.config.mjs
@@ -8,7 +8,10 @@ import vercel from '@astrojs/vercel'
 export default defineConfig({
   output: 'server',
   vite: {
-    plugins: [tailwindcss()],
+    // @tailwindcss/vite's Plugin type comes from a different vite instance
+    // than astro's, causing a structurally-identical type mismatch under
+    // `// @ts-check`. Cast through a variable to satisfy the checker.
+    plugins: [/** @type {any} */ (tailwindcss())],
   },
 
   adapter: vercel(),

--- a/e2e/pages/AuthPage.ts
+++ b/e2e/pages/AuthPage.ts
@@ -1,4 +1,4 @@
-import { Page, Locator } from '@playwright/test'
+import { type Page, type Locator } from '@playwright/test'
 
 export class AuthPage {
     readonly page: Page

--- a/e2e/pages/GamePage.ts
+++ b/e2e/pages/GamePage.ts
@@ -1,4 +1,4 @@
-import { Page, Locator } from '@playwright/test'
+import { type Page, type Locator } from '@playwright/test'
 
 export class GamePage {
     readonly page: Page

--- a/e2e/pages/HomePage.ts
+++ b/e2e/pages/HomePage.ts
@@ -1,4 +1,4 @@
-import { Page, Locator } from '@playwright/test'
+import { type Page, type Locator } from '@playwright/test'
 
 export class HomePage {
     readonly page: Page

--- a/env.d.ts
+++ b/env.d.ts
@@ -23,4 +23,19 @@ interface ImportMeta {
 
 interface Window {
     memoryMatrixGame?: import('@/lib/games/memory-matrix/initFramework').MemoryMatrixInitResult
+    showAchievementAward?: (
+        achievements: import('@/lib/achievements').AchievementNotification[]
+    ) => void
+    showChallengeComplete?: (challengeUpdates: {
+        completedChallenges: Array<{
+            id: string
+            name: string
+            description: string
+            icon: string
+            xpReward: number
+        }>
+        xpEarned: number
+        levelUp: boolean
+        newLevel?: number
+    }) => void
 }

--- a/env.d.ts
+++ b/env.d.ts
@@ -26,16 +26,7 @@ interface Window {
     showAchievementAward?: (
         achievements: import('@/lib/achievements').AchievementNotification[]
     ) => void
-    showChallengeComplete?: (challengeUpdates: {
-        completedChallenges: Array<{
-            id: string
-            name: string
-            description: string
-            icon: string
-            xpReward: number
-        }>
-        xpEarned: number
-        levelUp: boolean
-        newLevel?: number
-    }) => void
+    showChallengeComplete?: (
+        challengeUpdates: import('@/lib/games/core/types').ChallengeUpdates
+    ) => void
 }

--- a/package.json
+++ b/package.json
@@ -20,6 +20,7 @@
     "test:e2e:headed": "playwright test --headed",
     "test:e2e:debug": "playwright test --debug",
     "test:e2e:report": "playwright show-report",
+    "typecheck": "astro check",
     "lint": "eslint .",
     "lint:fix": "eslint . --fix",
     "format": "prettier --write .",

--- a/src/components/AchievementAward.astro
+++ b/src/components/AchievementAward.astro
@@ -199,17 +199,12 @@ const classes = cn(
 <script>
   import type { AchievementNotification } from '@/lib/achievements'
 
-  // Alias to the canonical notification shape so the global
-  // `window.showAchievementAward` signature (declared in scoreService.ts)
-  // stays consistent across the app.
-  type AchievementData = AchievementNotification
-
   class AchievementAward {
     private overlay: HTMLElement
     private backdrop: HTMLElement
     private container: HTMLElement
     private template: HTMLTemplateElement
-    private queue: AchievementData[] = []
+    private queue: AchievementNotification[] = []
     private isShowing = false
 
     constructor() {
@@ -253,7 +248,9 @@ const classes = cn(
     /**
      * Show achievement awards for newly earned achievements
      */
-    async showAchievements(achievements: AchievementData[]): Promise<void> {
+    async showAchievements(
+      achievements: AchievementNotification[]
+    ): Promise<void> {
       if (!achievements || achievements.length === 0) {
         return
       }
@@ -297,7 +294,7 @@ const classes = cn(
      * Show a single achievement
      */
     private async showSingleAchievement(
-      achievement: AchievementData
+      achievement: AchievementNotification
     ): Promise<void> {
       // Create achievement card
       const card = this.createAchievementCard(achievement)
@@ -327,7 +324,9 @@ const classes = cn(
     /**
      * Create achievement card element from template
      */
-    private createAchievementCard(achievement: AchievementData): HTMLElement {
+    private createAchievementCard(
+      achievement: AchievementNotification
+    ): HTMLElement {
       // Clone template
       const clone = this.template.content.cloneNode(true) as DocumentFragment
 
@@ -504,7 +503,9 @@ const classes = cn(
   })
 
   // Global function to show achievements
-  window.showAchievementAward = function (achievements: AchievementData[]) {
+  window.showAchievementAward = function (
+    achievements: AchievementNotification[]
+  ) {
     if (achievementAward) {
       achievementAward.showAchievements(achievements)
     }

--- a/src/components/AchievementAward.astro
+++ b/src/components/AchievementAward.astro
@@ -197,13 +197,12 @@ const classes = cn(
 </style>
 
 <script>
-  interface AchievementData {
-    id: string
-    name: string
-    description: string
-    icon: string
-    rarity: 'common' | 'rare' | 'epic' | 'legendary'
-  }
+  import type { AchievementNotification } from '@/lib/achievements'
+
+  // Alias to the canonical notification shape so the global
+  // `window.showAchievementAward` signature (declared in scoreService.ts)
+  // stays consistent across the app.
+  type AchievementData = AchievementNotification
 
   class AchievementAward {
     private overlay: HTMLElement
@@ -508,13 +507,6 @@ const classes = cn(
   window.showAchievementAward = function (achievements: AchievementData[]) {
     if (achievementAward) {
       achievementAward.showAchievements(achievements)
-    }
-  }
-
-  // Add to global scope for TypeScript
-  declare global {
-    interface Window {
-      showAchievementAward: (achievements: AchievementData[]) => void
     }
   }
 </script>

--- a/src/components/AchievementAward.test.ts
+++ b/src/components/AchievementAward.test.ts
@@ -3,6 +3,7 @@
  */
 
 import { describe, it, expect, beforeEach, afterEach, vi } from 'vitest'
+// @ts-expect-error - jsdom has no bundled types
 import { JSDOM } from 'jsdom'
 import { readFileSync } from 'node:fs'
 import { resolve } from 'node:path'

--- a/src/components/AchievementAward.test.ts
+++ b/src/components/AchievementAward.test.ts
@@ -3,7 +3,6 @@
  */
 
 import { describe, it, expect, beforeEach, afterEach, vi } from 'vitest'
-// @ts-expect-error - jsdom has no bundled types
 import { JSDOM } from 'jsdom'
 import { readFileSync } from 'node:fs'
 import { resolve } from 'node:path'

--- a/src/components/ChallengeComplete.astro
+++ b/src/components/ChallengeComplete.astro
@@ -104,264 +104,277 @@
 </style>
 
 <script>
-  /**
-   * @typedef {Object} ChallengeCompleteData
-   * @property {Array<{id:string,name:string,description:string,icon:string,xpReward:number}>} completedChallenges
-   * @property {number} xpEarned
-   * @property {boolean} levelUp
-   * @property {number | undefined} [newLevel]
-   */
-
-  /** @type {ChallengeCompleteData[]} */
-  const pendingCalls = []
-
-  function ChallengeCompleteManager() {
-    /** @type {HTMLElement|null} */
-    this.overlay = document.getElementById('challenge-complete-overlay')
-    /** @type {HTMLElement|null} */
-    this.card = document.getElementById('challenge-complete-card')
-    /** @type {HTMLTemplateElement|null} */
-    this.template = document.getElementById('challenge-card-template')
-    /** @type {ChallengeCompleteData[]} */
-    this.queue = []
-    this.isShowing = false
-    /** @type {HTMLElement|null} */
-    this.previouslyFocused = null
-    /** @type {number|null} */
-    this.autoDismissTimer = null
-    /** @type {(() => void)|undefined} */
-    this.resolveDismiss = undefined
-    this.keydownHandler = event => this.handleKeydown(event)
-
-    if (this.overlay) {
-      this.overlay.addEventListener('click', event => {
-        const target = /** @type {HTMLElement} */ (event.target)
-        const isBackdrop =
-          target === this.overlay ||
-          (target &&
-            target.dataset &&
-            target.dataset.overlayBackdrop === 'true')
-        if (isBackdrop) {
-          this.dismiss()
-        }
-      })
-    }
+  interface ChallengeCompleteChallenge {
+    id: string
+    name: string
+    description: string
+    icon: string
+    xpReward: number
   }
 
-  ChallengeCompleteManager.prototype.show = function (data) {
-    this.queue.push(data)
-    if (!this.isShowing) {
-      this.processQueue()
-    }
+  interface ChallengeCompleteData {
+    completedChallenges: ChallengeCompleteChallenge[]
+    xpEarned: number
+    levelUp: boolean
+    newLevel?: number
   }
 
-  ChallengeCompleteManager.prototype.processQueue = async function () {
-    if (this.queue.length === 0) {
+  const pendingCalls: ChallengeCompleteData[] = []
+
+  class ChallengeCompleteManager {
+    overlay: HTMLElement | null
+    card: HTMLElement | null
+    template: HTMLTemplateElement | null
+    queue: ChallengeCompleteData[]
+    isShowing: boolean
+    previouslyFocused: HTMLElement | null
+    autoDismissTimer: number | null
+    resolveDismiss: (() => void) | undefined
+    keydownHandler: (event: KeyboardEvent) => void
+
+    constructor() {
+      this.overlay = document.getElementById('challenge-complete-overlay')
+      this.card = document.getElementById('challenge-complete-card')
+      this.template = document.getElementById(
+        'challenge-card-template'
+      ) as HTMLTemplateElement | null
+      this.queue = []
       this.isShowing = false
-      return
+      this.previouslyFocused = null
+      this.autoDismissTimer = null
+      this.resolveDismiss = undefined
+      this.keydownHandler = event => this.handleKeydown(event)
+
+      if (this.overlay) {
+        this.overlay.addEventListener('click', event => {
+          const target = event.target as HTMLElement
+          const isBackdrop =
+            target === this.overlay ||
+            (target &&
+              target.dataset &&
+              target.dataset.overlayBackdrop === 'true')
+          if (isBackdrop) {
+            this.dismiss()
+          }
+        })
+      }
     }
 
-    const data = this.queue[0]
-    const completedChallenges = Array.isArray(data.completedChallenges)
-      ? data.completedChallenges
-      : []
+    show(data: ChallengeCompleteData): void {
+      this.queue.push(data)
+      if (!this.isShowing) {
+        this.processQueue()
+      }
+    }
 
-    if (!completedChallenges.length) {
+    async processQueue(): Promise<void> {
+      if (this.queue.length === 0) {
+        this.isShowing = false
+        return
+      }
+
+      const data = this.queue[0]
+      const completedChallenges = Array.isArray(data.completedChallenges)
+        ? data.completedChallenges
+        : []
+
+      if (!completedChallenges.length) {
+        this.isShowing = false
+        this.queue.shift()
+        this.processQueue()
+        return
+      }
+
+      this.isShowing = true
+
+      for (let i = 0; i < completedChallenges.length; i++) {
+        const challenge = completedChallenges[i]
+        const isLast = i === completedChallenges.length - 1
+        this.renderCard(
+          challenge,
+          challenge.xpReward,
+          isLast ? data.levelUp : false,
+          isLast ? data.newLevel : undefined
+        )
+        this.showOverlay()
+        this.startAutoDismiss()
+        await new Promise<void>(resolve => {
+          this.resolveDismiss = resolve
+        })
+      }
+
       this.isShowing = false
       this.queue.shift()
       this.processQueue()
-      return
     }
 
-    this.isShowing = true
+    renderCard(
+      challenge: ChallengeCompleteChallenge,
+      xpEarned: number,
+      levelUp: boolean,
+      newLevel: number | undefined
+    ): void {
+      if (!this.template || !this.card) {
+        return
+      }
+      const content = this.template.content.cloneNode(true) as DocumentFragment
 
-    for (let i = 0; i < completedChallenges.length; i++) {
-      const challenge = completedChallenges[i]
-      const isLast = i === completedChallenges.length - 1
-      this.renderCard(
-        challenge,
-        challenge.xpReward,
-        isLast ? data.levelUp : false,
-        isLast ? data.newLevel : undefined
-      )
-      this.showOverlay()
-      this.startAutoDismiss()
-      await new Promise(resolve => {
-        this.resolveDismiss = resolve
+      const iconEl = content.querySelector('#challenge-icon')
+      const xpEl = content.querySelector('#xp-earned')
+      const nameEl = content.querySelector('#challenge-name')
+      const descEl = content.querySelector('#challenge-description')
+      if (iconEl) {
+        iconEl.textContent = challenge.icon
+      }
+      if (xpEl) {
+        xpEl.textContent = `+${xpEarned} XP`
+      }
+      if (nameEl) {
+        nameEl.textContent = challenge.name
+      }
+      if (descEl) {
+        descEl.textContent = challenge.description
+      }
+
+      if (levelUp && newLevel !== undefined && newLevel !== null) {
+        const badge = content.querySelector('#level-up-badge')
+        const newLevelEl = content.querySelector('#new-level')
+        if (badge) {
+          badge.classList.remove('hidden')
+        }
+        if (newLevelEl) {
+          newLevelEl.textContent = String(newLevel)
+        }
+      }
+
+      this.card.innerHTML = ''
+      this.card.appendChild(content)
+
+      const continueButton = this.card.querySelector('#challenge-continue')
+      if (continueButton) {
+        continueButton.addEventListener('click', () => this.dismiss())
+      }
+    }
+
+    showOverlay(): void {
+      if (!this.overlay) {
+        return
+      }
+      this.previouslyFocused = document.activeElement as HTMLElement | null
+      this.overlay.classList.remove('hidden')
+      this.overlay.setAttribute('aria-hidden', 'false')
+      document.addEventListener('keydown', this.keydownHandler)
+      this.setInitialFocus()
+    }
+
+    dismiss(): void {
+      if (!this.overlay) {
+        return
+      }
+      this.clearAutoDismiss()
+      this.overlay.classList.add('hidden')
+      this.overlay.setAttribute('aria-hidden', 'true')
+      document.removeEventListener('keydown', this.keydownHandler)
+      this.restoreFocus()
+      const resolver = this.resolveDismiss
+      this.resolveDismiss = undefined
+      if (resolver) {
+        resolver()
+      }
+    }
+
+    setInitialFocus(): void {
+      requestAnimationFrame(() => {
+        const continueButton = this.card?.querySelector('#challenge-continue')
+        const target = (continueButton || this.card) as HTMLElement | null
+        if (target && typeof target.focus === 'function') {
+          target.focus()
+        }
       })
     }
 
-    this.isShowing = false
-    this.queue.shift()
-    this.processQueue()
-  }
-
-  ChallengeCompleteManager.prototype.renderCard = function (
-    challenge,
-    xpEarned,
-    levelUp,
-    newLevel
-  ) {
-    if (!this.template || !this.card) {
-      return
-    }
-    const content = this.template.content.cloneNode(true)
-
-    const iconEl = content.querySelector('#challenge-icon')
-    const xpEl = content.querySelector('#xp-earned')
-    const nameEl = content.querySelector('#challenge-name')
-    const descEl = content.querySelector('#challenge-description')
-    if (iconEl) {
-      iconEl.textContent = challenge.icon
-    }
-    if (xpEl) {
-      xpEl.textContent = `+${xpEarned} XP`
-    }
-    if (nameEl) {
-      nameEl.textContent = challenge.name
-    }
-    if (descEl) {
-      descEl.textContent = challenge.description
-    }
-
-    if (levelUp && newLevel !== undefined && newLevel !== null) {
-      const badge = content.querySelector('#level-up-badge')
-      const newLevelEl = content.querySelector('#new-level')
-      if (badge) {
-        badge.classList.remove('hidden')
+    getFocusableElements(): Element[] {
+      if (!this.card) {
+        return []
       }
-      if (newLevelEl) {
-        newLevelEl.textContent = String(newLevel)
+      const selectors =
+        'button, [href], input, select, textarea, [tabindex]:not([tabindex="-1"])'
+      return Array.from(this.card.querySelectorAll(selectors)).filter(el => {
+        return (
+          el &&
+          !(el as HTMLElement).hasAttribute('disabled') &&
+          (el as HTMLElement).getAttribute('aria-hidden') !== 'true' &&
+          (el as HTMLElement).offsetParent !== null
+        )
+      })
+    }
+
+    handleKeydown(event: KeyboardEvent): void {
+      if (!this.isShowing) {
+        return
       }
-    }
-
-    this.card.innerHTML = ''
-    this.card.appendChild(content)
-
-    const continueButton = this.card.querySelector('#challenge-continue')
-    if (continueButton) {
-      continueButton.addEventListener('click', () => this.dismiss())
-    }
-  }
-
-  ChallengeCompleteManager.prototype.showOverlay = function () {
-    if (!this.overlay) {
-      return
-    }
-    this.previouslyFocused = document.activeElement
-    this.overlay.classList.remove('hidden')
-    this.overlay.setAttribute('aria-hidden', 'false')
-    document.addEventListener('keydown', this.keydownHandler)
-    this.setInitialFocus()
-  }
-
-  ChallengeCompleteManager.prototype.dismiss = function () {
-    if (!this.overlay) {
-      return
-    }
-    this.clearAutoDismiss()
-    this.overlay.classList.add('hidden')
-    this.overlay.setAttribute('aria-hidden', 'true')
-    document.removeEventListener('keydown', this.keydownHandler)
-    this.restoreFocus()
-    const resolver = this.resolveDismiss
-    this.resolveDismiss = undefined
-    if (resolver) {
-      resolver()
-    }
-  }
-
-  ChallengeCompleteManager.prototype.setInitialFocus = function () {
-    requestAnimationFrame(() => {
-      const continueButton = this.card?.querySelector('#challenge-continue')
-      const target = continueButton || this.card
-      if (target && typeof target.focus === 'function') {
-        target.focus()
-      }
-    })
-  }
-
-  ChallengeCompleteManager.prototype.getFocusableElements = function () {
-    if (!this.card) {
-      return []
-    }
-    const selectors =
-      'button, [href], input, select, textarea, [tabindex]:not([tabindex="-1"])'
-    return Array.from(this.card.querySelectorAll(selectors)).filter(el => {
-      return (
-        el &&
-        !el.hasAttribute('disabled') &&
-        el.getAttribute('aria-hidden') !== 'true' &&
-        el.offsetParent !== null
-      )
-    })
-  }
-
-  ChallengeCompleteManager.prototype.handleKeydown = function (event) {
-    if (!this.isShowing) {
-      return
-    }
-    if (event.key === 'Escape') {
-      event.preventDefault()
-      this.dismiss()
-      return
-    }
-
-    if (event.key !== 'Tab') {
-      return
-    }
-
-    const focusable = this.getFocusableElements()
-    if (focusable.length === 0) {
-      event.preventDefault()
-      this.card?.focus()
-      return
-    }
-
-    const first = focusable[0]
-    const last = focusable[focusable.length - 1]
-    const active = document.activeElement
-
-    if (event.shiftKey) {
-      if (active === first || !this.card?.contains(active)) {
+      if (event.key === 'Escape') {
         event.preventDefault()
-        if (last) {
-          last.focus()
+        this.dismiss()
+        return
+      }
+
+      if (event.key !== 'Tab') {
+        return
+      }
+
+      const focusable = this.getFocusableElements()
+      if (focusable.length === 0) {
+        event.preventDefault()
+        this.card?.focus()
+        return
+      }
+
+      const first = focusable[0]
+      const last = focusable[focusable.length - 1]
+      const active = document.activeElement
+
+      if (event.shiftKey) {
+        if (active === first || !this.card?.contains(active)) {
+          event.preventDefault()
+          if (last) {
+            ;(last as HTMLElement).focus()
+          }
+        }
+      } else if (active === last || !this.card?.contains(active)) {
+        event.preventDefault()
+        if (first) {
+          ;(first as HTMLElement).focus()
         }
       }
-    } else if (active === last || !this.card?.contains(active)) {
-      event.preventDefault()
-      if (first) {
-        first.focus()
+    }
+
+    restoreFocus(): void {
+      if (
+        this.previouslyFocused &&
+        document.contains(this.previouslyFocused) &&
+        typeof this.previouslyFocused.focus === 'function'
+      ) {
+        this.previouslyFocused.focus()
       }
+      this.previouslyFocused = null
     }
-  }
 
-  ChallengeCompleteManager.prototype.restoreFocus = function () {
-    if (
-      this.previouslyFocused &&
-      document.contains(this.previouslyFocused) &&
-      typeof this.previouslyFocused.focus === 'function'
-    ) {
-      this.previouslyFocused.focus()
+    startAutoDismiss(): void {
+      this.clearAutoDismiss()
+      this.autoDismissTimer = window.setTimeout(() => this.dismiss(), 5000)
     }
-    this.previouslyFocused = null
-  }
 
-  ChallengeCompleteManager.prototype.startAutoDismiss = function () {
-    this.clearAutoDismiss()
-    this.autoDismissTimer = window.setTimeout(() => this.dismiss(), 5000)
-  }
-
-  ChallengeCompleteManager.prototype.clearAutoDismiss = function () {
-    if (this.autoDismissTimer !== null) {
-      window.clearTimeout(this.autoDismissTimer)
-      this.autoDismissTimer = null
+    clearAutoDismiss(): void {
+      if (this.autoDismissTimer !== null) {
+        window.clearTimeout(this.autoDismissTimer)
+        this.autoDismissTimer = null
+      }
     }
   }
 
   // Initialize and expose globally
-  let manager = null
+  let manager: ChallengeCompleteManager | null = null
 
   document.addEventListener('DOMContentLoaded', () => {
     manager = new ChallengeCompleteManager()
@@ -373,7 +386,7 @@
     }
   })
 
-  window.showChallengeComplete = data => {
+  window.showChallengeComplete = (data: ChallengeCompleteData) => {
     if (manager) {
       manager.show(data)
       return

--- a/src/components/ChallengeComplete.astro
+++ b/src/components/ChallengeComplete.astro
@@ -147,13 +147,11 @@
 
       if (this.overlay) {
         this.overlay.addEventListener('click', event => {
-          const target = event.target as HTMLElement
-          const isBackdrop =
-            target === this.overlay ||
-            (target &&
-              target.dataset &&
-              target.dataset.overlayBackdrop === 'true')
-          if (isBackdrop) {
+          const target = event.target as Node
+          // Dismiss whenever the click lands outside the card (overlay,
+          // backdrop, or the centering wrapper). Clicks inside the card are
+          // preserved.
+          if (this.card && !this.card.contains(target)) {
             this.dismiss()
           }
         })

--- a/src/components/UserDropdown.astro
+++ b/src/components/UserDropdown.astro
@@ -197,8 +197,11 @@ const menuItemClass =
           // session is actually gone; otherwise surface the failure instead
           // of silently indicating success.
           try {
-            const { data: session } = await authClient.getSession()
-            if (!session) {
+            const { data: session, error } = await authClient.getSession()
+            // Only reload if we positively confirmed the session is gone.
+            // A null `data` with an `error` means the check itself failed
+            // (e.g. 5xx / network error), not that the session was destroyed.
+            if (!session && !error) {
               window.location.reload()
               return
             }

--- a/src/components/UserDropdown.astro
+++ b/src/components/UserDropdown.astro
@@ -163,8 +163,11 @@ const menuItemClass =
 
         // If clicking on a link (Profile or Dashboard), close the dropdown after a short delay
         // to allow the navigation to complete
-        const target = event.target as HTMLElement | null
-        if (target && (target.tagName === 'A' || target.closest('a'))) {
+        const target = event.target
+        if (
+          target instanceof Element &&
+          (target.tagName === 'A' || !!target.closest('a'))
+        ) {
           setTimeout(closeDropdown, 100)
         }
       })
@@ -189,17 +192,21 @@ const menuItemClass =
           await authClient.signOut()
           window.location.reload()
         } catch (error) {
-          // Check if this is just a JSON parsing error but logout was successful
-          if (
-            error instanceof Error &&
-            error.message &&
-            error.message.includes('JSON')
-          ) {
-            // Logout probably succeeded, just reload the page
-            window.location.reload()
-            return
+          // signOut can throw spuriously (e.g. response-parsing errors) even
+          // when the session was destroyed. Reload ONLY after confirming the
+          // session is actually gone; otherwise surface the failure instead
+          // of silently indicating success.
+          try {
+            const { data: session } = await authClient.getSession()
+            if (!session) {
+              window.location.reload()
+              return
+            }
+          } catch {
+            // session check also failed — fall through to reset button state
           }
 
+          console.error('[logout] signOut failed:', error)
           // Reset button state on actual error
           logoutBtn.innerHTML = `
             <span class="flex items-center">

--- a/src/components/UserDropdown.astro
+++ b/src/components/UserDropdown.astro
@@ -163,7 +163,8 @@ const menuItemClass =
 
         // If clicking on a link (Profile or Dashboard), close the dropdown after a short delay
         // to allow the navigation to complete
-        if (event.target.tagName === 'A' || event.target.closest('a')) {
+        const target = event.target as HTMLElement | null
+        if (target && (target.tagName === 'A' || target.closest('a'))) {
           setTimeout(closeDropdown, 100)
         }
       })
@@ -189,7 +190,11 @@ const menuItemClass =
           window.location.reload()
         } catch (error) {
           // Check if this is just a JSON parsing error but logout was successful
-          if (error.message && error.message.includes('JSON')) {
+          if (
+            error instanceof Error &&
+            error.message &&
+            error.message.includes('JSON')
+          ) {
             // Logout probably succeeded, just reload the page
             window.location.reload()
             return

--- a/src/lib/achievements.test.ts
+++ b/src/lib/achievements.test.ts
@@ -128,7 +128,7 @@ describe('Achievement System', () => {
 
     describe('Pagination', () => {
         // Mock achievement data for testing
-        const mockAchievements = [
+        const mockAchievements: Achievement[] = [
             {
                 id: 'test_1',
                 name: 'Test Achievement 1',
@@ -136,7 +136,7 @@ describe('Achievement System', () => {
                 logo: '🏆',
                 rarity: AchievementRarity.COMMON,
                 gameId: 'global',
-                scoreThreshold: 100,
+                condition: { type: 'score_threshold', threshold: 100 },
             },
             {
                 id: 'test_2',
@@ -145,7 +145,7 @@ describe('Achievement System', () => {
                 logo: '🥇',
                 rarity: AchievementRarity.RARE,
                 gameId: GameID.TETRIS,
-                scoreThreshold: 200,
+                condition: { type: 'score_threshold', threshold: 200 },
             },
             {
                 id: 'test_3',
@@ -154,7 +154,7 @@ describe('Achievement System', () => {
                 logo: '🥈',
                 rarity: AchievementRarity.EPIC,
                 gameId: GameID.TETRIS,
-                scoreThreshold: 300,
+                condition: { type: 'score_threshold', threshold: 300 },
             },
             {
                 id: 'test_4',
@@ -163,7 +163,7 @@ describe('Achievement System', () => {
                 logo: '🥉',
                 rarity: AchievementRarity.LEGENDARY,
                 gameId: GameID.BUBBLE_SHOOTER,
-                scoreThreshold: 400,
+                condition: { type: 'score_threshold', threshold: 400 },
             },
             {
                 id: 'test_5',
@@ -172,9 +172,9 @@ describe('Achievement System', () => {
                 logo: '🎖️',
                 rarity: AchievementRarity.COMMON,
                 gameId: 'global',
-                scoreThreshold: 500,
+                condition: { type: 'score_threshold', threshold: 500 },
             },
-        ] as unknown as Achievement[]
+        ]
 
         it('should return first page with default page size', () => {
             const result = getPaginatedAchievements(mockAchievements)
@@ -252,7 +252,7 @@ describe('Achievement System', () => {
             expect(result.achievements[0]).toHaveProperty('logo')
             expect(result.achievements[0]).toHaveProperty('rarity')
             expect(result.achievements[0]).toHaveProperty('gameId')
-            expect(result.achievements[0]).toHaveProperty('scoreThreshold')
+            expect(result.achievements[0]).toHaveProperty('condition')
         })
     })
 })

--- a/src/lib/achievements.test.ts
+++ b/src/lib/achievements.test.ts
@@ -8,6 +8,8 @@ import {
     getRarityGlow,
     getPaginatedAchievements,
     ACHIEVEMENTS,
+    AchievementRarity,
+    type Achievement,
 } from './achievements'
 import { GameID } from './games'
 
@@ -69,6 +71,7 @@ describe('Achievement System', () => {
         })
 
         it('should return empty array for non-existent game', () => {
+            // @ts-expect-error Testing invalid input
             const achievements = getAchievementsByGame('non_existent')
             expect(achievements).toHaveLength(0)
         })
@@ -86,17 +89,33 @@ describe('Achievement System', () => {
 
     describe('Rarity Styling Helpers', () => {
         it('should return correct colors for rarities', () => {
-            expect(getRarityColor('common')).toContain('cetus-ink-muted')
-            expect(getRarityColor('rare')).toContain('text-cetus-accent ')
-            expect(getRarityColor('epic')).toContain('cetus-accent-3')
-            expect(getRarityColor('legendary')).toContain('cetus-accent-2')
+            expect(getRarityColor(AchievementRarity.COMMON)).toContain(
+                'cetus-ink-muted'
+            )
+            expect(getRarityColor(AchievementRarity.RARE)).toContain(
+                'text-cetus-accent '
+            )
+            expect(getRarityColor(AchievementRarity.EPIC)).toContain(
+                'cetus-accent-3'
+            )
+            expect(getRarityColor(AchievementRarity.LEGENDARY)).toContain(
+                'cetus-accent-2'
+            )
         })
 
         it('should return correct glow effects for rarities', () => {
-            expect(getRarityGlow('common')).toContain('cetus-ink-muted')
-            expect(getRarityGlow('rare')).toContain('shadow-cetus-accent/25')
-            expect(getRarityGlow('epic')).toContain('cetus-accent-3')
-            expect(getRarityGlow('legendary')).toContain('cetus-accent-2')
+            expect(getRarityGlow(AchievementRarity.COMMON)).toContain(
+                'cetus-ink-muted'
+            )
+            expect(getRarityGlow(AchievementRarity.RARE)).toContain(
+                'shadow-cetus-accent/25'
+            )
+            expect(getRarityGlow(AchievementRarity.EPIC)).toContain(
+                'cetus-accent-3'
+            )
+            expect(getRarityGlow(AchievementRarity.LEGENDARY)).toContain(
+                'cetus-accent-2'
+            )
         })
 
         it('should handle invalid rarity gracefully', () => {
@@ -115,7 +134,7 @@ describe('Achievement System', () => {
                 name: 'Test Achievement 1',
                 description: 'First test achievement',
                 logo: '🏆',
-                rarity: 'common',
+                rarity: AchievementRarity.COMMON,
                 gameId: 'global',
                 scoreThreshold: 100,
             },
@@ -124,8 +143,8 @@ describe('Achievement System', () => {
                 name: 'Test Achievement 2',
                 description: 'Second test achievement',
                 logo: '🥇',
-                rarity: 'rare',
-                gameId: 'tetris',
+                rarity: AchievementRarity.RARE,
+                gameId: GameID.TETRIS,
                 scoreThreshold: 200,
             },
             {
@@ -133,8 +152,8 @@ describe('Achievement System', () => {
                 name: 'Test Achievement 3',
                 description: 'Third test achievement',
                 logo: '🥈',
-                rarity: 'epic',
-                gameId: 'tetris',
+                rarity: AchievementRarity.EPIC,
+                gameId: GameID.TETRIS,
                 scoreThreshold: 300,
             },
             {
@@ -142,8 +161,8 @@ describe('Achievement System', () => {
                 name: 'Test Achievement 4',
                 description: 'Fourth test achievement',
                 logo: '🥉',
-                rarity: 'legendary',
-                gameId: 'bubble_shooter',
+                rarity: AchievementRarity.LEGENDARY,
+                gameId: GameID.BUBBLE_SHOOTER,
                 scoreThreshold: 400,
             },
             {
@@ -151,11 +170,11 @@ describe('Achievement System', () => {
                 name: 'Test Achievement 5',
                 description: 'Fifth test achievement',
                 logo: '🎖️',
-                rarity: 'common',
+                rarity: AchievementRarity.COMMON,
                 gameId: 'global',
                 scoreThreshold: 500,
             },
-        ]
+        ] as unknown as Achievement[]
 
         it('should return first page with default page size', () => {
             const result = getPaginatedAchievements(mockAchievements)

--- a/src/lib/achievements.ts
+++ b/src/lib/achievements.ts
@@ -43,8 +43,12 @@ export interface Achievement {
     condition: {
         type: 'score_threshold' | 'games_played' | 'in_game' | 'custom'
         threshold?: number
-        // For in-game achievements, a check function is required
-        check?: (gameData: AchievementCheckData, score: number) => boolean
+        // For in-game achievements, a check function is required.
+        // Declared as a method (not a function-property) so the parameter is
+        // checked bivariantly; individual achievements narrow `gameData` to
+        // their game-specific shape, which is sound at the call site where the
+        // real game data is passed in.
+        check?(gameData: AchievementCheckData, score: number): boolean
         customCheck?: string // For future extensibility
     }
     isHidden?: boolean // Hidden until unlocked

--- a/src/lib/achievements.ts
+++ b/src/lib/achievements.ts
@@ -51,6 +51,17 @@ export interface Achievement {
     rarity: AchievementRarity
 }
 
+// Shape of an achievement notification payload dispatched to the global
+// `window.showAchievementAward` handler (see scoreService.ts). Shared by all
+// game init frameworks so the global Window augmentation stays consistent.
+export interface AchievementNotification {
+    id: string
+    name: string
+    description: string
+    icon: string
+    rarity: AchievementRarity
+}
+
 // Combined type for user achievements with details
 export type UserAchievementWithDetails = UserAchievementRecord & {
     achievement: Achievement

--- a/src/lib/auth.test.ts
+++ b/src/lib/auth.test.ts
@@ -149,6 +149,23 @@ describe('Auth Env Validation', () => {
 })
 
 describe('Google-only Auth Integration', () => {
+    // The better-auth client's typed `data` payload for social sign-in omits the
+    // `user`/`isNewUser` fields the mock supplies, so assert against this typed
+    // view of the response instead of an `any` cast.
+    type SocialSignInData = {
+        user?: {
+            id: string
+            email: string
+            name?: string
+            emailVerified?: boolean
+        }
+        isNewUser?: boolean
+    }
+    const socialData = (
+        result: Awaited<ReturnType<typeof authClient.signIn.social>>
+    ): SocialSignInData | undefined =>
+        result.data as SocialSignInData | undefined
+
     beforeEach(() => {
         vi.clearAllMocks()
     })
@@ -173,7 +190,7 @@ describe('Google-only Auth Integration', () => {
             provider: 'google',
             callbackURL: '/',
         })
-        expect((result.data as any)?.user).toEqual(googleUser)
+        expect(socialData(result)?.user).toEqual(googleUser)
     })
 
     it('handles Google OAuth registration for a new user', async () => {
@@ -199,8 +216,8 @@ describe('Google-only Auth Integration', () => {
             provider: 'google',
             callbackURL: '/profile',
         })
-        expect((result.data as any)?.isNewUser).toBe(true)
-        expect((result.data as any)?.user).toEqual(newGoogleUser)
+        expect(socialData(result)?.isNewUser).toBe(true)
+        expect(socialData(result)?.user).toEqual(newGoogleUser)
     })
 
     it('handles Google OAuth errors', async () => {

--- a/src/lib/auth.test.ts
+++ b/src/lib/auth.test.ts
@@ -173,7 +173,7 @@ describe('Google-only Auth Integration', () => {
             provider: 'google',
             callbackURL: '/',
         })
-        expect(result.data?.user).toEqual(googleUser)
+        expect((result.data as any)?.user).toEqual(googleUser)
     })
 
     it('handles Google OAuth registration for a new user', async () => {
@@ -199,8 +199,8 @@ describe('Google-only Auth Integration', () => {
             provider: 'google',
             callbackURL: '/profile',
         })
-        expect(result.data?.isNewUser).toBe(true)
-        expect(result.data?.user).toEqual(newGoogleUser)
+        expect((result.data as any)?.isNewUser).toBe(true)
+        expect((result.data as any)?.user).toEqual(newGoogleUser)
     })
 
     it('handles Google OAuth errors', async () => {

--- a/src/lib/auth.ts
+++ b/src/lib/auth.ts
@@ -47,18 +47,21 @@ export const auth = betterAuth({
     },
     socialProviders: {
         google: {
-            clientId: googleClientId,
-            clientSecret: googleClientSecret,
+            clientId: googleClientId as string,
+            clientSecret: googleClientSecret as string,
         },
     },
     session: {
         expiresIn: 60 * 60 * 24 * 7, // 7 days
         updateAge: 60 * 60 * 24, // 1 day
+        // `cookie` is accepted by Better Auth at runtime but absent from the
+        // generated session-options type; cast to satisfy the type checker.
         cookie: {
             sameSite: 'lax',
             secure: import.meta.env.PROD,
             httpOnly: true,
-        },
+            // eslint-disable-next-line @typescript-eslint/no-explicit-any
+        } as any,
     },
     trustedOrigins: baseURL ? [baseURL] : [],
     secret,

--- a/src/lib/games/2048/initFramework.test.ts
+++ b/src/lib/games/2048/initFramework.test.ts
@@ -64,7 +64,7 @@ vi.mock('pixi.js', () => {
 })
 
 import { init2048GameFramework } from './initFramework'
-import type { Direction } from './types'
+import type { Direction, Tile } from './types'
 import { Application } from 'pixi.js'
 
 const NO_MOVE_RESULT = {
@@ -229,7 +229,7 @@ describe('init2048GameFramework', () => {
         it('does not move before the game starts', async () => {
             // Clean up the beforeEach game so its keydown listener doesn't
             // intercept the event dispatched against the fresh instance.
-            result.cleanup()
+            result!.cleanup()
             result = undefined
 
             const fresh = await init2048GameFramework()
@@ -429,7 +429,7 @@ describe('init2048GameFramework', () => {
             expect(state.moveCount).toBe(0)
             const tiles = state.board
                 .flat()
-                .filter((t): t is { value: number } => t !== null)
+                .filter((t): t is Tile => t !== null)
             // A fresh run spawns exactly INITIAL_TILES (2) tiles, not the
             // accumulated tiles from the previous run.
             expect(tiles.length).toBe(2)
@@ -622,7 +622,14 @@ describe('init2048GameFramework', () => {
             moveSpy.mockReturnValueOnce({
                 ...NO_MOVE_RESULT,
                 moved: true,
-                animations: [{ type: 'move', tileId: 'x', from: {}, to: {} }],
+                animations: [
+                    {
+                        type: 'move',
+                        tileId: 'x',
+                        from: { row: 0, col: 0 },
+                        to: { row: 0, col: 0 },
+                    },
+                ],
             })
             document.dispatchEvent(
                 new KeyboardEvent('keydown', {

--- a/src/lib/games/2048/initFramework.ts
+++ b/src/lib/games/2048/initFramework.ts
@@ -16,20 +16,7 @@ import {
     handleGameError,
 } from '@/lib/games/core/errors'
 
-// Achievement notification type
-interface AchievementNotification {
-    id: string
-    name: string
-    description: string
-    icon: string
-    rarity: 'common' | 'rare' | 'epic' | 'legendary'
-}
-
-declare global {
-    interface Window {
-        showAchievementAward?: (achievements: AchievementNotification[]) => void
-    }
-}
+import { type AchievementNotification } from '@/lib/achievements'
 
 export interface Game2048InitResult {
     game: Game2048

--- a/src/lib/games/bejeweled/init.test.ts
+++ b/src/lib/games/bejeweled/init.test.ts
@@ -329,7 +329,7 @@ describe('initBejeweledGame', () => {
             const gameInstance = vi.mocked(BejeweledGame).mock.results[0].value
             const onCall = vi
                 .mocked(gameInstance.on)
-                .mock.calls.find(c => c[0] === 'end')
+                .mock.calls.find((c: any[]) => c[0] === 'end')
 
             expect(onCall).toBeDefined()
             const handler = onCall![1] as (...args: unknown[]) => void
@@ -364,7 +364,7 @@ describe('initBejeweledGame', () => {
             const gameInstance = vi.mocked(BejeweledGame).mock.results[0].value
             const onCall = vi
                 .mocked(gameInstance.on)
-                .mock.calls.find(c => c[0] === 'end')
+                .mock.calls.find((c: any[]) => c[0] === 'end')
 
             expect(onCall).toBeDefined()
             const handler = onCall![1] as (...args: unknown[]) => void

--- a/src/lib/games/bejeweled/init.test.ts
+++ b/src/lib/games/bejeweled/init.test.ts
@@ -329,7 +329,7 @@ describe('initBejeweledGame', () => {
             const gameInstance = vi.mocked(BejeweledGame).mock.results[0].value
             const onCall = vi
                 .mocked(gameInstance.on)
-                .mock.calls.find((c: any[]) => c[0] === 'end')
+                .mock.calls.find((c: unknown[]) => c[0] === 'end')
 
             expect(onCall).toBeDefined()
             const handler = onCall![1] as (...args: unknown[]) => void
@@ -364,7 +364,7 @@ describe('initBejeweledGame', () => {
             const gameInstance = vi.mocked(BejeweledGame).mock.results[0].value
             const onCall = vi
                 .mocked(gameInstance.on)
-                .mock.calls.find((c: any[]) => c[0] === 'end')
+                .mock.calls.find((c: unknown[]) => c[0] === 'end')
 
             expect(onCall).toBeDefined()
             const handler = onCall![1] as (...args: unknown[]) => void

--- a/src/lib/games/bejeweled/init.ts
+++ b/src/lib/games/bejeweled/init.ts
@@ -36,20 +36,7 @@ export interface BejeweledInitResult {
     cleanup: () => void
 }
 
-// Minimal shape returned by /api/scores newAchievements payload
-interface AchievementNotification {
-    id: string
-    name: string
-    description: string
-    icon: string
-    rarity: 'common' | 'rare' | 'epic' | 'legendary'
-}
-
-declare global {
-    interface Window {
-        showAchievementAward?: (achievements: AchievementNotification[]) => void
-    }
-}
+import { type AchievementNotification } from '@/lib/achievements'
 
 export async function initBejeweledGame(
     customConfig?: Partial<BejeweledConfig>,

--- a/src/lib/games/bubble-shooter/initFramework.test.ts
+++ b/src/lib/games/bubble-shooter/initFramework.test.ts
@@ -638,7 +638,7 @@ describe('initBubbleShooterGameFramework', () => {
 
             const onGameEndCall = vi
                 .mocked(gameMock.on)
-                .mock.calls.find(call => call[0] === 'end')
+                .mock.calls.find((call: any[]) => call[0] === 'end')
             const onGameEnd = onGameEndCall?.[1] as
                 | ((...args: unknown[]) => unknown)
                 | undefined
@@ -660,7 +660,7 @@ describe('initBubbleShooterGameFramework', () => {
             const gameMock = vi.mocked(BubbleShooterGame).mock.results[0].value
             const onGameEndCall = vi
                 .mocked(gameMock.on)
-                .mock.calls.find(call => call[0] === 'end')
+                .mock.calls.find((call: any[]) => call[0] === 'end')
             const onGameEnd = onGameEndCall?.[1] as
                 | ((...args: unknown[]) => unknown)
                 | undefined

--- a/src/lib/games/bubble-shooter/initFramework.test.ts
+++ b/src/lib/games/bubble-shooter/initFramework.test.ts
@@ -1001,14 +1001,15 @@ describe('initBubbleShooterGameFramework', () => {
                     >
                 }
             )._canvasListeners
+            const baseState = gameMock.getState()
             vi.mocked(gameMock.getState).mockReturnValue({
-                ...gameMock.getState(),
+                ...baseState,
                 isActive: true,
                 isPaused: false,
                 projectile: null,
-                currentBubble: null,
+                currentBubble: { x: 300, y: 700, color: 0xff0000 },
                 shooter: { x: 300, y: 740 },
-            } as any)
+            })
             vi.mocked(gameMock.setAimAngle).mockClear()
             listeners['pointermove']?.[0]?.(
                 new MouseEvent('pointermove', { clientX: 100, clientY: 100 })

--- a/src/lib/games/bubble-shooter/initFramework.test.ts
+++ b/src/lib/games/bubble-shooter/initFramework.test.ts
@@ -1007,7 +1007,7 @@ describe('initBubbleShooterGameFramework', () => {
                 isActive: true,
                 isPaused: false,
                 projectile: null,
-                currentBubble: { x: 300, y: 700, color: 0xff0000 },
+                currentBubble: null,
                 shooter: { x: 300, y: 740 },
             })
             vi.mocked(gameMock.setAimAngle).mockClear()

--- a/src/lib/games/bubble-shooter/initFramework.test.ts
+++ b/src/lib/games/bubble-shooter/initFramework.test.ts
@@ -435,7 +435,7 @@ describe('initBubbleShooterGameFramework', () => {
     })
 
     describe('canvas aim/shoot handlers', () => {
-        it('mousemove calls game.setAimAngle when active', async () => {
+        it('pointermove calls game.setAimAngle when active', async () => {
             const { BubbleShooterGame } = await import('./BubbleShooterGame')
             const { BubbleShooterRenderer } = await import(
                 './BubbleShooterRenderer'
@@ -462,13 +462,13 @@ describe('initBubbleShooterGameFramework', () => {
                 shooter: { x: 300, y: 740 },
             } as any)
 
-            listeners['mousemove']?.[0]?.(
-                new MouseEvent('mousemove', { clientX: 100, clientY: 100 })
+            listeners['pointermove']?.[0]?.(
+                new MouseEvent('pointermove', { clientX: 100, clientY: 100 })
             )
             expect(gameMock.setAimAngle).toHaveBeenCalled()
         })
 
-        it('click calls game.shoot', async () => {
+        it('pointerdown calls game.shoot', async () => {
             const { BubbleShooterGame } = await import('./BubbleShooterGame')
             const { BubbleShooterRenderer } = await import(
                 './BubbleShooterRenderer'
@@ -486,7 +486,7 @@ describe('initBubbleShooterGameFramework', () => {
                 }
             )._canvasListeners
 
-            listeners['click']?.[0]?.(new MouseEvent('click'))
+            listeners['pointerdown']?.[0]?.(new MouseEvent('pointerdown'))
             expect(gameMock.shoot).toHaveBeenCalled()
         })
     })
@@ -938,7 +938,7 @@ describe('initBubbleShooterGameFramework', () => {
             res!.cleanup()
         })
 
-        it('mousemove ignores input when the game is not active', async () => {
+        it('pointermove ignores input when the game is not active', async () => {
             const { BubbleShooterGame } = await import('./BubbleShooterGame')
             const { BubbleShooterRenderer } = await import(
                 './BubbleShooterRenderer'
@@ -960,13 +960,13 @@ describe('initBubbleShooterGameFramework', () => {
                 isActive: false,
             } as any)
             vi.mocked(gameMock.setAimAngle).mockClear()
-            listeners['mousemove']?.[0]?.(
-                new MouseEvent('mousemove', { clientX: 100, clientY: 100 })
+            listeners['pointermove']?.[0]?.(
+                new MouseEvent('pointermove', { clientX: 100, clientY: 100 })
             )
             expect(gameMock.setAimAngle).not.toHaveBeenCalled()
         })
 
-        it('mousemove aims from the shooter when currentBubble is null', async () => {
+        it('pointermove aims from the shooter when currentBubble is null', async () => {
             const { BubbleShooterGame } = await import('./BubbleShooterGame')
             const { BubbleShooterRenderer } = await import(
                 './BubbleShooterRenderer'
@@ -992,8 +992,8 @@ describe('initBubbleShooterGameFramework', () => {
                 shooter: { x: 300, y: 740 },
             } as any)
             vi.mocked(gameMock.setAimAngle).mockClear()
-            listeners['mousemove']?.[0]?.(
-                new MouseEvent('mousemove', { clientX: 100, clientY: 100 })
+            listeners['pointermove']?.[0]?.(
+                new MouseEvent('pointermove', { clientX: 100, clientY: 100 })
             )
             expect(gameMock.setAimAngle).toHaveBeenCalled()
         })

--- a/src/lib/games/bubble-shooter/initFramework.test.ts
+++ b/src/lib/games/bubble-shooter/initFramework.test.ts
@@ -468,7 +468,7 @@ describe('initBubbleShooterGameFramework', () => {
             expect(gameMock.setAimAngle).toHaveBeenCalled()
         })
 
-        it('pointerdown calls game.shoot', async () => {
+        it('pointerdown aims before shooting', async () => {
             const { BubbleShooterGame } = await import('./BubbleShooterGame')
             const { BubbleShooterRenderer } = await import(
                 './BubbleShooterRenderer'
@@ -486,7 +486,25 @@ describe('initBubbleShooterGameFramework', () => {
                 }
             )._canvasListeners
 
-            listeners['pointerdown']?.[0]?.(new MouseEvent('pointerdown'))
+            // The pointerdown handler must update aim before shooting so a
+            // tap shoots toward the touch point, not the last pointermove
+            // position. Gate on active state so setAimAngle is reached.
+            vi.mocked(gameMock.getState).mockReturnValue({
+                ...gameMock.getState(),
+                isActive: true,
+                isPaused: false,
+                projectile: null,
+                currentBubble: { x: 300, y: 700, color: 0xff0000 },
+                shooter: { x: 300, y: 740 },
+            } as any)
+            vi.mocked(gameMock.setAimAngle).mockClear()
+            vi.mocked(gameMock.shoot).mockClear()
+
+            listeners['pointerdown']?.[0]?.(
+                new MouseEvent('pointerdown', { clientX: 100, clientY: 100 })
+            )
+
+            expect(gameMock.setAimAngle).toHaveBeenCalledBefore(gameMock.shoot)
             expect(gameMock.shoot).toHaveBeenCalled()
         })
     })

--- a/src/lib/games/bubble-shooter/initFramework.ts
+++ b/src/lib/games/bubble-shooter/initFramework.ts
@@ -484,6 +484,11 @@ function setupCanvasControls(
     }
 
     const pointerDownHandler = (e: PointerEvent) => {
+        // Ignore non-primary presses (right/middle click) so only the main
+        // button / touch / pen tip can aim and shoot.
+        if (e.button !== 0) {
+            return
+        }
         // Update aim on press so a tap shoots toward the touch point, not the
         // last pointermove position (which may not have fired on touch).
         pointerMoveHandler(e)

--- a/src/lib/games/bubble-shooter/initFramework.ts
+++ b/src/lib/games/bubble-shooter/initFramework.ts
@@ -19,20 +19,7 @@ import {
     handleGameError,
 } from '@/lib/games/core/errors'
 
-// Achievement notification type
-interface AchievementNotification {
-    id: string
-    name: string
-    description: string
-    icon: string
-    rarity: 'common' | 'rare' | 'epic' | 'legendary'
-}
-
-declare global {
-    interface Window {
-        showAchievementAward?: (achievements: AchievementNotification[]) => void
-    }
-}
+import { type AchievementNotification } from '@/lib/achievements'
 
 export interface BubbleShooterInitResult {
     game: BubbleShooterGame

--- a/src/lib/games/bubble-shooter/initFramework.ts
+++ b/src/lib/games/bubble-shooter/initFramework.ts
@@ -471,15 +471,19 @@ function setupCanvasControls(
         return () => {}
     }
 
-    const mouseMoveHandler = (e: MouseEvent) => {
+    // Prevent the browser from intercepting touch gestures (scroll, zoom)
+    // so pointer events reach our aim/shoot handlers on touch devices.
+    canvas.style.touchAction = 'none'
+
+    const pointerMoveHandler = (e: PointerEvent) => {
         const state = game.getState()
         if (!state.isActive || state.isPaused || state.projectile) {
             return
         }
 
         const rect = canvas.getBoundingClientRect()
-        const mouseX = e.clientX - rect.left
-        const mouseY = e.clientY - rect.top
+        const pointerX = e.clientX - rect.left
+        const pointerY = e.clientY - rect.top
 
         const aimFromY = state.currentBubble
             ? state.currentBubble.y
@@ -488,20 +492,23 @@ function setupCanvasControls(
             ? state.currentBubble.x
             : state.shooter.x
 
-        const angle = Math.atan2(mouseY - aimFromY, mouseX - aimFromX)
+        const angle = Math.atan2(pointerY - aimFromY, pointerX - aimFromX)
         game.setAimAngle(angle)
     }
 
-    const clickHandler = () => {
+    const pointerDownHandler = (e: PointerEvent) => {
+        // Update aim on press so a tap shoots toward the touch point, not the
+        // last pointermove position (which may not have fired on touch).
+        pointerMoveHandler(e)
         game.shoot()
     }
 
-    canvas.addEventListener('mousemove', mouseMoveHandler)
-    canvas.addEventListener('click', clickHandler)
+    canvas.addEventListener('pointermove', pointerMoveHandler)
+    canvas.addEventListener('pointerdown', pointerDownHandler)
 
     return () => {
-        canvas.removeEventListener('mousemove', mouseMoveHandler)
-        canvas.removeEventListener('click', clickHandler)
+        canvas.removeEventListener('pointermove', pointerMoveHandler)
+        canvas.removeEventListener('pointerdown', pointerDownHandler)
     }
 }
 

--- a/src/lib/games/core/GameInitializer.test.ts
+++ b/src/lib/games/core/GameInitializer.test.ts
@@ -92,7 +92,7 @@ describe('GameInitializer', () => {
             rendererConfig: {
                 type: 'dom',
                 container: '#game-container',
-            } as unknown as Record<string, unknown>,
+            },
             callbacks,
         })
         initializers.push(initializer)

--- a/src/lib/games/core/GameInitializer.test.ts
+++ b/src/lib/games/core/GameInitializer.test.ts
@@ -92,7 +92,7 @@ describe('GameInitializer', () => {
             rendererConfig: {
                 type: 'dom',
                 container: '#game-container',
-            } as RendererConfig,
+            } as unknown as Record<string, unknown>,
             callbacks,
         })
         initializers.push(initializer)
@@ -408,7 +408,7 @@ describe('GameInitializer', () => {
                 rendererConfig: {
                     type: 'dom',
                     container: '#game-container',
-                } as RendererConfig,
+                } as unknown as Record<string, unknown>,
             })
             initializers.push(achInitializer)
 
@@ -474,8 +474,12 @@ describe('GameInitializer', () => {
         it('setupEventHandlers early-returns when this.game is null (line 208)', () => {
             const config = {
                 gameId: GameID.TETRIS,
-                gameClass: TestGame,
-                rendererClass: TestRenderer,
+                gameClass: TestGame as unknown as new (
+                    ...args: unknown[]
+                ) => TestGame,
+                rendererClass: TestRenderer as unknown as new (
+                    ...args: unknown[]
+                ) => TestRenderer,
                 gameConfig: {
                     duration: 60,
                     achievementIntegration: false,
@@ -494,8 +498,12 @@ describe('GameInitializer', () => {
         it('setupAchievementHandling early-returns when this.game is null (line 267)', () => {
             const config = {
                 gameId: GameID.TETRIS,
-                gameClass: TestGame,
-                rendererClass: TestRenderer,
+                gameClass: TestGame as unknown as new (
+                    ...args: unknown[]
+                ) => TestGame,
+                rendererClass: TestRenderer as unknown as new (
+                    ...args: unknown[]
+                ) => TestRenderer,
                 gameConfig: {
                     duration: 60,
                     achievementIntegration: false,

--- a/src/lib/games/core/GameInitializer.ts
+++ b/src/lib/games/core/GameInitializer.ts
@@ -7,6 +7,7 @@ import type {
     ScoringConfig,
 } from './types'
 import type { GameID } from '@/lib/games'
+import type { AchievementNotification } from '@/lib/achievements'
 
 export interface GameInitializerConfig<
     TGame extends BaseGame,
@@ -275,7 +276,7 @@ export class GameInitializer<
         // Listen for game end events to show achievement notifications
         this.game.on('end', event => {
             const data = event.data as {
-                newAchievements?: string[]
+                newAchievements?: AchievementNotification[]
                 challengeUpdates?: ChallengeUpdates
             }
             if (data?.newAchievements && data.newAchievements.length > 0) {
@@ -328,12 +329,5 @@ export class GameInitializer<
 
         // Clear element references
         this.elements = {}
-    }
-}
-
-// Type augmentation for global achievement function
-declare global {
-    interface Window {
-        showAchievementAward?: (achievements: string[]) => void
     }
 }

--- a/src/lib/games/core/GameInitializer.ts
+++ b/src/lib/games/core/GameInitializer.ts
@@ -281,12 +281,18 @@ export class GameInitializer<
             }
             if (data?.newAchievements && data.newAchievements.length > 0) {
                 // Show achievement notifications using global function
-                if (typeof window.showAchievementAward === 'function') {
+                if (
+                    typeof window !== 'undefined' &&
+                    typeof window.showAchievementAward === 'function'
+                ) {
                     window.showAchievementAward(data.newAchievements)
                 }
             }
             if (data?.challengeUpdates?.completedChallenges?.length) {
-                if (typeof window.showChallengeComplete === 'function') {
+                if (
+                    typeof window !== 'undefined' &&
+                    typeof window.showChallengeComplete === 'function'
+                ) {
                     window.showChallengeComplete(data.challengeUpdates)
                 }
             }

--- a/src/lib/games/evader/EvaderGame.test.ts
+++ b/src/lib/games/evader/EvaderGame.test.ts
@@ -528,6 +528,53 @@ describe('EvaderGame', () => {
         })
     })
 
+    describe('keyboard and touch source overlap', () => {
+        it('should preserve movement when touch releases a key still held by keyboard', () => {
+            game.start()
+            const initialY = game.getState().player.y
+
+            // Keyboard holds ArrowUp, then D-pad presses the same ArrowUp
+            game.pressKey('ArrowUp', 'keyboard')
+            game.pressKey('ArrowUp', 'touch')
+
+            // D-pad releases — keyboard ArrowUp is still physically held
+            game.releaseKey('ArrowUp', 'touch')
+            game.update(0.1)
+
+            const newY = game.getState().player.y
+            expect(newY).toBeLessThan(initialY)
+        })
+
+        it('should preserve movement when keyboard releases a key still held by touch', () => {
+            game.start()
+            const initialY = game.getState().player.y
+
+            game.pressKey('ArrowUp', 'touch')
+            game.pressKey('ArrowUp', 'keyboard')
+
+            // Keyboard releases — D-pad ArrowUp is still pressed
+            game.releaseKey('ArrowUp', 'keyboard')
+            game.update(0.1)
+
+            const newY = game.getState().player.y
+            expect(newY).toBeLessThan(initialY)
+        })
+
+        it('should stop movement only when both sources release', () => {
+            game.start()
+            const initialY = game.getState().player.y
+
+            game.pressKey('ArrowUp', 'keyboard')
+            game.pressKey('ArrowUp', 'touch')
+            game.releaseKey('ArrowUp', 'touch')
+            game.releaseKey('ArrowUp', 'keyboard')
+
+            game.update(0.1)
+            const afterReleaseY = game.getState().player.y
+            expect(afterReleaseY).toBe(initialY)
+        })
+    })
+
     describe('getGameData contract', () => {
         it('returns EvaderGameData shape with longestSurvivalTime', () => {
             const data = (

--- a/src/lib/games/evader/EvaderGame.ts
+++ b/src/lib/games/evader/EvaderGame.ts
@@ -7,6 +7,10 @@ import type { GameObject, GameHistoryEntry } from './types'
 import { clamp, rectOverlap, generateId } from '@/lib/games/shared/utils'
 import { rollSpawnType } from '@/lib/games/shared/spawner'
 
+/** Input source for pressKey/releaseKey. Keyboard and touch are tracked
+ * independently so releasing one source doesn't drop a key held by the other. */
+export type InputSource = 'keyboard' | 'touch'
+
 // Default configuration for the Evader game
 export const DEFAULT_EVADER_CONFIG: EvaderConfig = {
     // BaseGameConfig — Evader is a 60-second countdown game.
@@ -34,7 +38,11 @@ export class EvaderGame extends BaseGame<
     EvaderStats
 > {
     private spawnTimerId: number | null = null
-    private rawHeldKeys: Set<string> = new Set()
+    // Track keyboard and touch inputs separately so releasing one source
+    // (e.g. the D-pad) doesn't drop a key still physically held by the other
+    // (e.g. the keyboard). Both feed getActiveDirections() via union.
+    private keyboardHeldKeys: Set<string> = new Set()
+    private touchHeldKeys: Set<string> = new Set()
 
     constructor(
         config: Partial<EvaderConfig> = {},
@@ -80,7 +88,7 @@ export class EvaderGame extends BaseGame<
     }
 
     protected onGameStart(): void {
-        this.rawHeldKeys.clear()
+        this.clearHeldKeys()
         this.startSpawnTimer()
         this.emitStateChange()
     }
@@ -95,12 +103,12 @@ export class EvaderGame extends BaseGame<
 
     protected onGameEnd(_finalScore: number, _finalStats: EvaderStats): void {
         this.stopSpawnTimer()
-        this.rawHeldKeys.clear()
+        this.clearHeldKeys()
     }
 
     protected onGameReset(): void {
         this.stopSpawnTimer()
-        this.rawHeldKeys.clear()
+        this.clearHeldKeys()
         this.emitStateChange()
     }
 
@@ -256,19 +264,25 @@ export class EvaderGame extends BaseGame<
         this.emitStateChange()
     }
 
-    pressKey(key: string): void {
+    pressKey(key: string, source: InputSource = 'keyboard'): void {
         const movementKey = normalizeMovementKey(key)
-        if (movementKey) {
-            this.rawHeldKeys.add(key)
+        if (!movementKey) {
+            return
         }
+        this.heldKeysFor(source).add(key)
     }
 
-    releaseKey(key: string): void {
-        this.rawHeldKeys.delete(key)
-        // Clear case variants to handle Shift state changes between keydown/keyup.
-        // e.g. press W (Shift held) adds 'W', release w (Shift released) must also remove 'W'.
-        this.rawHeldKeys.delete(key.toUpperCase())
-        this.rawHeldKeys.delete(key.toLowerCase())
+    releaseKey(key: string, source: InputSource = 'keyboard'): void {
+        const held = this.heldKeysFor(source)
+        held.delete(key)
+        if (source === 'keyboard') {
+            // Clear case variants to handle Shift state changes between
+            // keydown/keyup. e.g. press W (Shift held) adds 'W', release w
+            // (Shift released) must also remove 'W'. Touch sources use fixed
+            // data-key strings and don't need this.
+            held.delete(key.toUpperCase())
+            held.delete(key.toLowerCase())
+        }
     }
 
     getConfig(): EvaderConfig {
@@ -278,13 +292,28 @@ export class EvaderGame extends BaseGame<
     /** Derive normalized direction set from currently held raw keys. */
     private getActiveDirections(): Set<string> {
         const dirs = new Set<string>()
-        for (const key of this.rawHeldKeys) {
+        for (const key of this.keyboardHeldKeys) {
+            const dir = normalizeMovementKey(key)
+            if (dir) {
+                dirs.add(dir)
+            }
+        }
+        for (const key of this.touchHeldKeys) {
             const dir = normalizeMovementKey(key)
             if (dir) {
                 dirs.add(dir)
             }
         }
         return dirs
+    }
+
+    private heldKeysFor(source: InputSource): Set<string> {
+        return source === 'touch' ? this.touchHeldKeys : this.keyboardHeldKeys
+    }
+
+    private clearHeldKeys(): void {
+        this.keyboardHeldKeys.clear()
+        this.touchHeldKeys.clear()
     }
 
     /** Exposed for tests — returns the normalized direction set. */

--- a/src/lib/games/evader/EvaderRenderer.test.ts
+++ b/src/lib/games/evader/EvaderRenderer.test.ts
@@ -56,7 +56,12 @@ vi.mock('pixi.js', () => {
         Application: vi.fn(makeApp),
         Container: vi.fn(makeContainer),
         Graphics: vi.fn(makeGraphics),
-        FillGradient: vi.fn(() => ({ addColorStop: vi.fn() })),
+        FillGradient: vi.fn(() => ({
+            addColorStop: vi.fn(),
+            destroy: vi.fn(),
+            start: { x: 0, y: 0 },
+            end: { x: 0, y: 0 },
+        })),
         Text: vi.fn(() => ({
             text: '',
             destroy: vi.fn(),
@@ -190,7 +195,41 @@ describe('EvaderRenderer', () => {
 
             renderer.render(state)
 
-            expect(vi.mocked(FillGradient)).toHaveBeenCalled()
+            // Local-space vertical gradient; rect is positioned at player.x/y
+            expect(vi.mocked(FillGradient)).toHaveBeenCalledWith(0, 0, 0, 1)
+            const gradientInstance = vi.mocked(FillGradient).mock.results[0]
+                ?.value as {
+                addColorStop: ReturnType<typeof vi.fn>
+            }
+            expect(gradientInstance.addColorStop).toHaveBeenCalledTimes(3)
+            expect(gradientInstance.addColorStop).toHaveBeenNthCalledWith(
+                1,
+                0,
+                0x6bffae
+            )
+            expect(gradientInstance.addColorStop).toHaveBeenNthCalledWith(
+                2,
+                0.5,
+                0x00ff66
+            )
+            expect(gradientInstance.addColorStop).toHaveBeenNthCalledWith(
+                3,
+                1,
+                0x00cc44
+            )
+
+            // Player rect is drawn at the configured position/size
+            const rectCalls = vi.mocked(Graphics).mock.results.flatMap(r => {
+                const g = r.value as { rect: ReturnType<typeof vi.fn> }
+                return g.rect?.mock?.calls ?? []
+            })
+            expect(rectCalls).toContainEqual([
+                100 - 30 / 2,
+                200 - 30 / 2,
+                30,
+                30,
+            ])
+
             renderer.cleanup()
         })
 

--- a/src/lib/games/evader/EvaderRenderer.test.ts
+++ b/src/lib/games/evader/EvaderRenderer.test.ts
@@ -175,7 +175,7 @@ describe('EvaderRenderer', () => {
     })
 
     describe('render', () => {
-        it('renders the player at its position', async () => {
+        it('renders the player at its position using FillGradient', async () => {
             const config = makeConfig({ playerSize: 30 })
             const rendererConfig = createEvaderRendererConfig(
                 config,
@@ -190,8 +190,7 @@ describe('EvaderRenderer', () => {
 
             renderer.render(state)
 
-            // No throw means render succeeded
-            expect(true).toBe(true)
+            expect(vi.mocked(FillGradient)).toHaveBeenCalled()
             renderer.cleanup()
         })
 

--- a/src/lib/games/evader/EvaderRenderer.ts
+++ b/src/lib/games/evader/EvaderRenderer.ts
@@ -21,7 +21,9 @@ export class EvaderRenderer extends PixiJSRenderer {
     private objectGraphics: Map<string, PIXI.Graphics> = new Map()
     private playerGradient: PIXI.FillGradient | null = null
     private coinGradient: PIXI.FillGradient | null = null
+    private coinGradientRadius = NaN
     private bombGradient: PIXI.FillGradient | null = null
+    private bombGradientRadius = NaN
 
     constructor(config: EvaderRendererConfig) {
         super(config)
@@ -121,21 +123,26 @@ export class EvaderRenderer extends PixiJSRenderer {
     }
 
     private getCoinGradient(radius: number): PIXI.FillGradient {
-        if (!this.coinGradient) {
+        // Rebuild when radius changes so the gradient always matches the
+        // circle geometry (objectSize is constant today, but this guards
+        // against a future dynamic radius).
+        if (!this.coinGradient || this.coinGradientRadius !== radius) {
             this.coinGradient = new PIXI.FillGradient(0, -radius, 0, radius)
             this.coinGradient.addColorStop(0, 0xffd700)
             this.coinGradient.addColorStop(0.5, 0xffed4e)
             this.coinGradient.addColorStop(1, 0xffa500)
+            this.coinGradientRadius = radius
         }
         return this.coinGradient
     }
 
     private getBombGradient(radius: number): PIXI.FillGradient {
-        if (!this.bombGradient) {
+        if (!this.bombGradient || this.bombGradientRadius !== radius) {
             this.bombGradient = new PIXI.FillGradient(0, -radius, 0, radius)
             this.bombGradient.addColorStop(0, 0xff4444)
             this.bombGradient.addColorStop(0.5, 0xff0000)
             this.bombGradient.addColorStop(1, 0xcc0000)
+            this.bombGradientRadius = radius
         }
         return this.bombGradient
     }

--- a/src/lib/games/evader/EvaderRenderer.ts
+++ b/src/lib/games/evader/EvaderRenderer.ts
@@ -19,6 +19,9 @@ export class EvaderRenderer extends PixiJSRenderer {
     private objectContainer: PIXI.Container | null = null
     private playerGraphic: PIXI.Graphics | null = null
     private objectGraphics: Map<string, PIXI.Graphics> = new Map()
+    private playerGradient: PIXI.FillGradient | null = null
+    private coinGradient: PIXI.FillGradient | null = null
+    private bombGradient: PIXI.FillGradient | null = null
 
     constructor(config: EvaderRendererConfig) {
         super(config)
@@ -105,6 +108,38 @@ export class EvaderRenderer extends PixiJSRenderer {
         })
     }
 
+    private getPlayerGradient(): PIXI.FillGradient {
+        if (!this.playerGradient) {
+            // Local-space vertical gradient (0→1) fills the player rect
+            // regardless of world position, so geometry never needs updating.
+            this.playerGradient = new PIXI.FillGradient(0, 0, 0, 1)
+            this.playerGradient.addColorStop(0, 0x6bffae)
+            this.playerGradient.addColorStop(0.5, 0x00ff66)
+            this.playerGradient.addColorStop(1, 0x00cc44)
+        }
+        return this.playerGradient
+    }
+
+    private getCoinGradient(radius: number): PIXI.FillGradient {
+        if (!this.coinGradient) {
+            this.coinGradient = new PIXI.FillGradient(0, -radius, 0, radius)
+            this.coinGradient.addColorStop(0, 0xffd700)
+            this.coinGradient.addColorStop(0.5, 0xffed4e)
+            this.coinGradient.addColorStop(1, 0xffa500)
+        }
+        return this.coinGradient
+    }
+
+    private getBombGradient(radius: number): PIXI.FillGradient {
+        if (!this.bombGradient) {
+            this.bombGradient = new PIXI.FillGradient(0, -radius, 0, radius)
+            this.bombGradient.addColorStop(0, 0xff4444)
+            this.bombGradient.addColorStop(0.5, 0xff0000)
+            this.bombGradient.addColorStop(1, 0xcc0000)
+        }
+        return this.bombGradient
+    }
+
     private renderPlayer(player: Player): void {
         if (!this.playerGraphic) {
             return
@@ -115,16 +150,6 @@ export class EvaderRenderer extends PixiJSRenderer {
         const playerWidth = this.evaderConfig.playerSize
         const playerHeight = this.evaderConfig.playerSize
 
-        const playerGradient = new PIXI.FillGradient(
-            player.x,
-            player.y - playerHeight / 2,
-            player.x,
-            player.y + playerHeight / 2
-        )
-        playerGradient.addColorStop(0, 0x6bffae)
-        playerGradient.addColorStop(0.5, 0x00ff66)
-        playerGradient.addColorStop(1, 0x00cc44)
-
         this.playerGraphic
             .rect(
                 player.x - playerWidth / 2,
@@ -132,7 +157,7 @@ export class EvaderRenderer extends PixiJSRenderer {
                 playerWidth,
                 playerHeight
             )
-            .fill(playerGradient)
+            .fill(this.getPlayerGradient())
             .stroke({ color: 0x00ff66, width: 2 })
     }
 
@@ -165,35 +190,21 @@ export class EvaderRenderer extends PixiJSRenderer {
             objectGraphic.y = obj.y
 
             if (obj.type === 'coin') {
-                const coinGradient = new PIXI.FillGradient(
-                    0,
-                    -radius,
-                    0,
-                    radius
-                )
-                coinGradient.addColorStop(0, 0xffd700)
-                coinGradient.addColorStop(0.5, 0xffed4e)
-                coinGradient.addColorStop(1, 0xffa500)
-
-                objectGraphic.circle(0, 0, radius).fill(coinGradient).stroke({
-                    color: 0xffd700,
-                    width: 2,
-                })
+                objectGraphic
+                    .circle(0, 0, radius)
+                    .fill(this.getCoinGradient(radius))
+                    .stroke({
+                        color: 0xffd700,
+                        width: 2,
+                    })
             } else {
-                const bombGradient = new PIXI.FillGradient(
-                    0,
-                    -radius,
-                    0,
-                    radius
-                )
-                bombGradient.addColorStop(0, 0xff4444)
-                bombGradient.addColorStop(0.5, 0xff0000)
-                bombGradient.addColorStop(1, 0xcc0000)
-
-                objectGraphic.circle(0, 0, radius).fill(bombGradient).stroke({
-                    color: 0xff0000,
-                    width: 2,
-                })
+                objectGraphic
+                    .circle(0, 0, radius)
+                    .fill(this.getBombGradient(radius))
+                    .stroke({
+                        color: 0xff0000,
+                        width: 2,
+                    })
             }
         }
     }
@@ -201,6 +212,13 @@ export class EvaderRenderer extends PixiJSRenderer {
     cleanup(): void {
         this.objectGraphics.forEach(graphic => graphic.destroy())
         this.objectGraphics.clear()
+
+        this.playerGradient?.destroy()
+        this.playerGradient = null
+        this.coinGradient?.destroy()
+        this.coinGradient = null
+        this.bombGradient?.destroy()
+        this.bombGradient = null
 
         if (this.boardGraphic) {
             this.boardGraphic.destroy()

--- a/src/lib/games/evader/EvaderRenderer.ts
+++ b/src/lib/games/evader/EvaderRenderer.ts
@@ -114,6 +114,17 @@ export class EvaderRenderer extends PixiJSRenderer {
 
         const playerWidth = this.evaderConfig.playerSize
         const playerHeight = this.evaderConfig.playerSize
+
+        const playerGradient = new PIXI.FillGradient(
+            player.x,
+            player.y - playerHeight / 2,
+            player.x,
+            player.y + playerHeight / 2
+        )
+        playerGradient.addColorStop(0, 0x6bffae)
+        playerGradient.addColorStop(0.5, 0x00ff66)
+        playerGradient.addColorStop(1, 0x00cc44)
+
         this.playerGraphic
             .rect(
                 player.x - playerWidth / 2,
@@ -121,8 +132,8 @@ export class EvaderRenderer extends PixiJSRenderer {
                 playerWidth,
                 playerHeight
             )
-            .fill(0x00ff00) // Green for player
-            .stroke({ color: 0x00ff00, width: 2 })
+            .fill(playerGradient)
+            .stroke({ color: 0x00ff66, width: 2 })
     }
 
     private renderObjects(objects: GameObject[]): void {

--- a/src/lib/games/evader/initFramework.test.ts
+++ b/src/lib/games/evader/initFramework.test.ts
@@ -1,7 +1,12 @@
 // initFramework unit tests for Evader
 import { describe, it, expect, vi, beforeEach, afterEach } from 'vitest'
+import { screen, fireEvent } from '@testing-library/dom'
 import { initEvaderGameFramework, showGameOver } from './initFramework'
 import type { EvaderStats } from './frameworkTypes'
+import {
+    AchievementRarity,
+    type AchievementNotification,
+} from '@/lib/achievements'
 
 // Mock pixi.js for the renderer
 vi.mock('pixi.js', () => {
@@ -56,7 +61,12 @@ vi.mock('pixi.js', () => {
         Application: vi.fn(makeApp),
         Container: vi.fn(makeContainer),
         Graphics: vi.fn(makeGraphics),
-        FillGradient: vi.fn(() => ({ addColorStop: vi.fn() })),
+        FillGradient: vi.fn(() => ({
+            addColorStop: vi.fn(),
+            destroy: vi.fn(),
+            start: { x: 0, y: 0 },
+            end: { x: 0, y: 0 },
+        })),
         Text: vi.fn(() => ({
             text: '',
             destroy: vi.fn(),
@@ -82,10 +92,10 @@ function setupDOM() {
         <button id="stop-btn" style="display:none">Stop</button>
         <button id="play-again-btn">Play Again</button>
         <div id="dpad">
-            <button data-key="ArrowUp">↑</button>
-            <button data-key="ArrowDown">↓</button>
-            <button data-key="ArrowLeft">←</button>
-            <button data-key="ArrowRight">→</button>
+            <button data-key="ArrowUp" aria-label="Move up">↑</button>
+            <button data-key="ArrowDown" aria-label="Move down">↓</button>
+            <button data-key="ArrowLeft" aria-label="Move left">←</button>
+            <button data-key="ArrowRight" aria-label="Move right">→</button>
         </div>
     `
 }
@@ -409,12 +419,8 @@ describe('initEvaderGameFramework', () => {
             const result = await initEvaderGameFramework()
             result!.game.start()
 
-            const upBtn = document.querySelector<HTMLButtonElement>(
-                'button[data-key="ArrowUp"]'
-            )!
-            upBtn.dispatchEvent(
-                new MouseEvent('pointerdown', { bubbles: true })
-            )
+            const upBtn = screen.getByRole('button', { name: 'Move up' })
+            fireEvent.pointerDown(upBtn)
             expect(result!.game.pressedKeys.has('up')).toBe(true)
             result!.cleanup()
         })
@@ -423,17 +429,11 @@ describe('initEvaderGameFramework', () => {
             const result = await initEvaderGameFramework()
             result!.game.start()
 
-            const rightBtn = document.querySelector<HTMLButtonElement>(
-                'button[data-key="ArrowRight"]'
-            )!
-            rightBtn.dispatchEvent(
-                new MouseEvent('pointerdown', { bubbles: true })
-            )
+            const rightBtn = screen.getByRole('button', { name: 'Move right' })
+            fireEvent.pointerDown(rightBtn)
             expect(result!.game.pressedKeys.has('right')).toBe(true)
 
-            rightBtn.dispatchEvent(
-                new MouseEvent('pointerup', { bubbles: true })
-            )
+            fireEvent.pointerUp(rightBtn)
             expect(result!.game.pressedKeys.has('right')).toBe(false)
             result!.cleanup()
         })
@@ -442,15 +442,9 @@ describe('initEvaderGameFramework', () => {
             const result = await initEvaderGameFramework()
             result!.game.start()
 
-            const downBtn = document.querySelector<HTMLButtonElement>(
-                'button[data-key="ArrowDown"]'
-            )!
-            downBtn.dispatchEvent(
-                new MouseEvent('pointerdown', { bubbles: true })
-            )
-            downBtn.dispatchEvent(
-                new MouseEvent('pointerleave', { bubbles: true })
-            )
+            const downBtn = screen.getByRole('button', { name: 'Move down' })
+            fireEvent.pointerDown(downBtn)
+            fireEvent.pointerLeave(downBtn)
             expect(result!.game.pressedKeys.has('down')).toBe(false)
             result!.cleanup()
         })
@@ -459,12 +453,11 @@ describe('initEvaderGameFramework', () => {
             const result = await initEvaderGameFramework()
             result!.game.start()
 
-            const upBtn = document.querySelector<HTMLButtonElement>(
-                'button[data-key="ArrowUp"]'
-            )!
+            const upBtn = screen.getByRole('button', { name: 'Move up' })
             const releaseSpy = vi.fn()
             upBtn.releasePointerCapture = releaseSpy
 
+            // Custom event needed so pointerId can be configured explicitly.
             const event = new MouseEvent('pointerdown', { bubbles: true })
             Object.defineProperty(event, 'pointerId', { value: 7 })
 
@@ -479,15 +472,8 @@ describe('initEvaderGameFramework', () => {
             const pressSpy = vi.spyOn(result!.game, 'pressKey')
             result!.cleanup()
 
-            const upBtn = document.querySelector<HTMLButtonElement>(
-                'button[data-key="ArrowUp"]'
-            )!
-            // jsdom lacks full PointerEvent support, so we synthesize a
-            // MouseEvent with the pointer event name. After cleanup, the
-            // listener must be removed — pressKey should not be called.
-            upBtn.dispatchEvent(
-                new MouseEvent('pointerdown', { bubbles: true })
-            )
+            const upBtn = screen.getByRole('button', { name: 'Move up' })
+            fireEvent.pointerDown(upBtn)
             expect(pressSpy).not.toHaveBeenCalled()
         })
 
@@ -499,12 +485,8 @@ describe('initEvaderGameFramework', () => {
             // Deliberately do NOT call game.start() — game is inactive.
             expect(result!.game.getState().isActive).toBe(false)
 
-            const leftBtn = document.querySelector<HTMLButtonElement>(
-                'button[data-key="ArrowLeft"]'
-            )!
-            leftBtn.dispatchEvent(
-                new MouseEvent('pointerdown', { bubbles: true })
-            )
+            const leftBtn = screen.getByRole('button', { name: 'Move left' })
+            fireEvent.pointerDown(leftBtn)
 
             expect(result!.game.pressedKeys.has('left')).toBe(false)
             result!.cleanup()
@@ -513,12 +495,12 @@ describe('initEvaderGameFramework', () => {
 
     describe('achievement notifications', () => {
         it('dispatches achievements via window.showAchievementAward when earned', async () => {
-            const achievement = {
+            const achievement: AchievementNotification = {
                 id: 'evader_pro',
                 name: 'Evader Pro',
                 description: 'Score 1000 in Evader',
                 icon: '🏆',
-                rarity: 'rare' as const,
+                rarity: AchievementRarity.RARE,
             }
             vi.stubGlobal(
                 'fetch',

--- a/src/lib/games/evader/initFramework.test.ts
+++ b/src/lib/games/evader/initFramework.test.ts
@@ -490,6 +490,25 @@ describe('initEvaderGameFramework', () => {
             )
             expect(pressSpy).not.toHaveBeenCalled()
         })
+
+        it('does not register a stuck key when pressed before the game starts', async () => {
+            // The D-pad press handler gates on game.getState().isActive so a
+            // press before start doesn't leave a stuck key in pressedKeys.
+            // This is the touch equivalent of the keyboard isActive gate.
+            const result = await initEvaderGameFramework()
+            // Deliberately do NOT call game.start() — game is inactive.
+            expect(result!.game.getState().isActive).toBe(false)
+
+            const leftBtn = document.querySelector<HTMLButtonElement>(
+                'button[data-key="ArrowLeft"]'
+            )!
+            leftBtn.dispatchEvent(
+                new MouseEvent('pointerdown', { bubbles: true })
+            )
+
+            expect(result!.game.pressedKeys.has('left')).toBe(false)
+            result!.cleanup()
+        })
     })
 
     describe('achievement notifications', () => {

--- a/src/lib/games/evader/initFramework.test.ts
+++ b/src/lib/games/evader/initFramework.test.ts
@@ -81,6 +81,12 @@ function setupDOM() {
         <button id="start-btn">Start</button>
         <button id="stop-btn" style="display:none">Stop</button>
         <button id="play-again-btn">Play Again</button>
+        <div id="dpad">
+            <button data-key="ArrowUp">↑</button>
+            <button data-key="ArrowDown">↓</button>
+            <button data-key="ArrowLeft">←</button>
+            <button data-key="ArrowRight">→</button>
+        </div>
     `
 }
 
@@ -391,6 +397,75 @@ describe('initEvaderGameFramework', () => {
             )
             expect(game.pressedKeys.has('up')).toBe(false)
             result!.cleanup()
+        })
+    })
+
+    describe('touch controls (D-pad)', () => {
+        it('pointerdown on D-pad button calls pressKey', async () => {
+            const result = await initEvaderGameFramework()
+            result!.game.start()
+
+            const upBtn = document.querySelector<HTMLButtonElement>(
+                'button[data-key="ArrowUp"]'
+            )!
+            upBtn.dispatchEvent(
+                new MouseEvent('pointerdown', { bubbles: true })
+            )
+            expect(result!.game.pressedKeys.has('up')).toBe(true)
+            result!.cleanup()
+        })
+
+        it('pointerup on D-pad button calls releaseKey', async () => {
+            const result = await initEvaderGameFramework()
+            result!.game.start()
+
+            const rightBtn = document.querySelector<HTMLButtonElement>(
+                'button[data-key="ArrowRight"]'
+            )!
+            rightBtn.dispatchEvent(
+                new MouseEvent('pointerdown', { bubbles: true })
+            )
+            expect(result!.game.pressedKeys.has('right')).toBe(true)
+
+            rightBtn.dispatchEvent(
+                new MouseEvent('pointerup', { bubbles: true })
+            )
+            expect(result!.game.pressedKeys.has('right')).toBe(false)
+            result!.cleanup()
+        })
+
+        it('pointerleave releases the key when finger slides off button', async () => {
+            const result = await initEvaderGameFramework()
+            result!.game.start()
+
+            const downBtn = document.querySelector<HTMLButtonElement>(
+                'button[data-key="ArrowDown"]'
+            )!
+            downBtn.dispatchEvent(
+                new MouseEvent('pointerdown', { bubbles: true })
+            )
+            downBtn.dispatchEvent(
+                new MouseEvent('pointerleave', { bubbles: true })
+            )
+            expect(result!.game.pressedKeys.has('down')).toBe(false)
+            result!.cleanup()
+        })
+
+        it('cleanup removes D-pad listeners', async () => {
+            const result = await initEvaderGameFramework()
+            result!.game.start()
+            result!.cleanup()
+
+            const upBtn = document.querySelector<HTMLButtonElement>(
+                'button[data-key="ArrowUp"]'
+            )!
+            // After cleanup, dispatching should not throw and should not
+            // affect the destroyed game's internal state.
+            expect(() =>
+                upBtn.dispatchEvent(
+                    new MouseEvent('pointerdown', { bubbles: true })
+                )
+            ).not.toThrow()
         })
     })
 

--- a/src/lib/games/evader/initFramework.test.ts
+++ b/src/lib/games/evader/initFramework.test.ts
@@ -401,6 +401,10 @@ describe('initEvaderGameFramework', () => {
     })
 
     describe('touch controls (D-pad)', () => {
+        // jsdom lacks full PointerEvent support, so pointer events are
+        // synthesized as MouseEvent with the pointer event name. The handlers
+        // registered in setupTouchControls listen for 'pointerdown' etc. and
+        // jsdom dispatches MouseEvent to those listeners by event name.
         it('pointerdown on D-pad button calls pressKey', async () => {
             const result = await initEvaderGameFramework()
             result!.game.start()
@@ -454,18 +458,19 @@ describe('initEvaderGameFramework', () => {
         it('cleanup removes D-pad listeners', async () => {
             const result = await initEvaderGameFramework()
             result!.game.start()
+            const pressSpy = vi.spyOn(result!.game, 'pressKey')
             result!.cleanup()
 
             const upBtn = document.querySelector<HTMLButtonElement>(
                 'button[data-key="ArrowUp"]'
             )!
-            // After cleanup, dispatching should not throw and should not
-            // affect the destroyed game's internal state.
-            expect(() =>
-                upBtn.dispatchEvent(
-                    new MouseEvent('pointerdown', { bubbles: true })
-                )
-            ).not.toThrow()
+            // jsdom lacks full PointerEvent support, so we synthesize a
+            // MouseEvent with the pointer event name. After cleanup, the
+            // listener must be removed — pressKey should not be called.
+            upBtn.dispatchEvent(
+                new MouseEvent('pointerdown', { bubbles: true })
+            )
+            expect(pressSpy).not.toHaveBeenCalled()
         })
     })
 

--- a/src/lib/games/evader/initFramework.test.ts
+++ b/src/lib/games/evader/initFramework.test.ts
@@ -513,12 +513,19 @@ describe('initEvaderGameFramework', () => {
 
     describe('achievement notifications', () => {
         it('dispatches achievements via window.showAchievementAward when earned', async () => {
+            const achievement = {
+                id: 'evader_pro',
+                name: 'Evader Pro',
+                description: 'Score 1000 in Evader',
+                icon: '🏆',
+                rarity: 'rare' as const,
+            }
             vi.stubGlobal(
                 'fetch',
                 vi.fn().mockResolvedValue({
                     ok: true,
                     json: async () => ({
-                        newAchievements: ['evader_pro'],
+                        newAchievements: [achievement],
                     }),
                 })
             )
@@ -529,7 +536,15 @@ describe('initEvaderGameFramework', () => {
             result!.game.start()
             await result!.game.end()
 
-            expect(showSpy).toHaveBeenCalled()
+            expect(showSpy).toHaveBeenCalledWith([
+                expect.objectContaining({
+                    id: 'evader_pro',
+                    name: 'Evader Pro',
+                    description: 'Score 1000 in Evader',
+                    icon: '🏆',
+                    rarity: 'rare',
+                }),
+            ])
             delete window.showAchievementAward
             result!.cleanup()
         })

--- a/src/lib/games/evader/initFramework.test.ts
+++ b/src/lib/games/evader/initFramework.test.ts
@@ -455,6 +455,24 @@ describe('initEvaderGameFramework', () => {
             result!.cleanup()
         })
 
+        it('releases implicit pointer capture on pointerdown so pointerleave fires on touch', async () => {
+            const result = await initEvaderGameFramework()
+            result!.game.start()
+
+            const upBtn = document.querySelector<HTMLButtonElement>(
+                'button[data-key="ArrowUp"]'
+            )!
+            const releaseSpy = vi.fn()
+            upBtn.releasePointerCapture = releaseSpy
+
+            const event = new MouseEvent('pointerdown', { bubbles: true })
+            Object.defineProperty(event, 'pointerId', { value: 7 })
+
+            upBtn.dispatchEvent(event)
+            expect(releaseSpy).toHaveBeenCalledWith(7)
+            result!.cleanup()
+        })
+
         it('cleanup removes D-pad listeners', async () => {
             const result = await initEvaderGameFramework()
             result!.game.start()

--- a/src/lib/games/evader/initFramework.ts
+++ b/src/lib/games/evader/initFramework.ts
@@ -12,20 +12,7 @@ import {
     handleGameError,
 } from '@/lib/games/core/errors'
 
-// Achievement notification type
-interface AchievementNotification {
-    id: string
-    name: string
-    description: string
-    icon: string
-    rarity: 'common' | 'rare' | 'epic' | 'legendary'
-}
-
-declare global {
-    interface Window {
-        showAchievementAward?: (achievements: AchievementNotification[]) => void
-    }
-}
+import { type AchievementNotification } from '@/lib/achievements'
 
 const MOVEMENT_KEYS = new Set([
     'ArrowUp',

--- a/src/lib/games/evader/initFramework.ts
+++ b/src/lib/games/evader/initFramework.ts
@@ -337,14 +337,14 @@ function setupKeyboardControls(game: EvaderGame): () => void {
         }
         if (MOVEMENT_KEYS.has(event.key) && game.getState().isActive) {
             event.preventDefault()
-            game.pressKey(event.key)
+            game.pressKey(event.key, 'keyboard')
         }
     }
 
     const handleKeyUp = (event: KeyboardEvent) => {
         if (MOVEMENT_KEYS.has(event.key)) {
             event.preventDefault()
-            game.releaseKey(event.key)
+            game.releaseKey(event.key, 'keyboard')
         }
     }
 
@@ -390,14 +390,14 @@ function setupTouchControls(game: EvaderGame): () => void {
             // Match the keyboard handler's isActive gate so a press before
             // the game starts doesn't leave a stuck key in rawHeldKeys.
             if (game.getState().isActive) {
-                game.pressKey(key)
+                game.pressKey(key, 'touch')
             }
         }
 
         const release = (e: PointerEvent) => {
             e.preventDefault()
             button.classList.remove('active')
-            game.releaseKey(key)
+            game.releaseKey(key, 'touch')
         }
 
         // pointerdown starts movement; pointerup / pointerleave / pointercancel

--- a/src/lib/games/evader/initFramework.ts
+++ b/src/lib/games/evader/initFramework.ts
@@ -391,7 +391,11 @@ function setupTouchControls(game: EvaderGame): () => void {
         const press = (e: PointerEvent) => {
             e.preventDefault()
             button.classList.add('active')
-            game.pressKey(key)
+            // Match the keyboard handler's isActive gate so a press before
+            // the game starts doesn't leave a stuck key in rawHeldKeys.
+            if (game.getState().isActive) {
+                game.pressKey(key)
+            }
         }
 
         const release = (e: PointerEvent) => {

--- a/src/lib/games/evader/initFramework.ts
+++ b/src/lib/games/evader/initFramework.ts
@@ -391,6 +391,15 @@ function setupTouchControls(game: EvaderGame): () => void {
         const press = (e: PointerEvent) => {
             e.preventDefault()
             button.classList.add('active')
+            // Touch pointers receive implicit pointer capture on pointerdown,
+            // which suppresses pointerleave while the finger is down — so
+            // "slide off button to release" silently fails on real devices.
+            // Release the capture so pointerleave fires normally on touch.
+            try {
+                button.releasePointerCapture(e.pointerId)
+            } catch {
+                // No-op: pointer not captured (mouse) or pointerId unavailable.
+            }
             // Match the keyboard handler's isActive gate so a press before
             // the game starts doesn't leave a stuck key in rawHeldKeys.
             if (game.getState().isActive) {

--- a/src/lib/games/evader/initFramework.ts
+++ b/src/lib/games/evader/initFramework.ts
@@ -168,6 +168,9 @@ export async function initEvaderGameFramework(
     // Set up keyboard controls
     const cleanupKeyboard = setupKeyboardControls(game)
 
+    // Set up touch / pointer D-pad controls
+    const cleanupTouchControls = setupTouchControls(game)
+
     // Set up button handlers
     const cleanupButtonHandlers = setupButtonHandlers(game)
 
@@ -217,6 +220,7 @@ export async function initEvaderGameFramework(
         cleanup: () => {
             cleanupRenderLoop()
             cleanupKeyboard()
+            cleanupTouchControls()
             cleanupButtonHandlers()
             cleanupUnloadWarning()
             game.off('end', onGameEnd)
@@ -363,6 +367,58 @@ function setupKeyboardControls(game: EvaderGame): () => void {
     return () => {
         document.removeEventListener('keydown', handleKeyDown)
         document.removeEventListener('keyup', handleKeyUp)
+    }
+}
+
+function setupTouchControls(game: EvaderGame): () => void {
+    const dpad = document.getElementById('dpad')
+    if (!dpad) {
+        return () => {}
+    }
+
+    const buttons = Array.from(
+        dpad.querySelectorAll<HTMLButtonElement>('button[data-key]')
+    )
+
+    const cleanups: (() => void)[] = []
+
+    for (const button of buttons) {
+        const key = button.dataset.key
+        if (!key || !MOVEMENT_KEYS.has(key)) {
+            continue
+        }
+
+        const press = (e: PointerEvent) => {
+            e.preventDefault()
+            button.classList.add('active')
+            game.pressKey(key)
+        }
+
+        const release = (e: PointerEvent) => {
+            e.preventDefault()
+            button.classList.remove('active')
+            game.releaseKey(key)
+        }
+
+        // pointerdown starts movement; pointerup / pointerleave / pointercancel
+        // end it so the player stops if the finger slides off the button.
+        button.addEventListener('pointerdown', press)
+        button.addEventListener('pointerup', release)
+        button.addEventListener('pointerleave', release)
+        button.addEventListener('pointercancel', release)
+
+        cleanups.push(() => {
+            button.removeEventListener('pointerdown', press)
+            button.removeEventListener('pointerup', release)
+            button.removeEventListener('pointerleave', release)
+            button.removeEventListener('pointercancel', release)
+        })
+    }
+
+    return () => {
+        for (const cleanup of cleanups) {
+            cleanup()
+        }
     }
 }
 

--- a/src/lib/games/memory-matrix/MemoryMatrixRenderer.test.ts
+++ b/src/lib/games/memory-matrix/MemoryMatrixRenderer.test.ts
@@ -445,9 +445,16 @@ describe('MemoryMatrixRenderer', () => {
             renderer.destroy()
         })
 
-        it('should not render when state object is missing board/needsRedraw', async () => {
+        it('should not render when state object is missing board', async () => {
             const renderer = await createRenderer()
-            renderer.render({ foo: 'bar' } as unknown)
+            renderer.render({ needsRedraw: true } as unknown)
+            expect(boardEl.children.length).toBe(0)
+            renderer.destroy()
+        })
+
+        it('should not render when state object is missing needsRedraw', async () => {
+            const renderer = await createRenderer()
+            renderer.render({ board: [] } as unknown)
             expect(boardEl.children.length).toBe(0)
             renderer.destroy()
         })

--- a/src/lib/games/memory-matrix/MemoryMatrixRenderer.test.ts
+++ b/src/lib/games/memory-matrix/MemoryMatrixRenderer.test.ts
@@ -192,6 +192,84 @@ describe('MemoryMatrixRenderer', () => {
         })
     })
 
+    describe('keyboard accessibility', () => {
+        it('should make interactive cards focusable with role and aria-label', async () => {
+            const renderer = await createRenderer()
+            renderer.render(makeState({ board: [[makeCard()]] }))
+
+            const cardEl = boardEl.querySelector('div') as HTMLElement
+            expect(cardEl.getAttribute('tabindex')).toBe('0')
+            expect(cardEl.getAttribute('role')).toBe('button')
+            expect(cardEl.getAttribute('aria-label')).toContain('face down')
+            renderer.destroy()
+        })
+
+        it('should not make flipped cards focusable', async () => {
+            const renderer = await createRenderer()
+            renderer.render(
+                makeState({ board: [[makeCard({ isFlipped: true })]] })
+            )
+
+            const cardEl = boardEl.querySelector('div') as HTMLElement
+            expect(cardEl.getAttribute('tabindex')).toBeNull()
+            expect(cardEl.getAttribute('role')).toBeNull()
+            renderer.destroy()
+        })
+
+        it('should not make matched cards focusable', async () => {
+            const renderer = await createRenderer()
+            renderer.render(
+                makeState({ board: [[makeCard({ isMatched: true })]] })
+            )
+
+            const cardEl = boardEl.querySelector('div') as HTMLElement
+            expect(cardEl.getAttribute('tabindex')).toBeNull()
+            renderer.destroy()
+        })
+
+        it('should invoke callback on Enter key', async () => {
+            const renderer = await createRenderer()
+            const callback = vi.fn()
+            renderer.setCardClickCallback(callback)
+            renderer.render(makeState({ board: [[makeCard()]] }))
+
+            const cardEl = boardEl.querySelector('div') as HTMLElement
+            cardEl.dispatchEvent(
+                new KeyboardEvent('keydown', { key: 'Enter', bubbles: true })
+            )
+            expect(callback).toHaveBeenCalled()
+            renderer.destroy()
+        })
+
+        it('should invoke callback on Space key', async () => {
+            const renderer = await createRenderer()
+            const callback = vi.fn()
+            renderer.setCardClickCallback(callback)
+            renderer.render(makeState({ board: [[makeCard()]] }))
+
+            const cardEl = boardEl.querySelector('div') as HTMLElement
+            cardEl.dispatchEvent(
+                new KeyboardEvent('keydown', { key: ' ', bubbles: true })
+            )
+            expect(callback).toHaveBeenCalled()
+            renderer.destroy()
+        })
+
+        it('should not invoke callback on other keys', async () => {
+            const renderer = await createRenderer()
+            const callback = vi.fn()
+            renderer.setCardClickCallback(callback)
+            renderer.render(makeState({ board: [[makeCard()]] }))
+
+            const cardEl = boardEl.querySelector('div') as HTMLElement
+            cardEl.dispatchEvent(
+                new KeyboardEvent('keydown', { key: 'Tab', bubbles: true })
+            )
+            expect(callback).not.toHaveBeenCalled()
+            renderer.destroy()
+        })
+    })
+
     describe('card CSS classes', () => {
         it('should apply matched card classes (green)', async () => {
             const renderer = await createRenderer()

--- a/src/lib/games/memory-matrix/MemoryMatrixRenderer.test.ts
+++ b/src/lib/games/memory-matrix/MemoryMatrixRenderer.test.ts
@@ -268,6 +268,52 @@ describe('MemoryMatrixRenderer', () => {
             expect(callback).not.toHaveBeenCalled()
             renderer.destroy()
         })
+
+        it('should not invoke callback when modifier keys are held', async () => {
+            const renderer = await createRenderer()
+            const callback = vi.fn()
+            renderer.setCardClickCallback(callback)
+            renderer.render(makeState({ board: [[makeCard()]] }))
+
+            const cardEl = boardEl.querySelector('div') as HTMLElement
+            cardEl.dispatchEvent(
+                new KeyboardEvent('keydown', {
+                    key: 'Enter',
+                    bubbles: true,
+                    ctrlKey: true,
+                })
+            )
+            expect(callback).not.toHaveBeenCalled()
+            renderer.destroy()
+        })
+
+        it('should set aria-label with face up status for flipped cards', async () => {
+            const renderer = await createRenderer()
+            renderer.render(
+                makeState({
+                    board: [[makeCard({ isFlipped: true, shape: '⭐' })]],
+                })
+            )
+
+            const cardEl = boardEl.querySelector('div') as HTMLElement
+            expect(cardEl.getAttribute('aria-label')).toContain('face up')
+            expect(cardEl.getAttribute('aria-label')).toContain('⭐')
+            renderer.destroy()
+        })
+
+        it('should set aria-label with matched status for matched cards', async () => {
+            const renderer = await createRenderer()
+            renderer.render(
+                makeState({
+                    board: [[makeCard({ isMatched: true, shape: '🔴' })]],
+                })
+            )
+
+            const cardEl = boardEl.querySelector('div') as HTMLElement
+            expect(cardEl.getAttribute('aria-label')).toContain('matched')
+            expect(cardEl.getAttribute('aria-label')).toContain('🔴')
+            renderer.destroy()
+        })
     })
 
     describe('card CSS classes', () => {

--- a/src/lib/games/memory-matrix/MemoryMatrixRenderer.test.ts
+++ b/src/lib/games/memory-matrix/MemoryMatrixRenderer.test.ts
@@ -318,6 +318,54 @@ describe('MemoryMatrixRenderer', () => {
         })
     })
 
+    describe('focus restoration on re-render', () => {
+        it('should restore focus to the card at the same position after rebuild', async () => {
+            const renderer = await createRenderer()
+            const callback = vi.fn()
+            renderer.setCardClickCallback(callback)
+            const state = makeState({
+                board: [
+                    [makeCard({ id: 'c-0-0' }), makeCard({ id: 'c-0-1' })],
+                    [makeCard({ id: 'c-1-0' }), makeCard({ id: 'c-1-1' })],
+                ],
+            })
+            renderer.render(state)
+
+            // Focus the card at row 1, col 1 (last child)
+            const cards = boardEl.querySelectorAll('div')
+            const targetCard = cards[3] as HTMLElement
+            targetCard.focus()
+            expect(document.activeElement).toBe(targetCard)
+
+            // Simulate a re-render after activation (e.g. card flip)
+            renderer.render(state)
+
+            // Focus should be restored to the card at the same position,
+            // not dropped to <body>
+            const refocusedCard = boardEl.querySelectorAll(
+                'div'
+            )[3] as HTMLElement
+            expect(document.activeElement).toBe(refocusedCard)
+            renderer.destroy()
+        })
+
+        it('should not restore focus when no card was focused', async () => {
+            const renderer = await createRenderer()
+            const state = makeState()
+            renderer.render(state)
+
+            // No card is focused before re-render
+            expect(document.activeElement).not.toBe(
+                boardEl.querySelector('div')
+            )
+
+            renderer.render(state)
+            // body retains focus; no crash
+            expect(boardEl.children.length).toBe(4)
+            renderer.destroy()
+        })
+    })
+
     describe('card CSS classes', () => {
         it('should apply matched card classes (green)', async () => {
             const renderer = await createRenderer()

--- a/src/lib/games/memory-matrix/MemoryMatrixRenderer.test.ts
+++ b/src/lib/games/memory-matrix/MemoryMatrixRenderer.test.ts
@@ -1,4 +1,5 @@
 import { describe, it, expect, beforeEach, afterEach, vi } from 'vitest'
+import { within, fireEvent } from '@testing-library/dom'
 import {
     MemoryMatrixRenderer,
     createMemoryMatrixRendererConfig,
@@ -197,10 +198,11 @@ describe('MemoryMatrixRenderer', () => {
             const renderer = await createRenderer()
             renderer.render(makeState({ board: [[makeCard()]] }))
 
-            const cardEl = boardEl.querySelector('div') as HTMLElement
-            expect(cardEl.getAttribute('tabindex')).toBe('0')
-            expect(cardEl.getAttribute('role')).toBe('button')
-            expect(cardEl.getAttribute('aria-label')).toContain('face down')
+            const cardEl = within(boardEl).getByRole('button', {
+                name: /face down/i,
+            })
+            expect(cardEl).toHaveAttribute('tabindex', '0')
+            expect(cardEl.getAttribute('aria-label')).toMatch(/face down/i)
             renderer.destroy()
         })
 
@@ -210,13 +212,12 @@ describe('MemoryMatrixRenderer', () => {
                 makeState({ board: [[makeCard({ isFlipped: true })]] })
             )
 
-            const cardEl = boardEl.querySelector('div') as HTMLElement
+            const cardEl = within(boardEl).getByRole('img', {
+                name: /face up/i,
+            })
             // tabindex="-1" keeps flipped cards out of tab order but allows
             // programmatic focus restoration after a re-render.
-            expect(cardEl.getAttribute('tabindex')).toBe('-1')
-            // Flipped cards are non-interactive; role="img" lets the
-            // aria-label announce state without making them focusable.
-            expect(cardEl.getAttribute('role')).toBe('img')
+            expect(cardEl).toHaveAttribute('tabindex', '-1')
             renderer.destroy()
         })
 
@@ -226,8 +227,10 @@ describe('MemoryMatrixRenderer', () => {
                 makeState({ board: [[makeCard({ isMatched: true })]] })
             )
 
-            const cardEl = boardEl.querySelector('div') as HTMLElement
-            expect(cardEl.getAttribute('tabindex')).toBe('-1')
+            const cardEl = within(boardEl).getByRole('img', {
+                name: /matched/i,
+            })
+            expect(cardEl).toHaveAttribute('tabindex', '-1')
             renderer.destroy()
         })
 
@@ -237,10 +240,10 @@ describe('MemoryMatrixRenderer', () => {
             renderer.setCardClickCallback(callback)
             renderer.render(makeState({ board: [[makeCard()]] }))
 
-            const cardEl = boardEl.querySelector('div') as HTMLElement
-            cardEl.dispatchEvent(
-                new KeyboardEvent('keydown', { key: 'Enter', bubbles: true })
-            )
+            const cardEl = within(boardEl).getByRole('button', {
+                name: /face down/i,
+            })
+            fireEvent.keyDown(cardEl, { key: 'Enter' })
             expect(callback).toHaveBeenCalled()
             renderer.destroy()
         })
@@ -251,10 +254,10 @@ describe('MemoryMatrixRenderer', () => {
             renderer.setCardClickCallback(callback)
             renderer.render(makeState({ board: [[makeCard()]] }))
 
-            const cardEl = boardEl.querySelector('div') as HTMLElement
-            cardEl.dispatchEvent(
-                new KeyboardEvent('keydown', { key: ' ', bubbles: true })
-            )
+            const cardEl = within(boardEl).getByRole('button', {
+                name: /face down/i,
+            })
+            fireEvent.keyDown(cardEl, { key: ' ' })
             expect(callback).toHaveBeenCalled()
             renderer.destroy()
         })
@@ -265,10 +268,10 @@ describe('MemoryMatrixRenderer', () => {
             renderer.setCardClickCallback(callback)
             renderer.render(makeState({ board: [[makeCard()]] }))
 
-            const cardEl = boardEl.querySelector('div') as HTMLElement
-            cardEl.dispatchEvent(
-                new KeyboardEvent('keydown', { key: 'Tab', bubbles: true })
-            )
+            const cardEl = within(boardEl).getByRole('button', {
+                name: /face down/i,
+            })
+            fireEvent.keyDown(cardEl, { key: 'Tab' })
             expect(callback).not.toHaveBeenCalled()
             renderer.destroy()
         })
@@ -279,14 +282,10 @@ describe('MemoryMatrixRenderer', () => {
             renderer.setCardClickCallback(callback)
             renderer.render(makeState({ board: [[makeCard()]] }))
 
-            const cardEl = boardEl.querySelector('div') as HTMLElement
-            cardEl.dispatchEvent(
-                new KeyboardEvent('keydown', {
-                    key: 'Enter',
-                    bubbles: true,
-                    ctrlKey: true,
-                })
-            )
+            const cardEl = within(boardEl).getByRole('button', {
+                name: /face down/i,
+            })
+            fireEvent.keyDown(cardEl, { key: 'Enter', ctrlKey: true })
             expect(callback).not.toHaveBeenCalled()
             renderer.destroy()
         })
@@ -299,9 +298,10 @@ describe('MemoryMatrixRenderer', () => {
                 })
             )
 
-            const cardEl = boardEl.querySelector('div') as HTMLElement
-            expect(cardEl.getAttribute('aria-label')).toContain('face up')
-            expect(cardEl.getAttribute('aria-label')).toContain('⭐')
+            const cardEl = within(boardEl).getByRole('img', {
+                name: /face up.*⭐/i,
+            })
+            expect(cardEl).toBeInTheDocument()
             renderer.destroy()
         })
 
@@ -313,9 +313,10 @@ describe('MemoryMatrixRenderer', () => {
                 })
             )
 
-            const cardEl = boardEl.querySelector('div') as HTMLElement
-            expect(cardEl.getAttribute('aria-label')).toContain('matched')
-            expect(cardEl.getAttribute('aria-label')).toContain('🔴')
+            const cardEl = within(boardEl).getByRole('img', {
+                name: /matched.*🔴/i,
+            })
+            expect(cardEl).toBeInTheDocument()
             renderer.destroy()
         })
     })
@@ -333,9 +334,9 @@ describe('MemoryMatrixRenderer', () => {
             })
             renderer.render(state)
 
-            // Focus the card at row 1, col 1 (last child)
-            const cards = boardEl.querySelectorAll('div')
-            const targetCard = cards[3] as HTMLElement
+            // Focus the card at row 2, col 2 (last of four face-down cards)
+            const cards = within(boardEl).getAllByRole('button')
+            const targetCard = cards[3]
             targetCard.focus()
             expect(document.activeElement).toBe(targetCard)
 
@@ -344,9 +345,7 @@ describe('MemoryMatrixRenderer', () => {
 
             // Focus should be restored to the card at the same position,
             // not dropped to <body>
-            const refocusedCard = boardEl.querySelectorAll(
-                'div'
-            )[3] as HTMLElement
+            const refocusedCard = within(boardEl).getAllByRole('button')[3]
             expect(document.activeElement).toBe(refocusedCard)
             renderer.destroy()
         })
@@ -357,13 +356,20 @@ describe('MemoryMatrixRenderer', () => {
             renderer.render(state)
 
             // No card is focused before re-render
-            expect(document.activeElement).not.toBe(
-                boardEl.querySelector('div')
-            )
+            expect(
+                within(boardEl)
+                    .getAllByRole('button')
+                    .some(card => card === document.activeElement)
+            ).toBe(false)
 
             renderer.render(state)
-            // body retains focus; no crash
+            // Focus stays outside the board; structure is intact
             expect(boardEl.children.length).toBe(4)
+            expect(
+                within(boardEl)
+                    .getAllByRole('button')
+                    .some(card => card === document.activeElement)
+            ).toBe(false)
             renderer.destroy()
         })
 
@@ -377,7 +383,9 @@ describe('MemoryMatrixRenderer', () => {
             renderer.render(state)
 
             // Focus the face-down card (tabindex="0")
-            const cardEl = boardEl.querySelector('div') as HTMLElement
+            const cardEl = within(boardEl).getByRole('button', {
+                name: /face down/i,
+            })
             cardEl.focus()
             expect(document.activeElement).toBe(cardEl)
 
@@ -387,8 +395,10 @@ describe('MemoryMatrixRenderer', () => {
 
             // Focus should be restored to the now-flipped card (tabindex="-1"),
             // not dropped to <body>
-            const flippedCardEl = boardEl.querySelector('div') as HTMLElement
-            expect(flippedCardEl.getAttribute('tabindex')).toBe('-1')
+            const flippedCardEl = within(boardEl).getByRole('img', {
+                name: /face up/i,
+            })
+            expect(flippedCardEl).toHaveAttribute('tabindex', '-1')
             expect(document.activeElement).toBe(flippedCardEl)
             renderer.destroy()
         })

--- a/src/lib/games/memory-matrix/MemoryMatrixRenderer.test.ts
+++ b/src/lib/games/memory-matrix/MemoryMatrixRenderer.test.ts
@@ -212,7 +212,9 @@ describe('MemoryMatrixRenderer', () => {
 
             const cardEl = boardEl.querySelector('div') as HTMLElement
             expect(cardEl.getAttribute('tabindex')).toBeNull()
-            expect(cardEl.getAttribute('role')).toBeNull()
+            // Flipped cards are non-interactive; role="img" lets the
+            // aria-label announce state without making them focusable.
+            expect(cardEl.getAttribute('role')).toBe('img')
             renderer.destroy()
         })
 

--- a/src/lib/games/memory-matrix/MemoryMatrixRenderer.test.ts
+++ b/src/lib/games/memory-matrix/MemoryMatrixRenderer.test.ts
@@ -204,28 +204,30 @@ describe('MemoryMatrixRenderer', () => {
             renderer.destroy()
         })
 
-        it('should not make flipped cards focusable', async () => {
+        it('should make flipped cards programmatically focusable but not tab-focusable', async () => {
             const renderer = await createRenderer()
             renderer.render(
                 makeState({ board: [[makeCard({ isFlipped: true })]] })
             )
 
             const cardEl = boardEl.querySelector('div') as HTMLElement
-            expect(cardEl.getAttribute('tabindex')).toBeNull()
+            // tabindex="-1" keeps flipped cards out of tab order but allows
+            // programmatic focus restoration after a re-render.
+            expect(cardEl.getAttribute('tabindex')).toBe('-1')
             // Flipped cards are non-interactive; role="img" lets the
             // aria-label announce state without making them focusable.
             expect(cardEl.getAttribute('role')).toBe('img')
             renderer.destroy()
         })
 
-        it('should not make matched cards focusable', async () => {
+        it('should make matched cards programmatically focusable but not tab-focusable', async () => {
             const renderer = await createRenderer()
             renderer.render(
                 makeState({ board: [[makeCard({ isMatched: true })]] })
             )
 
             const cardEl = boardEl.querySelector('div') as HTMLElement
-            expect(cardEl.getAttribute('tabindex')).toBeNull()
+            expect(cardEl.getAttribute('tabindex')).toBe('-1')
             renderer.destroy()
         })
 
@@ -362,6 +364,32 @@ describe('MemoryMatrixRenderer', () => {
             renderer.render(state)
             // body retains focus; no crash
             expect(boardEl.children.length).toBe(4)
+            renderer.destroy()
+        })
+
+        it('should restore focus to a card that flips between renders', async () => {
+            const renderer = await createRenderer()
+            const callback = vi.fn()
+            renderer.setCardClickCallback(callback)
+
+            const card = makeCard({ id: 'c-0-0', isFlipped: false })
+            const state = makeState({ board: [[card]] })
+            renderer.render(state)
+
+            // Focus the face-down card (tabindex="0")
+            const cardEl = boardEl.querySelector('div') as HTMLElement
+            cardEl.focus()
+            expect(document.activeElement).toBe(cardEl)
+
+            // Simulate the card flipping after keyboard activation
+            card.isFlipped = true
+            renderer.render(state)
+
+            // Focus should be restored to the now-flipped card (tabindex="-1"),
+            // not dropped to <body>
+            const flippedCardEl = boardEl.querySelector('div') as HTMLElement
+            expect(flippedCardEl.getAttribute('tabindex')).toBe('-1')
+            expect(document.activeElement).toBe(flippedCardEl)
             renderer.destroy()
         })
     })

--- a/src/lib/games/memory-matrix/MemoryMatrixRenderer.ts
+++ b/src/lib/games/memory-matrix/MemoryMatrixRenderer.ts
@@ -43,6 +43,25 @@ export class MemoryMatrixRenderer extends DOMRenderer {
         if (!boardElement) {
             return
         }
+
+        // Capture the row/col of the focused card before rebuilding so
+        // focus can be restored after. Without this, keyboard activation
+        // (Enter/Space) triggers a re-render that removes the focused
+        // element from the DOM, dropping focus to <body>.
+        const active = document.activeElement as HTMLElement | null
+        let focusRow: number | null = null
+        let focusCol: number | null = null
+        if (active && boardElement.contains(active)) {
+            focusRow = Number(active.getAttribute('data-row'))
+            focusCol = Number(active.getAttribute('data-col'))
+            if (Number.isNaN(focusRow)) {
+                focusRow = null
+            }
+            if (Number.isNaN(focusCol)) {
+                focusCol = null
+            }
+        }
+
         while (boardElement.firstChild) {
             boardElement.removeChild(boardElement.firstChild)
         }
@@ -53,6 +72,13 @@ export class MemoryMatrixRenderer extends DOMRenderer {
                 )
             })
         })
+
+        if (focusRow !== null && focusCol !== null) {
+            const cardToFocus = boardElement.querySelector<HTMLElement>(
+                `[data-row="${focusRow}"][data-col="${focusCol}"]`
+            )
+            cardToFocus?.focus()
+        }
     }
 
     private createCardElement(
@@ -61,6 +87,8 @@ export class MemoryMatrixRenderer extends DOMRenderer {
         col: number
     ): HTMLElement {
         const cardDiv = document.createElement('div')
+        cardDiv.setAttribute('data-row', String(row))
+        cardDiv.setAttribute('data-col', String(col))
         cardDiv.className = `
             memory-card aspect-square flex items-center justify-center text-2xl font-bold rounded-lg cursor-pointer
             transition-all duration-300 border-2 select-none

--- a/src/lib/games/memory-matrix/MemoryMatrixRenderer.ts
+++ b/src/lib/games/memory-matrix/MemoryMatrixRenderer.ts
@@ -70,6 +70,9 @@ export class MemoryMatrixRenderer extends DOMRenderer {
         if (card.isFlipped || card.isMatched) {
             cardDiv.textContent = card.shape
             const status = card.isMatched ? 'matched' : 'face up'
+            // role="img" gives the aria-label a role context so screen
+            // readers reliably announce the face-up/matched card state.
+            cardDiv.setAttribute('role', 'img')
             cardDiv.setAttribute(
                 'aria-label',
                 `Card row ${row + 1}, column ${col + 1}, ${status}, ${card.shape}`

--- a/src/lib/games/memory-matrix/MemoryMatrixRenderer.ts
+++ b/src/lib/games/memory-matrix/MemoryMatrixRenderer.ts
@@ -52,13 +52,17 @@ export class MemoryMatrixRenderer extends DOMRenderer {
         let focusRow: number | null = null
         let focusCol: number | null = null
         if (active && boardElement.contains(active)) {
-            focusRow = Number(active.getAttribute('data-row'))
-            focusCol = Number(active.getAttribute('data-col'))
-            if (Number.isNaN(focusRow)) {
-                focusRow = null
-            }
-            if (Number.isNaN(focusCol)) {
-                focusCol = null
+            const rowAttr = active.getAttribute('data-row')
+            const colAttr = active.getAttribute('data-col')
+            if (rowAttr !== null && colAttr !== null) {
+                focusRow = Number(rowAttr)
+                focusCol = Number(colAttr)
+                if (Number.isNaN(focusRow)) {
+                    focusRow = null
+                }
+                if (Number.isNaN(focusCol)) {
+                    focusCol = null
+                }
             }
         }
 
@@ -105,6 +109,10 @@ export class MemoryMatrixRenderer extends DOMRenderer {
                 'aria-label',
                 `Card row ${row + 1}, column ${col + 1}, ${status}, ${card.shape}`
             )
+            // tabindex="-1" keeps face-up cards out of tab order but allows
+            // programmatic focus restoration after a re-render so keyboard
+            // activation doesn't drop focus to <body>.
+            cardDiv.setAttribute('tabindex', '-1')
         } else {
             cardDiv.textContent = '?'
         }

--- a/src/lib/games/memory-matrix/MemoryMatrixRenderer.ts
+++ b/src/lib/games/memory-matrix/MemoryMatrixRenderer.ts
@@ -69,6 +69,11 @@ export class MemoryMatrixRenderer extends DOMRenderer {
 
         if (card.isFlipped || card.isMatched) {
             cardDiv.textContent = card.shape
+            const status = card.isMatched ? 'matched' : 'face up'
+            cardDiv.setAttribute(
+                'aria-label',
+                `Card row ${row + 1}, column ${col + 1}, ${status}, ${card.shape}`
+            )
         } else {
             cardDiv.textContent = '?'
         }
@@ -88,6 +93,9 @@ export class MemoryMatrixRenderer extends DOMRenderer {
             cardDiv.addEventListener('click', activate)
 
             cardDiv.addEventListener('keydown', (e: KeyboardEvent) => {
+                if (e.ctrlKey || e.metaKey || e.altKey) {
+                    return
+                }
                 if (e.key === 'Enter' || e.key === ' ') {
                     e.preventDefault()
                     activate()

--- a/src/lib/games/memory-matrix/MemoryMatrixRenderer.ts
+++ b/src/lib/games/memory-matrix/MemoryMatrixRenderer.ts
@@ -74,8 +74,24 @@ export class MemoryMatrixRenderer extends DOMRenderer {
         }
 
         if (!card.isMatched && !card.isFlipped) {
-            cardDiv.addEventListener('click', () => {
+            cardDiv.setAttribute('tabindex', '0')
+            cardDiv.setAttribute('role', 'button')
+            cardDiv.setAttribute(
+                'aria-label',
+                `Card row ${row + 1}, column ${col + 1}, face down`
+            )
+
+            const activate = () => {
                 this.onCardClick?.(row, col)
+            }
+
+            cardDiv.addEventListener('click', activate)
+
+            cardDiv.addEventListener('keydown', (e: KeyboardEvent) => {
+                if (e.key === 'Enter' || e.key === ' ') {
+                    e.preventDefault()
+                    activate()
+                }
             })
         }
 
@@ -88,7 +104,7 @@ export class MemoryMatrixRenderer extends DOMRenderer {
         } else if (card.isFlipped) {
             return 'text-white border-cyan-400 shadow-glow-cyan bg-slate-600'
         } else {
-            return 'bg-slate-700 border-slate-500 hover:border-cyan-400 hover:shadow-glow-cyan text-slate-400 hover:bg-slate-600'
+            return 'bg-slate-700 border-slate-500 hover:border-cyan-400 hover:shadow-glow-cyan text-slate-400 hover:bg-slate-600 focus-visible:outline-none focus-visible:border-cyan-400 focus-visible:shadow-glow-cyan'
         }
     }
 

--- a/src/lib/games/memory-matrix/initFramework.ts
+++ b/src/lib/games/memory-matrix/initFramework.ts
@@ -16,20 +16,7 @@ import {
 } from '@/lib/games/core/errors'
 import { formatTime } from './utils'
 
-// Achievement notification type
-interface AchievementNotification {
-    id: string
-    name: string
-    description: string
-    icon: string
-    rarity: 'common' | 'rare' | 'epic' | 'legendary'
-}
-
-declare global {
-    interface Window {
-        showAchievementAward?: (achievements: AchievementNotification[]) => void
-    }
-}
+import { type AchievementNotification } from '@/lib/achievements'
 
 export interface MemoryMatrixInitResult {
     game: MemoryMatrixGame

--- a/src/lib/games/path-navigator/initFramework.ts
+++ b/src/lib/games/path-navigator/initFramework.ts
@@ -19,20 +19,7 @@ import {
     handleGameError,
 } from '@/lib/games/core/errors'
 
-// Achievement notification type
-interface AchievementNotification {
-    id: string
-    name: string
-    description: string
-    icon: string
-    rarity: 'common' | 'rare' | 'epic' | 'legendary'
-}
-
-declare global {
-    interface Window {
-        showAchievementAward?: (achievements: AchievementNotification[]) => void
-    }
-}
+import { type AchievementNotification } from '@/lib/achievements'
 
 export interface PathNavigatorInitResult {
     game: PathNavigatorGame

--- a/src/lib/games/quick-math/renderer.test.ts
+++ b/src/lib/games/quick-math/renderer.test.ts
@@ -4,11 +4,12 @@ import type { MathQuestion, QuickMathState, QuickMathStats } from './game'
 
 function makeQuestion(overrides: Partial<MathQuestion> = {}): MathQuestion {
     return {
+        id: 'q1',
         question: '3 + 4',
         answer: 7,
         operation: 'addition',
-        num1: 3,
-        num2: 4,
+        operand1: 3,
+        operand2: 4,
         ...overrides,
     }
 }
@@ -23,8 +24,9 @@ function makeState(overrides: Partial<QuickMathState> = {}): QuickMathState {
         gameStarted: true,
         questionsAnswered: 0,
         correctAnswers: 0,
+        incorrectAnswers: 0,
+        currentAnswer: '',
         currentQuestion: null,
-        streak: 0,
         ...overrides,
     }
 }
@@ -281,10 +283,9 @@ describe('QuickMathRenderer', () => {
                 gameCompleted: true,
                 totalQuestions: 10,
                 correctAnswers: 8,
+                incorrectAnswers: 2,
                 accuracy: 80,
-                averageResponseTime: 3,
-                streak: 5,
-                longestStreak: 5,
+                averageTimePerQuestion: 3,
             }
             renderer.renderStats(stats)
             expect(totalEl.textContent).toBe('10')
@@ -298,10 +299,9 @@ describe('QuickMathRenderer', () => {
                 gameCompleted: false,
                 totalQuestions: 0,
                 correctAnswers: 0,
+                incorrectAnswers: 0,
                 accuracy: 0,
-                averageResponseTime: 0,
-                streak: 0,
-                longestStreak: 0,
+                averageTimePerQuestion: 0,
             }
             expect(() => renderer.renderStats(stats)).not.toThrow()
         })

--- a/src/lib/games/reflex/ReflexRenderer.ts
+++ b/src/lib/games/reflex/ReflexRenderer.ts
@@ -11,6 +11,7 @@ export interface ReflexRendererConfig extends PixiJSRendererConfig {
     gridSize: number
     cellSize: number
     gridLineColor: number
+    objectLifetime: number
 }
 
 const PADDING = 20
@@ -358,5 +359,6 @@ export function createReflexRendererConfig(
         gridSize: gameConfig.gridSize,
         cellSize: gameConfig.cellSize,
         gridLineColor: gameConfig.gridLineColor,
+        objectLifetime: gameConfig.objectLifetime,
     }
 }

--- a/src/lib/games/reflex/initFramework.ts
+++ b/src/lib/games/reflex/initFramework.ts
@@ -12,20 +12,7 @@ import {
     handleGameError,
 } from '@/lib/games/core/errors'
 
-// Achievement notification type
-interface AchievementNotification {
-    id: string
-    name: string
-    description: string
-    icon: string
-    rarity: 'common' | 'rare' | 'epic' | 'legendary'
-}
-
-declare global {
-    interface Window {
-        showAchievementAward?: (achievements: AchievementNotification[]) => void
-    }
-}
+import { type AchievementNotification } from '@/lib/achievements'
 
 export interface ReflexInitResult {
     game: ReflexGame

--- a/src/lib/games/satellite-sync/renderer.test.ts
+++ b/src/lib/games/satellite-sync/renderer.test.ts
@@ -10,7 +10,11 @@ import {
     type RendererState,
 } from './renderer'
 import { polarToWorld } from './geometry'
-import type { RuntimeSatellite, SatelliteSyncState } from './types'
+import type {
+    RuntimeSatellite,
+    RuntimeTarget,
+    SatelliteSyncState,
+} from './types'
 import type { Application } from 'pixi.js'
 
 vi.mock('pixi.js', () => {
@@ -181,7 +185,7 @@ describe('render', () => {
 
     it('draws the snap-candidate halo as exactly one extra circle+stroke over the target body', () => {
         const layout = buildLayout(400, 400, 2)
-        const baseTarget = {
+        const baseTarget: RuntimeTarget = {
             id: 'target-0',
             ring: 1,
             defAngle: 0,
@@ -191,13 +195,14 @@ describe('render', () => {
             locked: false,
             lockedBySatId: null,
         }
-        const baseSatellite = {
+        const baseSatellite: RuntimeSatellite = {
             id: 'sat-0',
             ring: 0,
             angle: 0,
             color: 'cyan',
             aimAngle: 0,
             lockedTargetId: null,
+            snapCandidateId: null,
         }
 
         // Baseline: identical scene WITHOUT a snap candidate.

--- a/src/lib/games/snake/initFramework.test.ts
+++ b/src/lib/games/snake/initFramework.test.ts
@@ -544,7 +544,7 @@ describe('initSnakeGameFramework', () => {
             // Get the onGameEnd callback registered with game.on('end', handler)
             const onGameEndCall = vi
                 .mocked(gameMock.on)
-                .mock.calls.find(call => call[0] === 'end')
+                .mock.calls.find((call: any[]) => call[0] === 'end')
             const onGameEnd = onGameEndCall?.[1] as
                 | ((...args: unknown[]) => unknown)
                 | undefined
@@ -568,7 +568,7 @@ describe('initSnakeGameFramework', () => {
 
             const onGameEndCall = vi
                 .mocked(gameMock.on)
-                .mock.calls.find(call => call[0] === 'end')
+                .mock.calls.find((call: any[]) => call[0] === 'end')
             const onGameEnd = onGameEndCall?.[1] as
                 | ((...args: unknown[]) => unknown)
                 | undefined
@@ -585,7 +585,7 @@ describe('initSnakeGameFramework', () => {
 
             const onGameEndCall = vi
                 .mocked(gameMock.on)
-                .mock.calls.find(call => call[0] === 'end')
+                .mock.calls.find((call: any[]) => call[0] === 'end')
             const onGameEnd = onGameEndCall?.[1] as
                 | ((...args: unknown[]) => unknown)
                 | undefined

--- a/src/lib/games/snake/initFramework.test.ts
+++ b/src/lib/games/snake/initFramework.test.ts
@@ -544,7 +544,7 @@ describe('initSnakeGameFramework', () => {
             // Get the onGameEnd callback registered with game.on('end', handler)
             const onGameEndCall = vi
                 .mocked(gameMock.on)
-                .mock.calls.find((call: any[]) => call[0] === 'end')
+                .mock.calls.find((call: unknown[]) => call[0] === 'end')
             const onGameEnd = onGameEndCall?.[1] as
                 | ((...args: unknown[]) => unknown)
                 | undefined
@@ -568,7 +568,7 @@ describe('initSnakeGameFramework', () => {
 
             const onGameEndCall = vi
                 .mocked(gameMock.on)
-                .mock.calls.find((call: any[]) => call[0] === 'end')
+                .mock.calls.find((call: unknown[]) => call[0] === 'end')
             const onGameEnd = onGameEndCall?.[1] as
                 | ((...args: unknown[]) => unknown)
                 | undefined
@@ -585,7 +585,7 @@ describe('initSnakeGameFramework', () => {
 
             const onGameEndCall = vi
                 .mocked(gameMock.on)
-                .mock.calls.find((call: any[]) => call[0] === 'end')
+                .mock.calls.find((call: unknown[]) => call[0] === 'end')
             const onGameEnd = onGameEndCall?.[1] as
                 | ((...args: unknown[]) => unknown)
                 | undefined

--- a/src/lib/games/snake/initFramework.ts
+++ b/src/lib/games/snake/initFramework.ts
@@ -12,20 +12,7 @@ import {
     handleGameError,
 } from '@/lib/games/core/errors'
 
-// Achievement notification type
-interface AchievementNotification {
-    id: string
-    name: string
-    description: string
-    icon: string
-    rarity: 'common' | 'rare' | 'epic' | 'legendary'
-}
-
-declare global {
-    interface Window {
-        showAchievementAward?: (achievements: AchievementNotification[]) => void
-    }
-}
+import { type AchievementNotification } from '@/lib/achievements'
 
 export interface SnakeInitResult {
     game: SnakeGame

--- a/src/lib/games/snake/utils.ts
+++ b/src/lib/games/snake/utils.ts
@@ -8,12 +8,17 @@ import { generateId } from '@/lib/games/shared/utils'
 
 export { generateId }
 
+// Only the grid dimensions are needed by the bound/food helpers; accepting
+// this narrower shape lets callers pass a partial constants object while full
+// GameConstants remains assignable.
+type GridDimensions = Pick<GameConstants, 'GRID_WIDTH' | 'GRID_HEIGHT'>
+
 /**
  * Check if position is out of bounds
  */
 export function isOutOfBounds(
     pos: Position,
-    constants: GameConstants
+    constants: GridDimensions
 ): boolean {
     return (
         pos.x < 0 ||
@@ -45,7 +50,7 @@ export function positionsEqual(pos1: Position, pos2: Position): boolean {
  */
 export function generateFoodPosition(
     snake: SnakeSegment[],
-    constants: GameConstants
+    constants: GridDimensions
 ): Position {
     let position: Position
     let attempts = 0

--- a/src/lib/games/sudoku/SudokuGame.test.ts
+++ b/src/lib/games/sudoku/SudokuGame.test.ts
@@ -64,7 +64,8 @@ describe('SudokuGame', () => {
             const state = game.getState()
             expect(state.score).toBe(0)
             expect(
-                state.timer !== undefined || state.timeRemaining !== undefined
+                (state as any).timer !== undefined ||
+                    state.timeRemaining !== undefined
             ).toBe(true)
             expect(state.isGameOver).toBe(false)
             expect(state.gameStarted).toBe(false)

--- a/src/lib/games/sudoku/SudokuGame.test.ts
+++ b/src/lib/games/sudoku/SudokuGame.test.ts
@@ -63,10 +63,7 @@ describe('SudokuGame', () => {
         it('should initialize with correct default state', () => {
             const state = game.getState()
             expect(state.score).toBe(0)
-            expect(
-                (state as any).timer !== undefined ||
-                    state.timeRemaining !== undefined
-            ).toBe(true)
+            expect(state.timeRemaining).toBeDefined()
             expect(state.isGameOver).toBe(false)
             expect(state.gameStarted).toBe(false)
             expect(state.isActive).toBe(false)

--- a/src/lib/games/sudoku/initFramework.ts
+++ b/src/lib/games/sudoku/initFramework.ts
@@ -12,20 +12,7 @@ import {
     handleGameError,
 } from '@/lib/games/core/errors'
 
-// Achievement notification type
-interface AchievementNotification {
-    id: string
-    name: string
-    description: string
-    icon: string
-    rarity: 'common' | 'rare' | 'epic' | 'legendary'
-}
-
-declare global {
-    interface Window {
-        showAchievementAward?: (achievements: AchievementNotification[]) => void
-    }
-}
+import { type AchievementNotification } from '@/lib/achievements'
 
 export interface SudokuInitResult {
     game: SudokuGame

--- a/src/lib/games/tetris/TetrisGame.test.ts
+++ b/src/lib/games/tetris/TetrisGame.test.ts
@@ -129,9 +129,11 @@ describe('TetrisGame', () => {
 
     describe('piece generation', () => {
         it('should generate pieces with valid types over many calls', () => {
+            type PieceGeneratingTetris = { generateNextPiece: () => Piece }
+            const pieceGenerator = game as unknown as PieceGeneratingTetris
             const types = new Set<string>()
             for (let i = 0; i < 100; i++) {
-                types.add((game as any).generateNextPiece().type)
+                types.add(pieceGenerator.generateNextPiece().type)
             }
             expect(types.size).toBeGreaterThanOrEqual(3)
         })

--- a/src/lib/games/tetris/TetrisGame.test.ts
+++ b/src/lib/games/tetris/TetrisGame.test.ts
@@ -130,9 +130,8 @@ describe('TetrisGame', () => {
     describe('piece generation', () => {
         it('should generate pieces with valid types over many calls', () => {
             const types = new Set<string>()
-            // @ts-expect-error - accessing protected method for testing
             for (let i = 0; i < 100; i++) {
-                types.add(game.generateNextPiece().type)
+                types.add((game as any).generateNextPiece().type)
             }
             expect(types.size).toBeGreaterThanOrEqual(3)
         })
@@ -650,25 +649,25 @@ describe('TetrisGame', () => {
             game.start()
             // @ts-expect-error - accessing protected state for testing
             const piece = game.state.currentPiece
-            const startY = piece.y
+            const startY = piece!.y
             // Force the drop timer to be overdue
             // @ts-expect-error - accessing protected state for testing
             game.state.dropTime = Date.now() - (game.state.dropInterval + 100)
             game.update(16)
             // @ts-expect-error - accessing protected state for testing
-            expect(game.state.currentPiece.y).toBe(startY + 1)
+            expect(game.state.currentPiece!.y).toBe(startY + 1)
         })
 
         it('should not drop the piece before the interval elapses', () => {
             game.start()
             // @ts-expect-error - accessing protected state for testing
             const piece = game.state.currentPiece
-            const startY = piece.y
+            const startY = piece!.y
             // @ts-expect-error - accessing protected state for testing
             game.state.dropTime = Date.now() // just reset → not overdue
             game.update(16)
             // @ts-expect-error - accessing protected state for testing
-            expect(game.state.currentPiece.y).toBe(startY)
+            expect(game.state.currentPiece!.y).toBe(startY)
         })
     })
 

--- a/src/lib/games/tetris/initFramework.ts
+++ b/src/lib/games/tetris/initFramework.ts
@@ -13,20 +13,7 @@ import {
     handleGameError,
 } from '@/lib/games/core/errors'
 
-// Achievement notification type
-interface AchievementNotification {
-    id: string
-    name: string
-    description: string
-    icon: string
-    rarity: 'common' | 'rare' | 'epic' | 'legendary'
-}
-
-declare global {
-    interface Window {
-        showAchievementAward?: (achievements: AchievementNotification[]) => void
-    }
-}
+import { type AchievementNotification } from '@/lib/achievements'
 
 export interface TetrisInitResult {
     game: TetrisGame

--- a/src/lib/games/word-scramble/initFramework.test.ts
+++ b/src/lib/games/word-scramble/initFramework.test.ts
@@ -259,7 +259,7 @@ describe('initWordScrambleGameFramework', () => {
         it('onTimeUpdate should add red class when time <= 10', async () => {
             const instance = await initWordScrambleGameFramework()
             document.getElementById('start-btn')!.click()
-            instance.game['updateTime'](10)
+            instance!.game['updateTime'](10)
 
             const el = document.getElementById('time-remaining')!
             expect(el.classList.contains('text-red-400')).toBe(true)
@@ -269,8 +269,7 @@ describe('initWordScrambleGameFramework', () => {
         it('onChallengeUpdate should color easy words green', async () => {
             const instance = await initWordScrambleGameFramework()
             document.getElementById('start-btn')!.click()
-
-            instance.game['callbacks'].onChallengeUpdate?.({
+            ;(instance!.game['callbacks'] as any).onChallengeUpdate?.({
                 id: 'c1',
                 originalWord: 'cat',
                 scrambledWord: 'tac',
@@ -285,7 +284,7 @@ describe('initWordScrambleGameFramework', () => {
             const instance = await initWordScrambleGameFramework()
             document.getElementById('start-btn')!.click()
 
-            await instance.endGame()
+            await instance!.endGame()
 
             const answerInput = document.getElementById(
                 'answer-input'
@@ -302,7 +301,7 @@ describe('initWordScrambleGameFramework', () => {
             const instance = await initWordScrambleGameFramework()
             document.getElementById('start-btn')!.click()
 
-            const game = instance.game
+            const game = instance!.game
             ;(game as any).state.wordHistory = [
                 {
                     word: 'keyboard',
@@ -316,7 +315,7 @@ describe('initWordScrambleGameFramework', () => {
             ;(game as any).state.correctAnswers = 1
             ;(game as any).state.incorrectAnswers = 0
 
-            await instance.endGame()
+            await instance!.endGame()
 
             expect(document.getElementById('final-score')!.textContent).toBe(
                 game.getState().score.toString()
@@ -336,15 +335,15 @@ describe('initWordScrambleGameFramework', () => {
                 'answer-input'
             ) as HTMLInputElement
             answerInput.value =
-                instance.getState().currentChallenge!.originalWord
+                instance!.getState().currentChallenge!.originalWord
             document.getElementById('submit-answer')!.click()
-            expect(instance.getState().wordsUnscrambled).toBe(1)
+            expect(instance!.getState().wordsUnscrambled).toBe(1)
 
-            instance.restart()
+            instance!.restart()
 
-            expect(instance.getState().wordsUnscrambled).toBe(0)
-            expect(instance.getState().score).toBe(0)
-            expect(instance.getState().isActive).toBe(true)
+            expect(instance!.getState().wordsUnscrambled).toBe(0)
+            expect(instance!.getState().score).toBe(0)
+            expect(instance!.getState().isActive).toBe(true)
         })
 
         it('cleanup should not throw', async () => {
@@ -359,14 +358,14 @@ describe('initWordScrambleGameFramework', () => {
                 'answer-input'
             ) as HTMLInputElement
             answerInput.value =
-                instance.getState().currentChallenge!.originalWord
+                instance!.getState().currentChallenge!.originalWord
             document.getElementById('submit-answer')!.click()
-            expect(instance.getState().wordsUnscrambled).toBe(1)
+            expect(instance!.getState().wordsUnscrambled).toBe(1)
 
             document.getElementById('play-again-btn')!.click()
 
-            expect(instance.getState().wordsUnscrambled).toBe(0)
-            expect(instance.getState().isActive).toBe(true)
+            expect(instance!.getState().wordsUnscrambled).toBe(0)
+            expect(instance!.getState().isActive).toBe(true)
         })
 
         it('should call showAchievementAward when achievements are earned', async () => {

--- a/src/lib/games/word-scramble/initFramework.ts
+++ b/src/lib/games/word-scramble/initFramework.ts
@@ -13,19 +13,7 @@ import {
     handleGameError,
 } from '@/lib/games/core/errors'
 
-interface AchievementNotification {
-    id: string
-    name: string
-    description: string
-    icon: string
-    rarity: 'common' | 'rare' | 'epic' | 'legendary'
-}
-
-declare global {
-    interface Window {
-        showAchievementAward?: (achievements: AchievementNotification[]) => void
-    }
-}
+import { type AchievementNotification } from '@/lib/achievements'
 
 export interface WordScrambleInitResult {
     game: WordScrambleGame

--- a/src/lib/preferences.test.ts
+++ b/src/lib/preferences.test.ts
@@ -1,4 +1,4 @@
-import { describe, it, expect, beforeEach, vi } from 'vitest'
+import { describe, it, expect, beforeEach, afterEach, vi } from 'vitest'
 import {
     DEFAULT_CLIENT_PREFERENCES,
     DEFAULT_NOTIFICATION_PREFERENCES,

--- a/src/lib/server/db/queries.legacy-schema.test.ts
+++ b/src/lib/server/db/queries.legacy-schema.test.ts
@@ -1,0 +1,181 @@
+/**
+ * Regression tests for user_stats insert paths on a legacy schema.
+ *
+ * The base schema (scripts/init-db.sql) ships with xp, level, challenge_streak,
+ * last_challenge_date, and streak_days but NOT the login-reward or preference
+ * columns. Several insert paths include those columns without first running the
+ * corresponding ensure* migrations, so the insert is rejected by SQLite and the
+ * surrounding transaction rolls back.
+ *
+ * Each test below targets one insert path with a user that has NO stats row,
+ * forcing the insert (not update) branch on a legacy schema.
+ */
+import { describe, it, expect, beforeAll, vi } from 'vitest'
+import { sql } from 'kysely'
+
+// Real in-memory SQLite so the schema mismatch is actually exercised.
+vi.mock('@/lib/server/db/client', async () => {
+    const { Kysely } = await import('kysely')
+    const { LibsqlDialect } = await import('@libsql/kysely-libsql')
+    const { createClient } = await import('@libsql/client')
+
+    const client = createClient({ url: 'file::memory:?cache=shared' }) as any
+    const dialect = new LibsqlDialect({ client })
+    const db = new Kysely({ dialect })
+
+    return { db, dialect }
+})
+
+// claimLoginReward dynamically imports getLevelFromXP from @/lib/challenges.
+vi.mock('@/lib/challenges', () => ({
+    getLevelFromXP: (xp: number) => Math.floor(xp / 100) + 1,
+}))
+
+import { db } from '@/lib/server/db/client'
+import {
+    ensureDailyChallengeTable,
+    completeChallengeAndAwardXP,
+    updateUserXPAndLevel,
+    atomicCheckAndUpdateStreak,
+    claimLoginReward,
+} from '@/lib/server/db/queries'
+
+// Base schema mirrors scripts/init-db.sql: user_stats has xp/level/challenge/
+// streak_days but NOT login-reward or preference columns.
+beforeAll(async () => {
+    await sql`
+        CREATE TABLE IF NOT EXISTS user (
+            id TEXT PRIMARY KEY,
+            name TEXT NOT NULL,
+            email TEXT NOT NULL,
+            emailVerified INTEGER NOT NULL DEFAULT 0,
+            image TEXT,
+            createdAt TEXT DEFAULT CURRENT_TIMESTAMP,
+            updatedAt TEXT DEFAULT CURRENT_TIMESTAMP
+        )
+    `.execute(db)
+
+    await sql`
+        CREATE TABLE IF NOT EXISTS user_stats (
+            id INTEGER PRIMARY KEY AUTOINCREMENT,
+            user_id TEXT UNIQUE NOT NULL,
+            total_games_played INTEGER DEFAULT 0,
+            total_score INTEGER DEFAULT 0,
+            favorite_game TEXT,
+            xp INTEGER DEFAULT 0,
+            level INTEGER DEFAULT 1,
+            challenge_streak INTEGER DEFAULT 0,
+            last_challenge_date TEXT,
+            streak_days INTEGER DEFAULT 0,
+            created_at TEXT DEFAULT CURRENT_TIMESTAMP,
+            updated_at TEXT DEFAULT CURRENT_TIMESTAMP
+        )
+    `.execute(db)
+
+    await sql`
+        CREATE TABLE IF NOT EXISTS game_scores (
+            id INTEGER PRIMARY KEY AUTOINCREMENT,
+            user_id TEXT NOT NULL,
+            game_id TEXT NOT NULL,
+            score INTEGER NOT NULL DEFAULT 0,
+            created_at TEXT DEFAULT CURRENT_TIMESTAMP
+        )
+    `.execute(db)
+
+    await ensureDailyChallengeTable()
+})
+
+async function seedUser(userId: string): Promise<void> {
+    const email = `${userId}@test.com`
+    await sql`
+        INSERT OR IGNORE INTO user (id, name, email, emailVerified)
+        VALUES (${userId}, ${userId}, ${email}, 0)
+    `.execute(db)
+    await sql`DELETE FROM user_stats WHERE user_id = ${userId}`.execute(db)
+}
+
+describe('legacy schema insert paths', () => {
+    it('completeChallengeAndAwardXP creates stats row for user without one', async () => {
+        const userId = 'legacy-challenge-xp'
+        await seedUser(userId)
+
+        await sql`
+            INSERT OR REPLACE INTO daily_challenge_progress
+            (user_id, challenge_date, challenge_id, current_value, target_value, xp_awarded)
+            VALUES (${userId}, '2024-01-15', 'score_100', 100, 100, 0)
+        `.execute(db)
+
+        const result = await completeChallengeAndAwardXP(
+            userId,
+            '2024-01-15',
+            'score_100',
+            30
+        )
+        expect(result).toBe(true)
+
+        const stats = await sql<{
+            xp: number
+        }>`SELECT xp FROM user_stats WHERE user_id = ${userId}`.execute(db)
+        expect(stats.rows[0]?.xp).toBe(30)
+    })
+
+    it('updateUserXPAndLevel creates stats row for user without one', async () => {
+        const userId = 'legacy-update-xp'
+        await seedUser(userId)
+
+        const result = await updateUserXPAndLevel(userId, 40, 2)
+        expect(result).toBe(true)
+
+        const stats = await sql<{
+            xp: number
+            level: number
+        }>`SELECT xp, level FROM user_stats WHERE user_id = ${userId}`.execute(
+            db
+        )
+        expect(stats.rows[0]?.xp).toBe(40)
+        expect(stats.rows[0]?.level).toBe(2)
+    })
+
+    it('atomicCheckAndUpdateStreak creates stats row for user without one', async () => {
+        const userId = 'legacy-streak'
+        await seedUser(userId)
+
+        const result = await atomicCheckAndUpdateStreak(
+            userId,
+            '2024-01-15',
+            true
+        )
+        expect(result).toBe(true)
+
+        const stats = await sql<{
+            challenge_streak: number
+        }>`SELECT challenge_streak FROM user_stats WHERE user_id = ${userId}`.execute(
+            db
+        )
+        expect(stats.rows[0]?.challenge_streak).toBe(1)
+    })
+
+    it('claimLoginReward creates stats row for user without one', async () => {
+        const userId = 'legacy-login-reward'
+        await seedUser(userId)
+
+        const result = await claimLoginReward(
+            userId,
+            '2024-01-15',
+            1,
+            50,
+            false,
+            false
+        )
+        expect(result.success).toBe(true)
+
+        const stats = await sql<{
+            xp: number
+            login_streak: number
+        }>`SELECT xp, login_streak FROM user_stats WHERE user_id = ${userId}`.execute(
+            db
+        )
+        expect(stats.rows[0]?.xp).toBe(50)
+        expect(stats.rows[0]?.login_streak).toBe(1)
+    })
+})

--- a/src/lib/server/db/queries.legacy-schema.test.ts
+++ b/src/lib/server/db/queries.legacy-schema.test.ts
@@ -16,10 +16,9 @@ import { sql } from 'kysely'
 // Real in-memory SQLite so the schema mismatch is actually exercised.
 vi.mock('@/lib/server/db/client', async () => {
     const { Kysely } = await import('kysely')
-    const { LibsqlDialect } = await import('@libsql/kysely-libsql')
-    const { createClient } = await import('@libsql/client')
+    const { LibsqlDialect, libsql } = await import('@libsql/kysely-libsql')
 
-    const client = createClient({ url: 'file::memory:?cache=shared' }) as any
+    const client = libsql.createClient({ url: 'file::memory:?cache=shared' })
     const dialect = new LibsqlDialect({ client })
     const db = new Kysely({ dialect })
 

--- a/src/lib/server/db/queries.legacy-schema.test.ts
+++ b/src/lib/server/db/queries.legacy-schema.test.ts
@@ -14,6 +14,11 @@ import { describe, it, expect, beforeAll, vi } from 'vitest'
 import { sql } from 'kysely'
 
 // Real in-memory SQLite so the schema mismatch is actually exercised.
+// NOTE: This relies on vitest's per-file module isolation. The shared cache
+// URL (`cache=shared`) only shares state within a single module instance; each
+// test file gets its own fresh in-memory DB because vitest isolates modules
+// per file. Do not merge this into a shared setup file or enable
+// `isolate: false` without re-evaluating, or tests will leak schema state.
 vi.mock('@/lib/server/db/client', async () => {
     const { Kysely } = await import('kysely')
     const { LibsqlDialect, libsql } = await import('@libsql/kysely-libsql')

--- a/src/lib/server/db/queries.migrations.retry.test.ts
+++ b/src/lib/server/db/queries.migrations.retry.test.ts
@@ -1,0 +1,81 @@
+/**
+ * Tests that `ensureUserStatsSchema` retries after a transient migration
+ * failure instead of caching a failed run for the process lifetime.
+ *
+ * Isolated in-memory SQLite (separate from queries.migrations.test.ts) so the
+ * user_stats table can be dropped to force DDL failures without disturbing
+ * other tests' shared state. Vitest isolates each test file in its own module
+ * registry, so the module-level `_userStatsSchemaPromise` / `_migrationsRun`
+ * start fresh here.
+ */
+import { describe, it, expect, beforeAll, vi } from 'vitest'
+import { sql } from 'kysely'
+
+vi.mock('@/lib/server/db/client', async () => {
+    const { Kysely } = await import('kysely')
+    const { LibsqlDialect, libsql } = await import('@libsql/kysely-libsql')
+
+    const client = libsql.createClient({ url: 'file::memory:?cache=shared' })
+    const dialect = new LibsqlDialect({ client })
+    const db = new Kysely({ dialect })
+
+    return { db, dialect }
+})
+
+import { db } from '@/lib/server/db/client'
+import { ensureUserStatsSchema } from '@/lib/server/db/queries'
+
+async function columnNames(): Promise<string[]> {
+    const result = await sql<{
+        name: string
+    }>`PRAGMA table_info(user_stats)`.execute(db)
+    return result.rows.map(r => r.name)
+}
+
+describe('ensureUserStatsSchema retry on transient failure', () => {
+    beforeAll(async () => {
+        await sql`
+            CREATE TABLE IF NOT EXISTS user (
+                id TEXT PRIMARY KEY,
+                name TEXT NOT NULL,
+                email TEXT NOT NULL,
+                emailVerified INTEGER NOT NULL DEFAULT 0,
+                image TEXT,
+                createdAt TEXT DEFAULT CURRENT_TIMESTAMP,
+                updatedAt TEXT DEFAULT CURRENT_TIMESTAMP
+            )
+        `.execute(db)
+    })
+
+    it('retries and applies migrations after an initial transient DDL failure', async () => {
+        // Force a failure: no user_stats table, so PRAGMA returns no rows and
+        // ALTER TABLE inside the helpers throws (swallowed by design).
+        await sql`DROP TABLE IF EXISTS user_stats`.execute(db)
+
+        // First call must resolve (helpers swallow) and must NOT cache the
+        // failed run for the process lifetime.
+        await expect(ensureUserStatsSchema()).resolves.toBeUndefined()
+
+        // Recreate the base table so the retry can actually run the DDL.
+        await sql`
+            CREATE TABLE IF NOT EXISTS user_stats (
+                id INTEGER PRIMARY KEY AUTOINCREMENT,
+                user_id TEXT NOT NULL UNIQUE,
+                total_games_played INTEGER NOT NULL DEFAULT 0,
+                total_score INTEGER NOT NULL DEFAULT 0,
+                favorite_game TEXT,
+                created_at TEXT DEFAULT CURRENT_TIMESTAMP,
+                updated_at TEXT DEFAULT CURRENT_TIMESTAMP
+            )
+        `.execute(db)
+
+        // Second call must retry rather than returning a cached failed promise.
+        await expect(ensureUserStatsSchema()).resolves.toBeUndefined()
+
+        const cols = await columnNames()
+        expect(cols).toContain('streak_days')
+        expect(cols).toContain('xp')
+        expect(cols).toContain('login_streak')
+        expect(cols).toContain('email_notifications')
+    })
+})

--- a/src/lib/server/db/queries.migrations.test.ts
+++ b/src/lib/server/db/queries.migrations.test.ts
@@ -12,7 +12,7 @@ vi.mock('@/lib/server/db/client', async () => {
     const { LibsqlDialect } = await import('@libsql/kysely-libsql')
     const { createClient } = await import('@libsql/client')
 
-    const client = createClient({ url: 'file::memory:?cache=shared' })
+    const client = createClient({ url: 'file::memory:?cache=shared' }) as any
     const dialect = new LibsqlDialect({ client })
     const db = new Kysely({ dialect })
 

--- a/src/lib/server/db/queries.migrations.test.ts
+++ b/src/lib/server/db/queries.migrations.test.ts
@@ -9,10 +9,9 @@ import { sql } from 'kysely'
 // Set up in-memory SQLite WITHOUT the migration columns so migrations actually run
 vi.mock('@/lib/server/db/client', async () => {
     const { Kysely } = await import('kysely')
-    const { LibsqlDialect } = await import('@libsql/kysely-libsql')
-    const { createClient } = await import('@libsql/client')
+    const { LibsqlDialect, libsql } = await import('@libsql/kysely-libsql')
 
-    const client = createClient({ url: 'file::memory:?cache=shared' }) as any
+    const client = libsql.createClient({ url: 'file::memory:?cache=shared' })
     const dialect = new LibsqlDialect({ client })
     const db = new Kysely({ dialect })
 

--- a/src/lib/server/db/queries.ts
+++ b/src/lib/server/db/queries.ts
@@ -1478,25 +1478,35 @@ export async function completeChallengeAndAwardXP(
                     .where('user_id', '=', userId)
                     .execute()
             } else {
-                await trx
-                    .insertInto('user_stats')
-                    .values({
-                        user_id: userId,
-                        total_games_played: 0,
-                        total_score: 0,
-                        favorite_game: null,
-                        streak_days: 0,
-                        xp: xpAmount,
-                        level: 1,
-                        challenge_streak: 0,
-                        last_challenge_date: null,
+                // Only include login reward / preference columns if their
+                // migrations succeeded. ensureUserStatsSchema() swallows
+                // transient migration errors by design, so those columns
+                // may be absent — referencing them here would fail the
+                // insert and roll back the challenge XP award.
+                const insertValues = {
+                    user_id: userId,
+                    total_games_played: 0,
+                    total_score: 0,
+                    favorite_game: null,
+                    streak_days: 0,
+                    xp: xpAmount,
+                    level: 1,
+                    challenge_streak: 0,
+                    last_challenge_date: null,
+                    ...(_migrationsRun.has('loginRewardColumns') && {
                         login_streak: 0,
                         last_login_reward_date: null,
                         total_login_cycles: 0,
+                    }),
+                    ...(_migrationsRun.has('preferenceColumns') && {
                         email_notifications: 1,
                         push_notifications: 0,
                         challenge_reminders: 1,
-                    })
+                    }),
+                } as NewUserStats
+                await trx
+                    .insertInto('user_stats')
+                    .values(insertValues)
                     .execute()
             }
         })
@@ -1591,25 +1601,34 @@ export async function updateUserXPAndLevel(
         await ensureUserStatsSchema()
         const now = new Date().toISOString()
 
-        await db
-            .insertInto('user_stats')
-            .values({
-                user_id: userId,
-                total_games_played: 0,
-                total_score: 0,
-                favorite_game: null,
-                streak_days: 0,
-                xp: xpToAdd,
-                level: newLevel,
-                challenge_streak: 0,
-                last_challenge_date: null,
+        // Only include login reward / preference columns if their migrations
+        // succeeded; ensureUserStatsSchema() swallows transient migration
+        // errors, so those columns may be absent.
+        const insertValues = {
+            user_id: userId,
+            total_games_played: 0,
+            total_score: 0,
+            favorite_game: null,
+            streak_days: 0,
+            xp: xpToAdd,
+            level: newLevel,
+            challenge_streak: 0,
+            last_challenge_date: null,
+            ...(_migrationsRun.has('loginRewardColumns') && {
                 login_streak: 0,
                 last_login_reward_date: null,
                 total_login_cycles: 0,
+            }),
+            ...(_migrationsRun.has('preferenceColumns') && {
                 email_notifications: 1,
                 push_notifications: 0,
                 challenge_reminders: 1,
-            })
+            }),
+        } as NewUserStats
+
+        await db
+            .insertInto('user_stats')
+            .values(insertValues)
             .onConflict(oc =>
                 oc.column('user_id').doUpdateSet({
                     xp: sql`user_stats.xp + ${xpToAdd}`,

--- a/src/lib/server/db/queries.ts
+++ b/src/lib/server/db/queries.ts
@@ -1047,7 +1047,10 @@ export async function updateAllUserStreaksForUTC(): Promise<{
     incremented: number
     reset: number
 }> {
-    await ensureStreakColumn()
+    // Route through the shared migration guard so concurrent callers
+    // (e.g. a challenge request hitting this alongside another path)
+    // serialize on the same promise instead of racing on the DDL.
+    await ensureUserStatsSchema()
 
     const now = new Date()
     const todayUTC = new Date(
@@ -1531,7 +1534,7 @@ export async function getUserXPAndLevel(userId: string): Promise<{
     lastChallengeDate: string | null
 }> {
     try {
-        await ensureChallengeColumns()
+        await ensureUserStatsSchema()
         const stats = await db
             .selectFrom('user_stats')
             .select(['xp', 'level', 'challenge_streak', 'last_challenge_date'])
@@ -1739,26 +1742,37 @@ export async function atomicCheckAndUpdateStreak(
                 .executeTakeFirst()
 
             if (!stats) {
-                // If no stats, this is the first completion
-                await trx
-                    .insertInto('user_stats')
-                    .values({
-                        user_id: userId,
-                        total_games_played: 0,
-                        total_score: 0,
-                        favorite_game: null,
-                        streak_days: 0,
-                        xp: 0,
-                        level: 1,
-                        challenge_streak: 1,
-                        last_challenge_date: today,
+                // If no stats, this is the first completion. Only include
+                // login reward / preference columns if their migrations
+                // succeeded; ensureUserStatsSchema() swallows transient
+                // migration errors by design, so those columns may be
+                // absent — referencing them here would fail the insert,
+                // roll back the transaction, and silently drop the streak
+                // update.
+                const insertValues = {
+                    user_id: userId,
+                    total_games_played: 0,
+                    total_score: 0,
+                    favorite_game: null,
+                    streak_days: 0,
+                    xp: 0,
+                    level: 1,
+                    challenge_streak: 1,
+                    last_challenge_date: today,
+                    ...(_migrationsRun.has('loginRewardColumns') && {
                         login_streak: 0,
                         last_login_reward_date: null,
                         total_login_cycles: 0,
+                    }),
+                    ...(_migrationsRun.has('preferenceColumns') && {
                         email_notifications: 1,
                         push_notifications: 0,
                         challenge_reminders: 1,
-                    })
+                    }),
+                } as NewUserStats
+                await trx
+                    .insertInto('user_stats')
+                    .values(insertValues)
                     .execute()
                 return true
             }
@@ -1849,7 +1863,7 @@ export async function getLoginRewardStatus(userId: string): Promise<{
     total_login_cycles: number
 } | null> {
     try {
-        await ensureLoginRewardColumns()
+        await ensureUserStatsSchema()
         const stats = await db
             .selectFrom('user_stats')
             .select([
@@ -2021,7 +2035,7 @@ export async function getUserPreferences(userId: string): Promise<{
     challenge_reminders: boolean
 } | null> {
     try {
-        await ensurePreferenceColumns()
+        await ensureUserStatsSchema()
         const stats = await db
             .selectFrom('user_stats')
             .select([
@@ -2067,7 +2081,7 @@ export async function updateUserPreferences(
     }
 ): Promise<boolean> {
     try {
-        await ensurePreferenceColumns()
+        await ensureUserStatsSchema()
 
         // Ensure user_stats row exists
         const existing = await getUserStats(userId)

--- a/src/lib/server/db/queries.ts
+++ b/src/lib/server/db/queries.ts
@@ -54,6 +54,19 @@ export function ensureUserStatsSchema(): Promise<void> {
             await ensureChallengeColumns()
             await ensureLoginRewardColumns()
             await ensurePreferenceColumns()
+            // Each helper swallows its own errors by design (so a transient DB
+            // hiccup doesn't break the primary request flow) and only records
+            // success in `_migrationsRun`. If any helper failed, it did NOT add
+            // its key, so reset the shared promise to let the next caller retry
+            // instead of caching the failed run for the process lifetime.
+            const allSucceeded =
+                _migrationsRun.has('streakColumn') &&
+                _migrationsRun.has('challengeColumns') &&
+                _migrationsRun.has('loginRewardColumns') &&
+                _migrationsRun.has('preferenceColumns')
+            if (!allSucceeded) {
+                _userStatsSchemaPromise = null
+            }
         })().catch(err => {
             // Allow the next caller to retry; surface for observability.
             _userStatsSchemaPromise = null

--- a/src/lib/server/db/queries.ts
+++ b/src/lib/server/db/queries.ts
@@ -1391,7 +1391,10 @@ export async function completeChallengeAndAwardXP(
     xpAmount: number
 ): Promise<boolean> {
     try {
+        await ensureStreakColumn()
         await ensureChallengeColumns()
+        await ensureLoginRewardColumns()
+        await ensurePreferenceColumns()
 
         await db.transaction().execute(async trx => {
             const progress = await trx
@@ -1453,6 +1456,12 @@ export async function completeChallengeAndAwardXP(
                         level: 1,
                         challenge_streak: 0,
                         last_challenge_date: null,
+                        login_streak: 0,
+                        last_login_reward_date: null,
+                        total_login_cycles: 0,
+                        email_notifications: 1,
+                        push_notifications: 0,
+                        challenge_reminders: 1,
                     })
                     .execute()
             }
@@ -1545,7 +1554,10 @@ export async function updateUserXPAndLevel(
     newLevel: number
 ): Promise<boolean> {
     try {
+        await ensureStreakColumn()
         await ensureChallengeColumns()
+        await ensureLoginRewardColumns()
+        await ensurePreferenceColumns()
         const now = new Date().toISOString()
 
         await db
@@ -1560,6 +1572,12 @@ export async function updateUserXPAndLevel(
                 level: newLevel,
                 challenge_streak: 0,
                 last_challenge_date: null,
+                login_streak: 0,
+                last_login_reward_date: null,
+                total_login_cycles: 0,
+                email_notifications: 1,
+                push_notifications: 0,
+                challenge_reminders: 1,
             })
             .onConflict(oc =>
                 oc.column('user_id').doUpdateSet({
@@ -1657,7 +1675,10 @@ export async function atomicCheckAndUpdateStreak(
     allChallengesCompleted: boolean
 ): Promise<boolean> {
     try {
+        await ensureStreakColumn()
         await ensureChallengeColumns()
+        await ensureLoginRewardColumns()
+        await ensurePreferenceColumns()
 
         if (!allChallengesCompleted) {
             return false
@@ -1684,6 +1705,12 @@ export async function atomicCheckAndUpdateStreak(
                         level: 1,
                         challenge_streak: 1,
                         last_challenge_date: today,
+                        login_streak: 0,
+                        last_login_reward_date: null,
+                        total_login_cycles: 0,
+                        email_notifications: 1,
+                        push_notifications: 0,
+                        challenge_reminders: 1,
                     })
                     .execute()
                 return true
@@ -1817,8 +1844,10 @@ export async function claimLoginReward(
     streakBroken: boolean = false
 ): Promise<{ success: boolean; newXP?: number; newLevel?: number }> {
     try {
+        await ensureStreakColumn()
         await ensureLoginRewardColumns()
         await ensureChallengeColumns()
+        await ensurePreferenceColumns()
 
         const { getLevelFromXP } = await getChallengesModule()
 

--- a/src/lib/server/db/queries.ts
+++ b/src/lib/server/db/queries.ts
@@ -36,6 +36,33 @@ function chunkArray<T>(arr: T[], chunkSize: number = 100): T[][] {
 // Migration cache to avoid repeated PRAGMA calls
 const _migrationsRun = new Set<string>()
 
+// Shared, single-flight promise for the lazy user_stats schema migrations.
+// Concurrent callers (e.g. parallel SSR requests) all await the same promise so
+// the migration DDL runs at most once per process lifecycle instead of racing.
+let _userStatsSchemaPromise: Promise<void> | null = null
+
+/**
+ * Run every lazy user_stats column migration exactly once, serialized through a
+ * shared promise so concurrent callers cannot race on the DDL. Individual
+ * migrations remain defensive (they log+swallow on failure, by design, so a
+ * transient DB hiccup doesn't break the primary request flow).
+ */
+export function ensureUserStatsSchema(): Promise<void> {
+    if (!_userStatsSchemaPromise) {
+        _userStatsSchemaPromise = (async () => {
+            await ensureStreakColumn()
+            await ensureChallengeColumns()
+            await ensureLoginRewardColumns()
+            await ensurePreferenceColumns()
+        })().catch(err => {
+            // Allow the next caller to retry; surface for observability.
+            _userStatsSchemaPromise = null
+            console.warn('[ensureUserStatsSchema] migration error:', err)
+        })
+    }
+    return _userStatsSchemaPromise
+}
+
 // Lazy-cached dynamic imports to avoid repeated resolution
 let _achievementService:
     | typeof import('../../services/achievementService')
@@ -113,10 +140,7 @@ export async function upsertUserStats(
 ): Promise<boolean> {
     try {
         // Ensure schema has all required columns before insert/update
-        await ensureStreakColumn()
-        await ensureChallengeColumns()
-        await ensureLoginRewardColumns()
-        await ensurePreferenceColumns()
+        await ensureUserStatsSchema()
 
         // Check if stats exist
         const existing = await getUserStats(userId)
@@ -1391,10 +1415,7 @@ export async function completeChallengeAndAwardXP(
     xpAmount: number
 ): Promise<boolean> {
     try {
-        await ensureStreakColumn()
-        await ensureChallengeColumns()
-        await ensureLoginRewardColumns()
-        await ensurePreferenceColumns()
+        await ensureUserStatsSchema()
 
         await db.transaction().execute(async trx => {
             const progress = await trx
@@ -1554,10 +1575,7 @@ export async function updateUserXPAndLevel(
     newLevel: number
 ): Promise<boolean> {
     try {
-        await ensureStreakColumn()
-        await ensureChallengeColumns()
-        await ensureLoginRewardColumns()
-        await ensurePreferenceColumns()
+        await ensureUserStatsSchema()
         const now = new Date().toISOString()
 
         await db
@@ -1675,10 +1693,7 @@ export async function atomicCheckAndUpdateStreak(
     allChallengesCompleted: boolean
 ): Promise<boolean> {
     try {
-        await ensureStreakColumn()
-        await ensureChallengeColumns()
-        await ensureLoginRewardColumns()
-        await ensurePreferenceColumns()
+        await ensureUserStatsSchema()
 
         if (!allChallengesCompleted) {
             return false
@@ -1844,10 +1859,7 @@ export async function claimLoginReward(
     streakBroken: boolean = false
 ): Promise<{ success: boolean; newXP?: number; newLevel?: number }> {
     try {
-        await ensureStreakColumn()
-        await ensureLoginRewardColumns()
-        await ensureChallengeColumns()
-        await ensurePreferenceColumns()
+        await ensureUserStatsSchema()
 
         const { getLevelFromXP } = await getChallengesModule()
 

--- a/src/lib/services/achievementService.test.ts
+++ b/src/lib/services/achievementService.test.ts
@@ -13,7 +13,7 @@ import { GameID } from '@/lib/games'
 vi.mock('../server/db/queries', () => ({
     awardAchievement: vi.fn(),
     hasUserEarnedAchievement: vi.fn(),
-    getUserBestScoreForGame: vi.fn(),
+    getUserBestScore: vi.fn(),
 }))
 
 // Mock the achievements
@@ -59,7 +59,7 @@ vi.mock('../achievements', () => ({
 import {
     awardAchievement,
     hasUserEarnedAchievement,
-    getUserBestScoreForGame,
+    getUserBestScore,
 } from '../server/db/queries'
 import {
     getAchievementsByGame,
@@ -69,7 +69,7 @@ import {
 
 const mockAwardAchievement = vi.mocked(awardAchievement)
 const mockHasUserEarnedAchievement = vi.mocked(hasUserEarnedAchievement)
-const mockGetUserBestScoreForGame = vi.mocked(getUserBestScoreForGame)
+const mockGetUserBestScore = vi.mocked(getUserBestScore)
 const mockGetAchievementsByGame = vi.mocked(getAchievementsByGame)
 
 describe('Achievement Service', () => {
@@ -303,7 +303,7 @@ describe('Achievement Service', () => {
                     rarity: AchievementRarity.COMMON,
                 },
             ])
-            mockGetUserBestScoreForGame.mockResolvedValue(50) // 50% progress
+            mockGetUserBestScore.mockResolvedValue(50) // 50% progress
             mockHasUserEarnedAchievement.mockResolvedValue(false)
 
             const result = await getUserGameAchievementProgress(
@@ -328,7 +328,7 @@ describe('Achievement Service', () => {
                     rarity: AchievementRarity.COMMON,
                 },
             ])
-            mockGetUserBestScoreForGame.mockResolvedValue(200) // 200% but should cap at 100%
+            mockGetUserBestScore.mockResolvedValue(200) // 200% but should cap at 100%
             mockHasUserEarnedAchievement.mockResolvedValue(true)
 
             const result = await getUserGameAchievementProgress(
@@ -352,7 +352,7 @@ describe('Achievement Service', () => {
                     rarity: AchievementRarity.RARE,
                 } satisfies Achievement,
             ])
-            mockGetUserBestScoreForGame.mockResolvedValue(999)
+            mockGetUserBestScore.mockResolvedValue(999)
             mockHasUserEarnedAchievement.mockResolvedValue(false)
 
             const result = await getUserGameAchievementProgress(

--- a/src/lib/services/achievementService.test.ts
+++ b/src/lib/services/achievementService.test.ts
@@ -7,6 +7,7 @@ import {
     checkSpaceExplorerAchievement,
     checkInGameAchievements,
 } from './achievementService'
+import { GameID } from '@/lib/games'
 
 // Mock the database queries
 vi.mock('../server/db/queries', () => ({
@@ -47,6 +48,12 @@ vi.mock('../achievements', () => ({
             rarity: 'common',
         },
     ],
+    AchievementRarity: {
+        COMMON: 'common',
+        RARE: 'rare',
+        EPIC: 'epic',
+        LEGENDARY: 'legendary',
+    },
 }))
 
 import {
@@ -54,7 +61,7 @@ import {
     hasUserEarnedAchievement,
     getUserBestScoreForGame,
 } from '../server/db/queries'
-import { getAchievementsByGame } from '../achievements'
+import { getAchievementsByGame, AchievementRarity } from '../achievements'
 
 const mockAwardAchievement = vi.mocked(awardAchievement)
 const mockHasUserEarnedAchievement = vi.mocked(hasUserEarnedAchievement)
@@ -75,9 +82,9 @@ describe('Achievement Service', () => {
                     name: 'Tetris Novice',
                     description: 'Score 100 points in Tetris',
                     logo: '🔰',
-                    gameId: 'tetris',
+                    gameId: GameID.TETRIS,
                     condition: { type: 'score_threshold', threshold: 100 },
-                    rarity: 'common',
+                    rarity: AchievementRarity.COMMON,
                 },
             ])
             mockHasUserEarnedAchievement.mockResolvedValue(false)
@@ -85,11 +92,13 @@ describe('Achievement Service', () => {
 
             const result = await checkAndAwardAchievements(
                 'user123',
-                'tetris',
+                GameID.TETRIS,
                 150
             )
 
-            expect(mockGetAchievementsByGame).toHaveBeenCalledWith('tetris')
+            expect(mockGetAchievementsByGame).toHaveBeenCalledWith(
+                GameID.TETRIS
+            )
             expect(mockHasUserEarnedAchievement).toHaveBeenCalledWith(
                 'user123',
                 'tetris_novice'
@@ -108,16 +117,16 @@ describe('Achievement Service', () => {
                     name: 'Tetris Novice',
                     description: 'Score 100 points in Tetris',
                     logo: '🔰',
-                    gameId: 'tetris',
+                    gameId: GameID.TETRIS,
                     condition: { type: 'score_threshold', threshold: 100 },
-                    rarity: 'common',
+                    rarity: AchievementRarity.COMMON,
                 },
             ])
             mockHasUserEarnedAchievement.mockResolvedValue(true) // Already earned
 
             const result = await checkAndAwardAchievements(
                 'user123',
-                'tetris',
+                GameID.TETRIS,
                 150
             )
 
@@ -132,15 +141,15 @@ describe('Achievement Service', () => {
                     name: 'Tetris Novice',
                     description: 'Score 100 points in Tetris',
                     logo: '🔰',
-                    gameId: 'tetris',
+                    gameId: GameID.TETRIS,
                     condition: { type: 'score_threshold', threshold: 100 },
-                    rarity: 'common',
+                    rarity: AchievementRarity.COMMON,
                 },
             ])
 
             const result = await checkAndAwardAchievements(
                 'user123',
-                'tetris',
+                GameID.TETRIS,
                 50
             ) // Below threshold
 
@@ -155,18 +164,18 @@ describe('Achievement Service', () => {
                     name: 'Tetris Novice',
                     description: 'Score 100 points in Tetris',
                     logo: '🔰',
-                    gameId: 'tetris',
+                    gameId: GameID.TETRIS,
                     condition: { type: 'score_threshold', threshold: 100 },
-                    rarity: 'common',
+                    rarity: AchievementRarity.COMMON,
                 },
                 {
                     id: 'tetris_master',
                     name: 'Tetris Master',
                     description: 'Score 1000 points in Tetris',
                     logo: '👑',
-                    gameId: 'tetris',
+                    gameId: GameID.TETRIS,
                     condition: { type: 'score_threshold', threshold: 1000 },
-                    rarity: 'epic',
+                    rarity: AchievementRarity.EPIC,
                 },
             ])
             mockHasUserEarnedAchievement.mockResolvedValue(false)
@@ -174,7 +183,7 @@ describe('Achievement Service', () => {
 
             const result = await checkAndAwardAchievements(
                 'user123',
-                'tetris',
+                GameID.TETRIS,
                 1200
             )
 
@@ -189,7 +198,7 @@ describe('Achievement Service', () => {
 
             const result = await checkAndAwardAchievements(
                 'user123',
-                'tetris',
+                GameID.TETRIS,
                 150
             )
 
@@ -203,15 +212,15 @@ describe('Achievement Service', () => {
                     name: 'Broken Threshold',
                     description: 'Invalid threshold config',
                     logo: '❌',
-                    gameId: 'tetris',
+                    gameId: GameID.TETRIS,
                     condition: { type: 'score_threshold' },
-                    rarity: 'common',
+                    rarity: AchievementRarity.COMMON,
                 } as any,
             ])
 
             const result = await checkAndAwardAchievements(
                 'user123',
-                'tetris',
+                GameID.TETRIS,
                 1000
             )
 
@@ -285,9 +294,9 @@ describe('Achievement Service', () => {
                     name: 'Tetris Novice',
                     description: 'Score 100 points in Tetris',
                     logo: '🔰',
-                    gameId: 'tetris',
+                    gameId: GameID.TETRIS,
                     condition: { type: 'score_threshold', threshold: 100 },
-                    rarity: 'common',
+                    rarity: AchievementRarity.COMMON,
                 },
             ])
             mockGetUserBestScoreForGame.mockResolvedValue(50) // 50% progress
@@ -295,7 +304,7 @@ describe('Achievement Service', () => {
 
             const result = await getUserGameAchievementProgress(
                 'user123',
-                'tetris'
+                GameID.TETRIS
             )
 
             expect(result).toHaveLength(1)
@@ -310,9 +319,9 @@ describe('Achievement Service', () => {
                     name: 'Tetris Novice',
                     description: 'Score 100 points in Tetris',
                     logo: '🔰',
-                    gameId: 'tetris',
+                    gameId: GameID.TETRIS,
                     condition: { type: 'score_threshold', threshold: 100 },
-                    rarity: 'common',
+                    rarity: AchievementRarity.COMMON,
                 },
             ])
             mockGetUserBestScoreForGame.mockResolvedValue(200) // 200% but should cap at 100%
@@ -320,7 +329,7 @@ describe('Achievement Service', () => {
 
             const result = await getUserGameAchievementProgress(
                 'user123',
-                'tetris'
+                GameID.TETRIS
             )
 
             expect(result[0].progress).toBe(100)
@@ -334,9 +343,9 @@ describe('Achievement Service', () => {
                     name: 'Custom Condition',
                     description: 'Non-score based',
                     logo: '🧪',
-                    gameId: 'tetris',
+                    gameId: GameID.TETRIS,
                     condition: { type: 'in_game', check: () => true },
-                    rarity: 'rare',
+                    rarity: AchievementRarity.RARE,
                 } as any,
             ])
             mockGetUserBestScoreForGame.mockResolvedValue(999)
@@ -344,7 +353,7 @@ describe('Achievement Service', () => {
 
             const result = await getUserGameAchievementProgress(
                 'user123',
-                'tetris'
+                GameID.TETRIS
             )
 
             expect(result).toHaveLength(1)
@@ -359,7 +368,7 @@ describe('Achievement Service', () => {
 
             const result = await getUserGameAchievementProgress(
                 'user123',
-                'tetris'
+                GameID.TETRIS
             )
 
             expect(result).toEqual([])
@@ -426,9 +435,9 @@ describe('Achievement Service', () => {
                     name: 'Clean Stack',
                     description: 'Perform a special in-game condition',
                     logo: '✨',
-                    gameId: 'tetris',
+                    gameId: GameID.TETRIS,
                     condition: { type: 'in_game', check: inGameCheck },
-                    rarity: 'rare',
+                    rarity: AchievementRarity.RARE,
                 } as any,
             ])
             mockHasUserEarnedAchievement.mockResolvedValue(false)
@@ -436,7 +445,7 @@ describe('Achievement Service', () => {
 
             const result = await checkInGameAchievements(
                 'user123',
-                'tetris',
+                GameID.TETRIS,
                 { linesCleared: 4 } as any,
                 1200
             )
@@ -457,15 +466,15 @@ describe('Achievement Service', () => {
                     name: 'Clean Stack',
                     description: 'Perform a special in-game condition',
                     logo: '✨',
-                    gameId: 'tetris',
+                    gameId: GameID.TETRIS,
                     condition: { type: 'in_game', check: inGameCheck },
-                    rarity: 'rare',
+                    rarity: AchievementRarity.RARE,
                 } as any,
             ])
 
             const result = await checkInGameAchievements(
                 'user123',
-                'tetris',
+                GameID.TETRIS,
                 { linesCleared: 0 } as any,
                 10
             )
@@ -483,16 +492,16 @@ describe('Achievement Service', () => {
                     name: 'Clean Stack',
                     description: 'Perform a special in-game condition',
                     logo: '✨',
-                    gameId: 'tetris',
+                    gameId: GameID.TETRIS,
                     condition: { type: 'in_game', check: inGameCheck },
-                    rarity: 'rare',
+                    rarity: AchievementRarity.RARE,
                 } as any,
             ])
             mockHasUserEarnedAchievement.mockResolvedValue(true)
 
             const result = await checkInGameAchievements(
                 'user123',
-                'tetris',
+                GameID.TETRIS,
                 { linesCleared: 4 } as any,
                 1000
             )
@@ -509,9 +518,9 @@ describe('Achievement Service', () => {
                     name: 'Clean Stack',
                     description: 'Perform a special in-game condition',
                     logo: '✨',
-                    gameId: 'tetris',
+                    gameId: GameID.TETRIS,
                     condition: { type: 'in_game', check: inGameCheck },
-                    rarity: 'rare',
+                    rarity: AchievementRarity.RARE,
                 } as any,
             ])
             mockHasUserEarnedAchievement.mockResolvedValue(false)
@@ -519,7 +528,7 @@ describe('Achievement Service', () => {
 
             const result = await checkInGameAchievements(
                 'user123',
-                'tetris',
+                GameID.TETRIS,
                 { linesCleared: 4 } as any,
                 1000
             )

--- a/src/lib/services/achievementService.test.ts
+++ b/src/lib/services/achievementService.test.ts
@@ -61,7 +61,11 @@ import {
     hasUserEarnedAchievement,
     getUserBestScoreForGame,
 } from '../server/db/queries'
-import { getAchievementsByGame, AchievementRarity } from '../achievements'
+import {
+    getAchievementsByGame,
+    AchievementRarity,
+    type Achievement,
+} from '../achievements'
 
 const mockAwardAchievement = vi.mocked(awardAchievement)
 const mockHasUserEarnedAchievement = vi.mocked(hasUserEarnedAchievement)
@@ -215,7 +219,7 @@ describe('Achievement Service', () => {
                     gameId: GameID.TETRIS,
                     condition: { type: 'score_threshold' },
                     rarity: AchievementRarity.COMMON,
-                } as any,
+                } satisfies Achievement,
             ])
 
             const result = await checkAndAwardAchievements(
@@ -346,7 +350,7 @@ describe('Achievement Service', () => {
                     gameId: GameID.TETRIS,
                     condition: { type: 'in_game', check: () => true },
                     rarity: AchievementRarity.RARE,
-                } as any,
+                } satisfies Achievement,
             ])
             mockGetUserBestScoreForGame.mockResolvedValue(999)
             mockHasUserEarnedAchievement.mockResolvedValue(false)
@@ -438,7 +442,7 @@ describe('Achievement Service', () => {
                     gameId: GameID.TETRIS,
                     condition: { type: 'in_game', check: inGameCheck },
                     rarity: AchievementRarity.RARE,
-                } as any,
+                } satisfies Achievement,
             ])
             mockHasUserEarnedAchievement.mockResolvedValue(false)
             mockAwardAchievement.mockResolvedValue(true)
@@ -446,7 +450,7 @@ describe('Achievement Service', () => {
             const result = await checkInGameAchievements(
                 'user123',
                 GameID.TETRIS,
-                { linesCleared: 4 } as any,
+                { linesCleared: 4 },
                 1200
             )
 
@@ -469,13 +473,13 @@ describe('Achievement Service', () => {
                     gameId: GameID.TETRIS,
                     condition: { type: 'in_game', check: inGameCheck },
                     rarity: AchievementRarity.RARE,
-                } as any,
+                } satisfies Achievement,
             ])
 
             const result = await checkInGameAchievements(
                 'user123',
                 GameID.TETRIS,
-                { linesCleared: 0 } as any,
+                { linesCleared: 0 },
                 10
             )
 
@@ -495,14 +499,14 @@ describe('Achievement Service', () => {
                     gameId: GameID.TETRIS,
                     condition: { type: 'in_game', check: inGameCheck },
                     rarity: AchievementRarity.RARE,
-                } as any,
+                } satisfies Achievement,
             ])
             mockHasUserEarnedAchievement.mockResolvedValue(true)
 
             const result = await checkInGameAchievements(
                 'user123',
                 GameID.TETRIS,
-                { linesCleared: 4 } as any,
+                { linesCleared: 4 },
                 1000
             )
 
@@ -521,7 +525,7 @@ describe('Achievement Service', () => {
                     gameId: GameID.TETRIS,
                     condition: { type: 'in_game', check: inGameCheck },
                     rarity: AchievementRarity.RARE,
-                } as any,
+                } satisfies Achievement,
             ])
             mockHasUserEarnedAchievement.mockResolvedValue(false)
             mockAwardAchievement.mockResolvedValue(false)
@@ -529,7 +533,7 @@ describe('Achievement Service', () => {
             const result = await checkInGameAchievements(
                 'user123',
                 GameID.TETRIS,
-                { linesCleared: 4 } as any,
+                { linesCleared: 4 },
                 1000
             )
 

--- a/src/lib/services/achievementService.ts
+++ b/src/lib/services/achievementService.ts
@@ -7,7 +7,7 @@ import {
 import {
     awardAchievement,
     hasUserEarnedAchievement,
-    getUserBestScoreForGame,
+    getUserBestScore,
 } from '../server/db/queries'
 import type { GameType } from '../server/db/types'
 
@@ -102,7 +102,7 @@ export async function getUserGameAchievementProgress(
 > {
     try {
         const gameAchievements = getAchievementsByGame(gameId)
-        const userBestScore = await getUserBestScoreForGame(userId, gameId)
+        const userBestScore = (await getUserBestScore(userId, gameId)) ?? 0
 
         const progress = []
 

--- a/src/lib/services/scoreService.ts
+++ b/src/lib/services/scoreService.ts
@@ -7,24 +7,6 @@ import { type AchievementNotification } from '@/lib/achievements'
 import { getGameById, type GameID } from '@/lib/games'
 import type { GameData } from '@/lib/games/shared/types'
 
-declare global {
-    interface Window {
-        showAchievementAward?: (achievements: AchievementNotification[]) => void
-        showChallengeComplete?: (challengeUpdates: {
-            completedChallenges: Array<{
-                id: string
-                name: string
-                description: string
-                icon: string
-                xpReward: number
-            }>
-            xpEarned: number
-            levelUp: boolean
-            newLevel?: number
-        }) => void
-    }
-}
-
 export interface ScoreSubmissionResult {
     success: boolean
     newAchievements?: AchievementNotification[]

--- a/src/lib/services/scoreService.ts
+++ b/src/lib/services/scoreService.ts
@@ -3,21 +3,13 @@
  */
 
 import type { GameType } from '@/lib/server/db/types'
-import { AchievementRarity } from '@/lib/achievements'
+import { type AchievementNotification } from '@/lib/achievements'
 import { getGameById, type GameID } from '@/lib/games'
 import type { GameData } from '@/lib/games/shared/types'
 
 declare global {
     interface Window {
-        showAchievementAward?: (
-            achievements: Array<{
-                id: string
-                name: string
-                description: string
-                icon: string
-                rarity: AchievementRarity
-            }>
-        ) => void
+        showAchievementAward?: (achievements: AchievementNotification[]) => void
         showChallengeComplete?: (challengeUpdates: {
             completedChallenges: Array<{
                 id: string
@@ -35,13 +27,7 @@ declare global {
 
 export interface ScoreSubmissionResult {
     success: boolean
-    newAchievements?: Array<{
-        id: string
-        name: string
-        description: string
-        icon: string
-        rarity: AchievementRarity
-    }>
+    newAchievements?: AchievementNotification[]
     challengeUpdates?: {
         completedChallenges: Array<{
             id: string

--- a/src/pages/api/dev/add-test-scores.test.ts
+++ b/src/pages/api/dev/add-test-scores.test.ts
@@ -74,11 +74,11 @@ describe('POST /api/dev/add-test-scores', () => {
         vi.mocked(db.insertInto).mockImplementation(() => {
             callCount++
             if (callCount === 1) {
-                return { values: mockValuesUser } as ReturnType<
+                return { values: mockValuesUser } as unknown as ReturnType<
                     typeof db.insertInto
                 >
             }
-            return { values: mockValuesScores } as ReturnType<
+            return { values: mockValuesScores } as unknown as ReturnType<
                 typeof db.insertInto
             >
         })

--- a/src/pages/api/scores.test.ts
+++ b/src/pages/api/scores.test.ts
@@ -338,7 +338,7 @@ describe('POST /api/scores', () => {
         // Arrange: pass a valid GameID enum value but mock getGameById to return null
         vi.mocked(auth.api.getSession).mockResolvedValue(mockSession as any)
         const { getGameById } = await import('@/lib/games')
-        vi.mocked(getGameById).mockReturnValue(undefined as any)
+        vi.mocked(getGameById).mockReturnValue(undefined)
 
         const request = new Request('http://localhost:4321/api/scores', {
             method: 'POST',

--- a/src/pages/api/scores.test.ts
+++ b/src/pages/api/scores.test.ts
@@ -1,7 +1,7 @@
 import { describe, it, expect, vi, beforeEach } from 'vitest'
 import { POST } from '@/pages/api/scores'
 import { saveGameScoreWithAchievements } from '@/lib/server/db/queries'
-import { getGameById } from '@/lib/games'
+import { getGameById, GameID, type Game } from '@/lib/games'
 import { AchievementRarity } from '@/lib/achievements'
 import { auth } from '@/lib/auth'
 import { updateChallengeProgress } from '@/lib/services/challengeService'
@@ -12,7 +12,7 @@ vi.mock('@/lib/server/db/queries', () => ({
 }))
 
 vi.mock('@/lib/games', async importOriginal => {
-    const actual = await importOriginal()
+    const actual = (await importOriginal()) as Record<string, unknown>
     return {
         ...actual,
         getGameById: vi.fn(),
@@ -43,15 +43,27 @@ describe('POST /api/scores', () => {
     }
 
     const mockSession = {
+        session: {
+            id: 'session-123',
+            userId: 'user-123',
+            expiresAt: new Date(),
+            createdAt: new Date(),
+            updatedAt: new Date(),
+            token: 'session-token-123',
+            ipAddress: null,
+            userAgent: null,
+        },
         user: mockUser,
-        id: 'session-123',
     }
 
-    const mockGame = {
-        id: 'tetris',
+    const mockGame: Game = {
+        id: GameID.TETRIS,
         name: 'Tetris Challenge',
         description: 'Classic block-stacking puzzle game',
-        created_at: new Date(),
+        category: 'puzzle',
+        difficulty: 'medium',
+        tags: [],
+        isActive: true,
     }
 
     beforeEach(() => {
@@ -60,7 +72,7 @@ describe('POST /api/scores', () => {
 
     it('should successfully save a score for authenticated user', async () => {
         // Arrange
-        vi.mocked(auth.api.getSession).mockResolvedValue(mockSession)
+        vi.mocked(auth.api.getSession).mockResolvedValue(mockSession as any)
         const { getGameById } = await import('@/lib/games')
         vi.mocked(getGameById).mockReturnValue(mockGame)
         vi.mocked(saveGameScoreWithAchievements).mockResolvedValue({
@@ -80,7 +92,7 @@ describe('POST /api/scores', () => {
         })
 
         // Act
-        const response = await POST({ request })
+        const response = await POST({ request } as any)
         const result = await response.json()
 
         // Assert
@@ -123,7 +135,7 @@ describe('POST /api/scores', () => {
         })
 
         // Act
-        const response = await POST({ request })
+        const response = await POST({ request } as any)
         const result = await response.json()
 
         // Assert
@@ -135,7 +147,7 @@ describe('POST /api/scores', () => {
 
     it('should return 400 for missing gameId', async () => {
         // Arrange
-        vi.mocked(auth.api.getSession).mockResolvedValue(mockSession)
+        vi.mocked(auth.api.getSession).mockResolvedValue(mockSession as any)
 
         const request = new Request('http://localhost:4321/api/scores', {
             method: 'POST',
@@ -148,7 +160,7 @@ describe('POST /api/scores', () => {
         })
 
         // Act
-        const response = await POST({ request })
+        const response = await POST({ request } as any)
         const result = await response.json()
 
         // Assert
@@ -160,7 +172,7 @@ describe('POST /api/scores', () => {
 
     it('should return 400 for missing score', async () => {
         // Arrange
-        vi.mocked(auth.api.getSession).mockResolvedValue(mockSession)
+        vi.mocked(auth.api.getSession).mockResolvedValue(mockSession as any)
 
         const request = new Request('http://localhost:4321/api/scores', {
             method: 'POST',
@@ -173,7 +185,7 @@ describe('POST /api/scores', () => {
         })
 
         // Act
-        const response = await POST({ request })
+        const response = await POST({ request } as any)
         const result = await response.json()
 
         // Assert
@@ -185,7 +197,7 @@ describe('POST /api/scores', () => {
 
     it('should return 400 for invalid score type', async () => {
         // Arrange
-        vi.mocked(auth.api.getSession).mockResolvedValue(mockSession)
+        vi.mocked(auth.api.getSession).mockResolvedValue(mockSession as any)
 
         const request = new Request('http://localhost:4321/api/scores', {
             method: 'POST',
@@ -199,7 +211,7 @@ describe('POST /api/scores', () => {
         })
 
         // Act
-        const response = await POST({ request })
+        const response = await POST({ request } as any)
         const result = await response.json()
 
         // Assert
@@ -211,7 +223,7 @@ describe('POST /api/scores', () => {
 
     it('should return 400 for invalid game ID', async () => {
         // Arrange
-        vi.mocked(auth.api.getSession).mockResolvedValue(mockSession)
+        vi.mocked(auth.api.getSession).mockResolvedValue(mockSession as any)
 
         const request = new Request('http://localhost:4321/api/scores', {
             method: 'POST',
@@ -225,7 +237,7 @@ describe('POST /api/scores', () => {
         })
 
         // Act
-        const response = await POST({ request })
+        const response = await POST({ request } as any)
         const result = await response.json()
 
         // Assert - Zod validates against game ID enum, so invalid IDs are caught during validation
@@ -238,7 +250,7 @@ describe('POST /api/scores', () => {
 
     it('should return 500 when save fails', async () => {
         // Arrange
-        vi.mocked(auth.api.getSession).mockResolvedValue(mockSession)
+        vi.mocked(auth.api.getSession).mockResolvedValue(mockSession as any)
         const { getGameById } = await import('@/lib/games')
         vi.mocked(getGameById).mockReturnValue(mockGame)
         vi.mocked(saveGameScoreWithAchievements).mockResolvedValue({
@@ -258,7 +270,7 @@ describe('POST /api/scores', () => {
         })
 
         // Act
-        const response = await POST({ request })
+        const response = await POST({ request } as any)
         const result = await response.json()
 
         // Assert
@@ -275,7 +287,7 @@ describe('POST /api/scores', () => {
 
     it('should return 500 for database errors', async () => {
         // Arrange
-        vi.mocked(auth.api.getSession).mockResolvedValue(mockSession)
+        vi.mocked(auth.api.getSession).mockResolvedValue(mockSession as any)
         const { getGameById } = await import('@/lib/games')
         vi.mocked(getGameById).mockImplementation(() => {
             throw new Error('Database error')
@@ -293,7 +305,7 @@ describe('POST /api/scores', () => {
         })
 
         // Act
-        const response = await POST({ request })
+        const response = await POST({ request } as any)
         const result = await response.json()
 
         // Assert
@@ -303,7 +315,7 @@ describe('POST /api/scores', () => {
 
     it('should return 400 for malformed JSON', async () => {
         // Arrange
-        vi.mocked(auth.api.getSession).mockResolvedValue(mockSession)
+        vi.mocked(auth.api.getSession).mockResolvedValue(mockSession as any)
 
         const request = new Request('http://localhost:4321/api/scores', {
             method: 'POST',
@@ -314,7 +326,7 @@ describe('POST /api/scores', () => {
         })
 
         // Act
-        const response = await POST({ request })
+        const response = await POST({ request } as any)
         const result = await response.json()
 
         // Assert - Zod validation catches malformed JSON and returns 400
@@ -324,9 +336,9 @@ describe('POST /api/scores', () => {
 
     it('should return 400 when getGameById returns null', async () => {
         // Arrange: pass a valid GameID enum value but mock getGameById to return null
-        vi.mocked(auth.api.getSession).mockResolvedValue(mockSession)
+        vi.mocked(auth.api.getSession).mockResolvedValue(mockSession as any)
         const { getGameById } = await import('@/lib/games')
-        vi.mocked(getGameById).mockReturnValue(null)
+        vi.mocked(getGameById).mockReturnValue(undefined as any)
 
         const request = new Request('http://localhost:4321/api/scores', {
             method: 'POST',
@@ -334,7 +346,7 @@ describe('POST /api/scores', () => {
             body: JSON.stringify({ gameId: 'tetris', score: 1000 }),
         })
 
-        const response = await POST({ request })
+        const response = await POST({ request } as any)
         const result = await response.json()
 
         expect(response.status).toBe(400)
@@ -344,7 +356,7 @@ describe('POST /api/scores', () => {
 
     it('should include challengeUpdates when challenges are completed', async () => {
         // Arrange
-        vi.mocked(auth.api.getSession).mockResolvedValue(mockSession)
+        vi.mocked(auth.api.getSession).mockResolvedValue(mockSession as any)
         const { getGameById } = await import('@/lib/games')
         vi.mocked(getGameById).mockReturnValue(mockGame)
         vi.mocked(saveGameScoreWithAchievements).mockResolvedValue({
@@ -372,7 +384,7 @@ describe('POST /api/scores', () => {
             body: JSON.stringify({ gameId: 'tetris', score: 9999 }),
         })
 
-        const response = await POST({ request })
+        const response = await POST({ request } as any)
         const result = await response.json()
 
         expect(response.status).toBe(200)
@@ -385,7 +397,7 @@ describe('POST /api/scores', () => {
 
     it('should continue and return success even when updateChallengeProgress throws', async () => {
         // Arrange: mock session and game lookup to avoid flakiness
-        vi.mocked(auth.api.getSession).mockResolvedValue(mockSession)
+        vi.mocked(auth.api.getSession).mockResolvedValue(mockSession as any)
         const { getGameById } = await import('@/lib/games')
         vi.mocked(getGameById).mockReturnValue(mockGame)
 
@@ -403,7 +415,7 @@ describe('POST /api/scores', () => {
             body: JSON.stringify({ gameId: 'tetris', score: 500 }),
         })
 
-        const response = await POST({ request })
+        const response = await POST({ request } as any)
         const result = await response.json()
 
         expect(response.status).toBe(200)

--- a/src/pages/api/scores/best.test.ts
+++ b/src/pages/api/scores/best.test.ts
@@ -218,7 +218,7 @@ describe('GET /api/scores/best', () => {
     it('should return 400 when getGameById returns null for valid game ID', async () => {
         // Arrange
         vi.mocked(auth.api.getSession).mockResolvedValue(mockSession as any)
-        vi.mocked(getGameById).mockReturnValue(undefined as any)
+        vi.mocked(getGameById).mockReturnValue(undefined)
 
         const url = new URL(
             'http://localhost:4321/api/scores/best?gameId=tetris'

--- a/src/pages/api/scores/best.test.ts
+++ b/src/pages/api/scores/best.test.ts
@@ -1,7 +1,7 @@
 import { describe, it, expect, vi, beforeEach } from 'vitest'
 import { GET } from '@/pages/api/scores/best'
 import { getUserBestScore } from '@/lib/server/db/queries'
-import { getGameById } from '@/lib/games'
+import { getGameById, GameID, type Game } from '@/lib/games'
 import { auth } from '@/lib/auth'
 
 // Mock dependencies
@@ -43,15 +43,27 @@ describe('GET /api/scores/best', () => {
     }
 
     const mockSession = {
+        session: {
+            id: 'session-123',
+            userId: 'user-123',
+            expiresAt: new Date(),
+            createdAt: new Date(),
+            updatedAt: new Date(),
+            token: 'session-token-123',
+            ipAddress: null,
+            userAgent: null,
+        },
         user: mockUser,
-        id: 'session-123',
     }
 
-    const mockGame = {
-        id: 'tetris',
+    const mockGame: Game = {
+        id: GameID.TETRIS,
         name: 'Tetris Challenge',
         description: 'Classic block-stacking puzzle game',
-        created_at: new Date(),
+        category: 'puzzle',
+        difficulty: 'medium',
+        tags: [],
+        isActive: true,
     }
 
     beforeEach(() => {
@@ -60,7 +72,7 @@ describe('GET /api/scores/best', () => {
 
     it('should return best score for authenticated user and valid game', async () => {
         // Arrange
-        vi.mocked(auth.api.getSession).mockResolvedValue(mockSession)
+        vi.mocked(auth.api.getSession).mockResolvedValue(mockSession as any)
         const { getGameById } = await import('@/lib/games')
         vi.mocked(getGameById).mockReturnValue(mockGame)
         vi.mocked(getUserBestScore).mockResolvedValue(15000)
@@ -71,7 +83,7 @@ describe('GET /api/scores/best', () => {
         const request = new Request(url)
 
         // Act
-        const response = await GET({ request, url })
+        const response = await GET({ request, url } as any)
         const result = await response.json()
 
         // Assert
@@ -83,7 +95,7 @@ describe('GET /api/scores/best', () => {
 
     it('should return null when user has no scores for the game', async () => {
         // Arrange
-        vi.mocked(auth.api.getSession).mockResolvedValue(mockSession)
+        vi.mocked(auth.api.getSession).mockResolvedValue(mockSession as any)
         const { getGameById } = await import('@/lib/games')
         vi.mocked(getGameById).mockReturnValue(mockGame)
         vi.mocked(getUserBestScore).mockResolvedValue(null)
@@ -94,7 +106,7 @@ describe('GET /api/scores/best', () => {
         const request = new Request(url)
 
         // Act
-        const response = await GET({ request, url })
+        const response = await GET({ request, url } as any)
         const result = await response.json()
 
         // Assert
@@ -114,7 +126,7 @@ describe('GET /api/scores/best', () => {
         const request = new Request(url)
 
         // Act
-        const response = await GET({ request, url })
+        const response = await GET({ request, url } as any)
         const result = await response.json()
 
         // Assert
@@ -126,13 +138,13 @@ describe('GET /api/scores/best', () => {
 
     it('should return 400 for missing gameId parameter', async () => {
         // Arrange
-        vi.mocked(auth.api.getSession).mockResolvedValue(mockSession)
+        vi.mocked(auth.api.getSession).mockResolvedValue(mockSession as any)
 
         const url = new URL('http://localhost:4321/api/scores/best')
         const request = new Request(url)
 
         // Act
-        const response = await GET({ request, url })
+        const response = await GET({ request, url } as any)
         const result = await response.json()
 
         // Assert
@@ -144,13 +156,13 @@ describe('GET /api/scores/best', () => {
 
     it('should return 400 for empty gameId parameter', async () => {
         // Arrange
-        vi.mocked(auth.api.getSession).mockResolvedValue(mockSession)
+        vi.mocked(auth.api.getSession).mockResolvedValue(mockSession as any)
 
         const url = new URL('http://localhost:4321/api/scores/best?gameId=')
         const request = new Request(url)
 
         // Act
-        const response = await GET({ request, url })
+        const response = await GET({ request, url } as any)
         const result = await response.json()
 
         // Assert
@@ -162,7 +174,7 @@ describe('GET /api/scores/best', () => {
 
     it('should return 400 for invalid game ID', async () => {
         // Arrange
-        vi.mocked(auth.api.getSession).mockResolvedValue(mockSession)
+        vi.mocked(auth.api.getSession).mockResolvedValue(mockSession as any)
 
         const url = new URL(
             'http://localhost:4321/api/scores/best?gameId=invalid-game'
@@ -170,7 +182,7 @@ describe('GET /api/scores/best', () => {
         const request = new Request(url)
 
         // Act
-        const response = await GET({ request, url })
+        const response = await GET({ request, url } as any)
         const result = await response.json()
 
         // Assert
@@ -182,7 +194,7 @@ describe('GET /api/scores/best', () => {
 
     it('should handle different valid game IDs', async () => {
         // Arrange
-        vi.mocked(auth.api.getSession).mockResolvedValue(mockSession)
+        vi.mocked(auth.api.getSession).mockResolvedValue(mockSession as any)
         const { getGameById } = await import('@/lib/games')
         vi.mocked(getGameById).mockReturnValue(mockGame)
         vi.mocked(getUserBestScore).mockResolvedValue(8000)
@@ -193,7 +205,7 @@ describe('GET /api/scores/best', () => {
         const request = new Request(url)
 
         // Act
-        const response = await GET({ request, url })
+        const response = await GET({ request, url } as any)
         const result = await response.json()
 
         // Assert
@@ -205,8 +217,8 @@ describe('GET /api/scores/best', () => {
 
     it('should return 400 when getGameById returns null for valid game ID', async () => {
         // Arrange
-        vi.mocked(auth.api.getSession).mockResolvedValue(mockSession)
-        vi.mocked(getGameById).mockReturnValue(null)
+        vi.mocked(auth.api.getSession).mockResolvedValue(mockSession as any)
+        vi.mocked(getGameById).mockReturnValue(undefined as any)
 
         const url = new URL(
             'http://localhost:4321/api/scores/best?gameId=tetris'
@@ -214,7 +226,7 @@ describe('GET /api/scores/best', () => {
         const request = new Request(url)
 
         // Act
-        const response = await GET({ request, url })
+        const response = await GET({ request, url } as any)
         const result = await response.json()
 
         // Assert
@@ -226,7 +238,7 @@ describe('GET /api/scores/best', () => {
 
     it('should return 500 for database errors during game lookup', async () => {
         // Arrange
-        vi.mocked(auth.api.getSession).mockResolvedValue(mockSession)
+        vi.mocked(auth.api.getSession).mockResolvedValue(mockSession as any)
         const { getGameById } = await import('@/lib/games')
         vi.mocked(getGameById).mockImplementation(() => {
             throw new Error('Database error')
@@ -238,7 +250,7 @@ describe('GET /api/scores/best', () => {
         const request = new Request(url)
 
         // Act
-        const response = await GET({ request, url })
+        const response = await GET({ request, url } as any)
         const result = await response.json()
 
         // Assert
@@ -248,7 +260,7 @@ describe('GET /api/scores/best', () => {
 
     it('should return 500 for database errors during score lookup', async () => {
         // Arrange
-        vi.mocked(auth.api.getSession).mockResolvedValue(mockSession)
+        vi.mocked(auth.api.getSession).mockResolvedValue(mockSession as any)
         const { getGameById } = await import('@/lib/games')
         vi.mocked(getGameById).mockReturnValue(mockGame)
         vi.mocked(getUserBestScore).mockRejectedValue(
@@ -261,7 +273,7 @@ describe('GET /api/scores/best', () => {
         const request = new Request(url)
 
         // Act
-        const response = await GET({ request, url })
+        const response = await GET({ request, url } as any)
         const result = await response.json()
 
         // Assert
@@ -281,7 +293,7 @@ describe('GET /api/scores/best', () => {
         const request = new Request(url)
 
         // Act
-        const response = await GET({ request, url })
+        const response = await GET({ request, url } as any)
         const result = await response.json()
 
         // Assert
@@ -297,10 +309,10 @@ describe('GET /api/scores/best', () => {
         for (let i = 0; i < gameIds.length; i++) {
             vi.clearAllMocks()
 
-            vi.mocked(auth.api.getSession).mockResolvedValue(mockSession)
+            vi.mocked(auth.api.getSession).mockResolvedValue(mockSession as any)
             vi.mocked(getGameById).mockReturnValue({
                 ...mockGame,
-                id: gameIds[i],
+                id: gameIds[i] as GameID,
             })
             vi.mocked(getUserBestScore).mockResolvedValue(expectedScores[i])
 
@@ -310,7 +322,7 @@ describe('GET /api/scores/best', () => {
             const request = new Request(url)
 
             // Act
-            const response = await GET({ request, url })
+            const response = await GET({ request, url } as any)
             const result = await response.json()
 
             // Assert
@@ -326,7 +338,7 @@ describe('GET /api/scores/best', () => {
 
     it('should handle zero scores correctly', async () => {
         // Arrange
-        vi.mocked(auth.api.getSession).mockResolvedValue(mockSession)
+        vi.mocked(auth.api.getSession).mockResolvedValue(mockSession as any)
         const { getGameById } = await import('@/lib/games')
         vi.mocked(getGameById).mockReturnValue(mockGame)
         vi.mocked(getUserBestScore).mockResolvedValue(0)
@@ -337,7 +349,7 @@ describe('GET /api/scores/best', () => {
         const request = new Request(url)
 
         // Act
-        const response = await GET({ request, url })
+        const response = await GET({ request, url } as any)
         const result = await response.json()
 
         // Assert

--- a/src/pages/api/scores/history.test.ts
+++ b/src/pages/api/scores/history.test.ts
@@ -24,8 +24,17 @@ describe('GET /api/scores/history', () => {
     }
 
     const mockSession = {
+        session: {
+            id: 'session-123',
+            userId: 'user-123',
+            expiresAt: new Date(),
+            createdAt: new Date(),
+            updatedAt: new Date(),
+            token: 'session-token-123',
+            ipAddress: null,
+            userAgent: null,
+        },
         user: mockUser,
-        id: 'session-123',
     }
 
     const mockGameHistory = [
@@ -49,14 +58,14 @@ describe('GET /api/scores/history', () => {
 
     it('should return game history for authenticated user', async () => {
         // Arrange
-        vi.mocked(auth.api.getSession).mockResolvedValue(mockSession)
+        vi.mocked(auth.api.getSession).mockResolvedValue(mockSession as any)
         vi.mocked(getUserGameHistory).mockResolvedValue(mockGameHistory)
 
         const url = new URL('http://localhost:4321/api/scores/history')
         const request = new Request(url)
 
         // Act
-        const response = await GET({ request, url })
+        const response = await GET({ request, url } as any)
         const result = await response.json()
 
         // Assert
@@ -67,7 +76,7 @@ describe('GET /api/scores/history', () => {
 
     it('should return game history with custom limit', async () => {
         // Arrange
-        vi.mocked(auth.api.getSession).mockResolvedValue(mockSession)
+        vi.mocked(auth.api.getSession).mockResolvedValue(mockSession as any)
         vi.mocked(getUserGameHistory).mockResolvedValue(
             mockGameHistory.slice(0, 5)
         )
@@ -76,7 +85,7 @@ describe('GET /api/scores/history', () => {
         const request = new Request(url)
 
         // Act
-        const response = await GET({ request, url })
+        const response = await GET({ request, url } as any)
         const result = await response.json()
 
         // Assert
@@ -93,7 +102,7 @@ describe('GET /api/scores/history', () => {
         const request = new Request(url)
 
         // Act
-        const response = await GET({ request, url })
+        const response = await GET({ request, url } as any)
         const result = await response.json()
 
         // Assert
@@ -104,13 +113,13 @@ describe('GET /api/scores/history', () => {
 
     it('should return 400 for invalid limit parameter (negative)', async () => {
         // Arrange
-        vi.mocked(auth.api.getSession).mockResolvedValue(mockSession)
+        vi.mocked(auth.api.getSession).mockResolvedValue(mockSession as any)
 
         const url = new URL('http://localhost:4321/api/scores/history?limit=-1')
         const request = new Request(url)
 
         // Act
-        const response = await GET({ request, url })
+        const response = await GET({ request, url } as any)
         const result = await response.json()
 
         // Assert
@@ -121,13 +130,13 @@ describe('GET /api/scores/history', () => {
 
     it('should return 400 for invalid limit parameter (zero)', async () => {
         // Arrange
-        vi.mocked(auth.api.getSession).mockResolvedValue(mockSession)
+        vi.mocked(auth.api.getSession).mockResolvedValue(mockSession as any)
 
         const url = new URL('http://localhost:4321/api/scores/history?limit=0')
         const request = new Request(url)
 
         // Act
-        const response = await GET({ request, url })
+        const response = await GET({ request, url } as any)
         const result = await response.json()
 
         // Assert
@@ -138,7 +147,7 @@ describe('GET /api/scores/history', () => {
 
     it('should return 400 for invalid limit parameter (too large)', async () => {
         // Arrange
-        vi.mocked(auth.api.getSession).mockResolvedValue(mockSession)
+        vi.mocked(auth.api.getSession).mockResolvedValue(mockSession as any)
 
         const url = new URL(
             'http://localhost:4321/api/scores/history?limit=101'
@@ -146,7 +155,7 @@ describe('GET /api/scores/history', () => {
         const request = new Request(url)
 
         // Act
-        const response = await GET({ request, url })
+        const response = await GET({ request, url } as any)
         const result = await response.json()
 
         // Assert
@@ -157,7 +166,7 @@ describe('GET /api/scores/history', () => {
 
     it('should return 400 for invalid limit parameter (non-numeric)', async () => {
         // Arrange
-        vi.mocked(auth.api.getSession).mockResolvedValue(mockSession)
+        vi.mocked(auth.api.getSession).mockResolvedValue(mockSession as any)
 
         const url = new URL(
             'http://localhost:4321/api/scores/history?limit=abc'
@@ -165,7 +174,7 @@ describe('GET /api/scores/history', () => {
         const request = new Request(url)
 
         // Act
-        const response = await GET({ request, url })
+        const response = await GET({ request, url } as any)
         const result = await response.json()
 
         // Assert
@@ -176,14 +185,14 @@ describe('GET /api/scores/history', () => {
 
     it('should use default limit when not specified', async () => {
         // Arrange
-        vi.mocked(auth.api.getSession).mockResolvedValue(mockSession)
+        vi.mocked(auth.api.getSession).mockResolvedValue(mockSession as any)
         vi.mocked(getUserGameHistory).mockResolvedValue(mockGameHistory)
 
         const url = new URL('http://localhost:4321/api/scores/history')
         const request = new Request(url)
 
         // Act
-        const response = await GET({ request, url })
+        const response = await GET({ request, url } as any)
         const result = await response.json()
 
         // Assert
@@ -194,14 +203,14 @@ describe('GET /api/scores/history', () => {
 
     it('should return empty array when no history exists', async () => {
         // Arrange
-        vi.mocked(auth.api.getSession).mockResolvedValue(mockSession)
+        vi.mocked(auth.api.getSession).mockResolvedValue(mockSession as any)
         vi.mocked(getUserGameHistory).mockResolvedValue([])
 
         const url = new URL('http://localhost:4321/api/scores/history')
         const request = new Request(url)
 
         // Act
-        const response = await GET({ request, url })
+        const response = await GET({ request, url } as any)
         const result = await response.json()
 
         // Assert
@@ -212,7 +221,7 @@ describe('GET /api/scores/history', () => {
 
     it('should return 500 for database errors', async () => {
         // Arrange
-        vi.mocked(auth.api.getSession).mockResolvedValue(mockSession)
+        vi.mocked(auth.api.getSession).mockResolvedValue(mockSession as any)
         vi.mocked(getUserGameHistory).mockRejectedValue(
             new Error('Database error')
         )
@@ -221,7 +230,7 @@ describe('GET /api/scores/history', () => {
         const request = new Request(url)
 
         // Act
-        const response = await GET({ request, url })
+        const response = await GET({ request, url } as any)
         const result = await response.json()
 
         // Assert
@@ -231,7 +240,7 @@ describe('GET /api/scores/history', () => {
 
     it('should handle edge case limits correctly', async () => {
         // Arrange
-        vi.mocked(auth.api.getSession).mockResolvedValue(mockSession)
+        vi.mocked(auth.api.getSession).mockResolvedValue(mockSession as any)
         vi.mocked(getUserGameHistory).mockResolvedValue([])
 
         const testCases = [
@@ -249,7 +258,7 @@ describe('GET /api/scores/history', () => {
             const request = new Request(url)
 
             // Act
-            const response = await GET({ request, url })
+            const response = await GET({ request, url } as any)
 
             // Assert
             expect(response.status).toBe(200)

--- a/src/pages/api/settings/index.test.ts
+++ b/src/pages/api/settings/index.test.ts
@@ -185,7 +185,7 @@ describe('Settings API', () => {
                 json: async () => {
                     throw new SyntaxError('Unexpected token')
                 },
-            } as Request
+            } as unknown as Request
             const context = createMockContext(mockLocals, malformedRequest)
 
             const response = await POST(context)
@@ -200,7 +200,7 @@ describe('Settings API', () => {
                 json: async () => {
                     throw new TypeError('Not a syntax error')
                 },
-            } as Request
+            } as unknown as Request
             const context = createMockContext(mockLocals, badRequest)
 
             const response = await POST(context)

--- a/src/pages/api/user/update-streaks.test.ts
+++ b/src/pages/api/user/update-streaks.test.ts
@@ -181,7 +181,7 @@ describe('POST /api/user/update-streaks', () => {
 
     it('returns 403 in production when no CRON_SECRET is set', async () => {
         delete process.env.CRON_SECRET
-        vi.stubEnv('PROD', 'true')
+        vi.stubEnv('PROD', 'true' as any)
 
         const request = new Request(
             'http://localhost/api/user/update-streaks',

--- a/src/pages/api/user/update-streaks.test.ts
+++ b/src/pages/api/user/update-streaks.test.ts
@@ -181,7 +181,7 @@ describe('POST /api/user/update-streaks', () => {
 
     it('returns 403 in production when no CRON_SECRET is set', async () => {
         delete process.env.CRON_SECRET
-        vi.stubEnv('PROD', 'true' as any)
+        vi.stubEnv('PROD', true)
 
         const request = new Request(
             'http://localhost/api/user/update-streaks',

--- a/src/pages/evader/index.astro
+++ b/src/pages/evader/index.astro
@@ -224,6 +224,13 @@ import Button from '@/components/ui/Button.astro'
 </GamePage>
 
 <style>
+  /* Hide the touch D-pad on devices with a fine pointer (desktop/mouse). */
+  @media (hover: hover) and (pointer: fine) {
+    #dpad {
+      display: none;
+    }
+  }
+
   .dpad-btn {
     width: 3.5rem;
     height: 3.5rem;

--- a/src/pages/evader/index.astro
+++ b/src/pages/evader/index.astro
@@ -61,6 +61,50 @@ import Button from '@/components/ui/Button.astro'
             >End Game</Button
           >
         </div>
+
+        <!-- Touch / pointer D-pad for mobile devices -->
+        <div
+          id="dpad"
+          class="grid grid-cols-3 gap-2 select-none"
+          style="grid-template-areas: '. up .' 'left . right' '. down .';"
+        >
+          <button
+            type="button"
+            data-key="ArrowUp"
+            aria-label="Move up"
+            class="dpad-btn"
+            style="grid-area: up;"
+          >
+            &#8593;
+          </button>
+          <button
+            type="button"
+            data-key="ArrowLeft"
+            aria-label="Move left"
+            class="dpad-btn"
+            style="grid-area: left;"
+          >
+            &#8592;
+          </button>
+          <button
+            type="button"
+            data-key="ArrowRight"
+            aria-label="Move right"
+            class="dpad-btn"
+            style="grid-area: right;"
+          >
+            &#8594;
+          </button>
+          <button
+            type="button"
+            data-key="ArrowDown"
+            aria-label="Move down"
+            class="dpad-btn"
+            style="grid-area: down;"
+          >
+            &#8595;
+          </button>
+        </div>
       </div>
     </Card>
   </div>
@@ -174,6 +218,37 @@ import Button from '@/components/ui/Button.astro'
     </div>
   </div>
 </GamePage>
+
+<style>
+  .dpad-btn {
+    width: 3.5rem;
+    height: 3.5rem;
+    display: flex;
+    align-items: center;
+    justify-content: center;
+    font-size: 1.5rem;
+    line-height: 1;
+    border-radius: 0.75rem;
+    border: 2px solid rgba(6, 182, 212, 0.5);
+    background: rgba(6, 182, 212, 0.08);
+    color: #67e8f9;
+    cursor: pointer;
+    user-select: none;
+    -webkit-user-select: none;
+    touch-action: none;
+    transition:
+      background 0.1s,
+      border-color 0.1s,
+      box-shadow 0.1s;
+  }
+
+  .dpad-btn:active,
+  .dpad-btn.active {
+    background: rgba(6, 182, 212, 0.35);
+    border-color: #22d3ee;
+    box-shadow: 0 0 18px rgba(6, 182, 212, 0.55);
+  }
+</style>
 
 <script>
   import { initEvaderGameFramework } from '@/lib/games/evader/initFramework'

--- a/src/pages/evader/index.astro
+++ b/src/pages/evader/index.astro
@@ -73,6 +73,7 @@ import Button from '@/components/ui/Button.astro'
             data-key="ArrowUp"
             aria-label="Move up"
             class="dpad-btn"
+            tabindex="-1"
             style="grid-area: up;"
           >
             &#8593;
@@ -82,6 +83,7 @@ import Button from '@/components/ui/Button.astro'
             data-key="ArrowLeft"
             aria-label="Move left"
             class="dpad-btn"
+            tabindex="-1"
             style="grid-area: left;"
           >
             &#8592;
@@ -91,6 +93,7 @@ import Button from '@/components/ui/Button.astro'
             data-key="ArrowRight"
             aria-label="Move right"
             class="dpad-btn"
+            tabindex="-1"
             style="grid-area: right;"
           >
             &#8594;
@@ -100,6 +103,7 @@ import Button from '@/components/ui/Button.astro'
             data-key="ArrowDown"
             aria-label="Move down"
             class="dpad-btn"
+            tabindex="-1"
             style="grid-area: down;"
           >
             &#8595;

--- a/src/pages/evader/index.astro
+++ b/src/pages/evader/index.astro
@@ -73,7 +73,6 @@ import Button from '@/components/ui/Button.astro'
             data-key="ArrowUp"
             aria-label="Move up"
             class="dpad-btn"
-            tabindex="-1"
             style="grid-area: up;"
           >
             &#8593;
@@ -83,7 +82,6 @@ import Button from '@/components/ui/Button.astro'
             data-key="ArrowLeft"
             aria-label="Move left"
             class="dpad-btn"
-            tabindex="-1"
             style="grid-area: left;"
           >
             &#8592;
@@ -93,7 +91,6 @@ import Button from '@/components/ui/Button.astro'
             data-key="ArrowRight"
             aria-label="Move right"
             class="dpad-btn"
-            tabindex="-1"
             style="grid-area: right;"
           >
             &#8594;
@@ -103,7 +100,6 @@ import Button from '@/components/ui/Button.astro'
             data-key="ArrowDown"
             aria-label="Move down"
             class="dpad-btn"
-            tabindex="-1"
             style="grid-area: down;"
           >
             &#8595;
@@ -240,9 +236,9 @@ import Button from '@/components/ui/Button.astro'
     font-size: 1.5rem;
     line-height: 1;
     border-radius: 0.75rem;
-    border: 2px solid rgba(6, 182, 212, 0.5);
-    background: rgba(6, 182, 212, 0.08);
-    color: #67e8f9;
+    border: 2px solid color-mix(in oklab, var(--cetus-accent) 50%, transparent);
+    background: color-mix(in oklab, var(--cetus-accent) 8%, transparent);
+    color: var(--cetus-accent);
     cursor: pointer;
     user-select: none;
     -webkit-user-select: none;
@@ -253,11 +249,19 @@ import Button from '@/components/ui/Button.astro'
       box-shadow 0.1s;
   }
 
+  .dpad-btn:focus-visible {
+    outline: 2px solid var(--cetus-accent);
+    outline-offset: 2px;
+    box-shadow: 0 0 12px
+      color-mix(in oklab, var(--cetus-accent) 45%, transparent);
+  }
+
   .dpad-btn:active,
   .dpad-btn.active {
-    background: rgba(6, 182, 212, 0.35);
-    border-color: #22d3ee;
-    box-shadow: 0 0 18px rgba(6, 182, 212, 0.55);
+    background: color-mix(in oklab, var(--cetus-accent) 35%, transparent);
+    border-color: var(--cetus-accent);
+    box-shadow: 0 0 18px
+      color-mix(in oklab, var(--cetus-accent) 55%, transparent);
   }
 </style>
 

--- a/src/test/jsdom.d.ts
+++ b/src/test/jsdom.d.ts
@@ -1,0 +1,22 @@
+// Local ambient declaration for `jsdom`. jsdom does not ship bundled types and
+// `@types/jsdom` is not installed; declare only the surface used by tests so
+// the `import { JSDOM } from 'jsdom'` import type-checks without suppression.
+// If bundled types or `@types/jsdom` are added later, remove this file.
+declare module 'jsdom' {
+    export interface JSDOMOptions {
+        url?: string
+        pretendToBeVisual?: boolean
+        resources?: 'usable' | string
+        runScripts?: 'dangerously' | 'outside-only' | undefined
+    }
+
+    export interface JSDOMWindow extends Window {
+        document: Document
+    }
+
+    export class JSDOM {
+        constructor(html?: string, options?: JSDOMOptions)
+        readonly window: JSDOMWindow & typeof globalThis
+        serialize(): string
+    }
+}

--- a/turbo.json
+++ b/turbo.json
@@ -32,6 +32,9 @@
     "lint": {
       "outputs": []
     },
+    "typecheck": {
+      "outputs": []
+    },
     "test": {
       "outputs": [
         "coverage/**"

--- a/vitest.config.ts
+++ b/vitest.config.ts
@@ -2,48 +2,54 @@ import { defineConfig } from 'vitest/config'
 import { getViteConfig } from 'astro/config'
 import { resolve } from 'path'
 
-// getViteConfig returns an Astro UserConfig whose type doesn't include the
-// vitest `test` key, so cast the whole result to satisfy vitest's defineConfig.
-export default defineConfig(
-    // eslint-disable-next-line @typescript-eslint/no-explicit-any
-    getViteConfig({
-        test: {
-            environment: 'jsdom',
-            globals: true,
-            setupFiles: ['./src/test/setup.ts'],
-            include: [
-                'src/**/*.{test,spec}.{js,mjs,cjs,ts,mts,cts,jsx,tsx}',
-                'src/test/**/*.{test,spec}.{js,mjs,cjs,ts,mts,cts,jsx,tsx}',
+// `getViteConfig` returns an Astro `UserConfig` whose generated type omits the
+// vitest `test` key. Narrow the escape to exactly that boundary: build a typed
+// Vitest `UserConfig` (which DOES include `test`), and cast only the input to
+// `getViteConfig` / its output back across the incompatibility boundary.
+type VitestUserConfig = Parameters<typeof defineConfig>[0]
+
+const vitestConfig: VitestUserConfig = {
+    test: {
+        environment: 'jsdom',
+        globals: true,
+        setupFiles: ['./src/test/setup.ts'],
+        include: [
+            'src/**/*.{test,spec}.{js,mjs,cjs,ts,mts,cts,jsx,tsx}',
+            'src/test/**/*.{test,spec}.{js,mjs,cjs,ts,mts,cts,jsx,tsx}',
+        ],
+        coverage: {
+            provider: 'v8',
+            exclude: [
+                'e2e/**',
+                'node_modules/**',
+                '**/*.config.*',
+                '**/types.ts',
+                '**/index.ts',
+                '**/*.astro',
             ],
-            coverage: {
-                provider: 'v8',
-                exclude: [
-                    'e2e/**',
-                    'node_modules/**',
-                    '**/*.config.*',
-                    '**/types.ts',
-                    '**/index.ts',
-                    '**/*.astro',
-                ],
-            },
-            env: {
-                TURSO_DATABASE_URL: 'libsql://test-db.turso.io',
-                TURSO_AUTH_TOKEN: 'test-token',
-                BETTER_AUTH_SECRET: 'test-secret',
-                BETTER_AUTH_URL: 'http://localhost:4321',
-                GOOGLE_CLIENT_ID: 'test-google-client-id',
-                GOOGLE_CLIENT_SECRET: 'test-google-secret',
-            },
         },
-        resolve: {
-            alias: {
-                '@': resolve(__dirname, './src'),
-                'astro:middleware': resolve(
-                    __dirname,
-                    './src/test/mocks/astro-middleware.ts'
-                ),
-            },
+        env: {
+            TURSO_DATABASE_URL: 'libsql://test-db.turso.io',
+            TURSO_AUTH_TOKEN: 'test-token',
+            BETTER_AUTH_SECRET: 'test-secret',
+            BETTER_AUTH_URL: 'http://localhost:4321',
+            GOOGLE_CLIENT_ID: 'test-google-client-id',
+            GOOGLE_CLIENT_SECRET: 'test-google-secret',
         },
-        // eslint-disable-next-line @typescript-eslint/no-explicit-any
-    } as any) as any
+    },
+    resolve: {
+        alias: {
+            '@': resolve(__dirname, './src'),
+            'astro:middleware': resolve(
+                __dirname,
+                './src/test/mocks/astro-middleware.ts'
+            ),
+        },
+    },
+}
+
+export default defineConfig(
+    getViteConfig(
+        vitestConfig as Parameters<typeof getViteConfig>[0]
+    ) as VitestUserConfig
 )

--- a/vitest.config.ts
+++ b/vitest.config.ts
@@ -2,7 +2,10 @@ import { defineConfig } from 'vitest/config'
 import { getViteConfig } from 'astro/config'
 import { resolve } from 'path'
 
+// getViteConfig returns an Astro UserConfig whose type doesn't include the
+// vitest `test` key, so cast the whole result to satisfy vitest's defineConfig.
 export default defineConfig(
+    // eslint-disable-next-line @typescript-eslint/no-explicit-any
     getViteConfig({
         test: {
             environment: 'jsdom',
@@ -41,5 +44,6 @@ export default defineConfig(
                 ),
             },
         },
-    })
+        // eslint-disable-next-line @typescript-eslint/no-explicit-any
+    } as any) as any
 )


### PR DESCRIPTION
## Summary
This branch fixes several game renderer and initialization issues across the platform:

- Consolidates window globals into a centralized `AchievementNotification` type and removes duplicate global declarations.
- Updates game renderers and adds missing tests for bubble-shooter, evader, and memory-matrix.
- Improves Evader touch controls and gates them on active game state.
- Preserves Memory Matrix focus and adds proper card ARIA role for accessibility.
- Aligns game renderer tests with the updated renderer behavior.

## Commits
- `6c128ef` fix: consolidate window globals and preserve Memory Matrix focus.
- `2516873` fix: preserve Memory Matrix focus and align game renderer tests.
- `2e347e2` fix: centralize AchievementNotification type and remove duplicate global declarations.
- `ea2d74e` fix: add Evader active-state test and set Memory Matrix card role.
- `c229fc0` fix: improve Evader touch controls and Memory Matrix accessibility.
- `fca8a7c` fix: gate Evader touch controls on active state and tighten cleanup test.
- `d15f468` fix: update game renderers and add missing tests for bubble-shooter, evader, and memory-matrix

## Test plan
- [x] `bun run test:run` passes (116 test files, 2444 tests)

Generated with [Devin](https://devin.ai)

<!-- This is an auto-generated comment: release notes by coderabbit.ai -->
## Summary by CodeRabbit

* **New Features**
  * Added touch-friendly D-pad controls to Evader on mobile devices.
  * Improved Evader input handling when keyboard and touch controls are used together.
  * Added keyboard accessibility for Memory Matrix cards, including Enter/Space activation and focus preservation.
  * Improved achievement and challenge completion notifications with consistent update details.

* **Bug Fixes**
  * Improved logout handling when session confirmation encounters an error.
  * Strengthened database recovery for older account data schemas.
<!-- end of auto-generated comment: release notes by coderabbit.ai -->