### PR TITLE
Set up Cursor Cloud dev environment

### DIFF
--- a/.cursor/rules/cloud-dev-environment.mdc
+++ b/.cursor/rules/cloud-dev-environment.mdc
@@ -1,0 +1,15 @@
+---
+description: Cursor Cloud dev environment setup and non-obvious startup caveats for the Cetus platform
+alwaysApply: true
+---
+
+# Cursor Cloud specific instructions
+
+- **Tooling on PATH**: `bun` and the `turso` CLI are installed by the startup update script (to `~/.bun/bin` and `~/.turso`) and added to `~/.bashrc`. Interactive/login shells (e.g. tmux `bash -l`) pick them up automatically. In a non-login shell you may need `export PATH="$HOME/.bun/bin:$HOME/.turso:$PATH"`.
+- **`.env` is required to boot**: `src/lib/auth.ts` throws at startup unless `BETTER_AUTH_SECRET` is set AND `GOOGLE_CLIENT_ID`/`GOOGLE_CLIENT_SECRET` are non-empty and not `placeholder`. A local `.env` with dummy dev values is enough to boot the server and play games. The `.env` is gitignored and NOT created by the update script — create it if missing. Required keys: `TURSO_DATABASE_URL=http://127.0.0.1:8080`, `TURSO_AUTH_TOKEN=<any-non-empty>`, `BETTER_AUTH_SECRET`, `BETTER_AUTH_URL=http://localhost:4325`, `GOOGLE_CLIENT_ID`, `GOOGLE_CLIENT_SECRET`.
+- **Auth is Google-only**: Login cannot be completed without REAL Google OAuth credentials. Games are playable without logging in; scores/achievements only persist when authenticated. Dummy OAuth values only let the server boot, not sign in.
+- **Local DB**: `bun run db:dev` (or `bun run dev`) runs `turso dev --db-file ./db/db.sqlite`, an HTTP libSQL server on `http://127.0.0.1:8080`. Because the URL is not a `file:` URL, `TURSO_AUTH_TOKEN` must be set to any non-empty value (the local server ignores it).
+- **Fresh DB schema**: A brand-new `./db/db.sqlite` has no tables. Load base + game tables with `turso db shell http://127.0.0.1:8080 < better-auth_migrations/2025-07-04T06-35-06.738Z.sql` then `... < better-auth_migrations/2025-07-06-schema-consolidation.sql`. Some columns/tables (`user_stats` extra columns, `daily_challenge_progress`) are applied lazily at runtime by `src/lib/server/db/queries.ts`.
+- **Running services**: DB and web are separate persistent processes. Prefer running them in separate tmux sessions (`bun run db:dev` and `bun run web:dev`) rather than `bun run dev` (Turbo TUI) when you need to scrape logs. Web dev server is at `http://localhost:4325`.
+- **Verifying without a browser**: `curl -s "http://localhost:4325/api/leaderboard?gameId=snake"` exercises the full web→DB path and returns JSON when everything is wired up.
+- Standard lint/test/build/run commands are documented in `CLAUDE.md` under "Development Commands"; use `bun run <script>`.

--- a/CLAUDE.md
+++ b/CLAUDE.md
@@ -329,3 +329,14 @@ All API routes follow Astro's file-based routing in `src/pages/api/`:
 
 **Development** (`/api/dev`):
 - `POST /api/dev/add-test-scores` - Add test data (dev only)
+
+## Cursor Cloud specific instructions
+
+- **Tooling on PATH**: `bun` and the `turso` CLI are installed by the startup update script (to `~/.bun/bin` and `~/.turso`) and added to `~/.bashrc`. Interactive/login shells (e.g. tmux `bash -l`) pick them up automatically. In a non-login shell you may need `export PATH="$HOME/.bun/bin:$HOME/.turso:$PATH"`.
+- **`.env` is required to boot**: `src/lib/auth.ts` throws at startup unless `BETTER_AUTH_SECRET` is set AND `GOOGLE_CLIENT_ID`/`GOOGLE_CLIENT_SECRET` are non-empty and not `placeholder`. A local `.env` with dummy dev values is enough to boot the server and play games. The `.env` is gitignored and NOT created by the update script — create it if missing. Required keys: `TURSO_DATABASE_URL=http://127.0.0.1:8080`, `TURSO_AUTH_TOKEN=<any-non-empty>`, `BETTER_AUTH_SECRET`, `BETTER_AUTH_URL=http://localhost:4325`, `GOOGLE_CLIENT_ID`, `GOOGLE_CLIENT_SECRET`.
+- **Auth is Google-only**: Login cannot be completed without REAL Google OAuth credentials. Games are playable without logging in; scores/achievements only persist when authenticated. Dummy OAuth values only let the server boot, not sign in.
+- **Local DB**: `bun run db:dev` (or `bun run dev`) runs `turso dev --db-file ./db/db.sqlite`, an HTTP libSQL server on `http://127.0.0.1:8080`. Because the URL is not a `file:` URL, `TURSO_AUTH_TOKEN` must be set to any non-empty value (the local server ignores it).
+- **Fresh DB schema**: A brand-new `./db/db.sqlite` has no tables. Load base + game tables with `turso db shell http://127.0.0.1:8080 < better-auth_migrations/2025-07-04T06-35-06.738Z.sql` then `... < better-auth_migrations/2025-07-06-schema-consolidation.sql`. Some columns/tables (`user_stats` extra columns, `daily_challenge_progress`) are applied lazily at runtime by `src/lib/server/db/queries.ts`.
+- **Running services**: DB and web are separate persistent processes. Prefer running them in separate tmux sessions (`bun run db:dev` and `bun run web:dev`) rather than `bun run dev` (Turbo TUI) when you need to scrape logs. Web dev server is at `http://localhost:4325`.
+- **Verifying without a browser**: `curl -s "http://localhost:4325/api/leaderboard?gameId=snake"` exercises the full web→DB path and returns JSON when everything is wired up.
+- Standard lint/test/build/run commands are documented above under "Development Commands"; use `bun run <script>`.

--- a/CLAUDE.md
+++ b/CLAUDE.md
@@ -329,14 +329,3 @@ All API routes follow Astro's file-based routing in `src/pages/api/`:
 
 **Development** (`/api/dev`):
 - `POST /api/dev/add-test-scores` - Add test data (dev only)
-
-## Cursor Cloud specific instructions
-
-- **Tooling on PATH**: `bun` and the `turso` CLI are installed by the startup update script (to `~/.bun/bin` and `~/.turso`) and added to `~/.bashrc`. Interactive/login shells (e.g. tmux `bash -l`) pick them up automatically. In a non-login shell you may need `export PATH="$HOME/.bun/bin:$HOME/.turso:$PATH"`.
-- **`.env` is required to boot**: `src/lib/auth.ts` throws at startup unless `BETTER_AUTH_SECRET` is set AND `GOOGLE_CLIENT_ID`/`GOOGLE_CLIENT_SECRET` are non-empty and not `placeholder`. A local `.env` with dummy dev values is enough to boot the server and play games. The `.env` is gitignored and NOT created by the update script — create it if missing. Required keys: `TURSO_DATABASE_URL=http://127.0.0.1:8080`, `TURSO_AUTH_TOKEN=<any-non-empty>`, `BETTER_AUTH_SECRET`, `BETTER_AUTH_URL=http://localhost:4325`, `GOOGLE_CLIENT_ID`, `GOOGLE_CLIENT_SECRET`.
-- **Auth is Google-only**: Login cannot be completed without REAL Google OAuth credentials. Games are playable without logging in; scores/achievements only persist when authenticated. Dummy OAuth values only let the server boot, not sign in.
-- **Local DB**: `bun run db:dev` (or `bun run dev`) runs `turso dev --db-file ./db/db.sqlite`, an HTTP libSQL server on `http://127.0.0.1:8080`. Because the URL is not a `file:` URL, `TURSO_AUTH_TOKEN` must be set to any non-empty value (the local server ignores it).
-- **Fresh DB schema**: A brand-new `./db/db.sqlite` has no tables. Load base + game tables with `turso db shell http://127.0.0.1:8080 < better-auth_migrations/2025-07-04T06-35-06.738Z.sql` then `... < better-auth_migrations/2025-07-06-schema-consolidation.sql`. Some columns/tables (`user_stats` extra columns, `daily_challenge_progress`) are applied lazily at runtime by `src/lib/server/db/queries.ts`.
-- **Running services**: DB and web are separate persistent processes. Prefer running them in separate tmux sessions (`bun run db:dev` and `bun run web:dev`) rather than `bun run dev` (Turbo TUI) when you need to scrape logs. Web dev server is at `http://localhost:4325`.
-- **Verifying without a browser**: `curl -s "http://localhost:4325/api/leaderboard?gameId=snake"` exercises the full web→DB path and returns JSON when everything is wired up.
-- Standard lint/test/build/run commands are documented above under "Development Commands"; use `bun run <script>`.


### PR DESCRIPTION
<!-- CURSOR_AGENT_PR_BODY_BEGIN -->
## Summary

Sets up the development environment for the Cetus gaming platform in Cursor Cloud and documents non-obvious startup caveats for future agents.

Setup guidance lives in a Cursor rule file at `.cursor/rules/cloud-dev-environment.mdc` (`alwaysApply: true`). All environment tooling is handled by the startup update script (installs `bun` + `turso` CLI, runs `bun install`); it is not committed to the repo.

## Environment details

- **Package manager**: Bun (`bun@1.3.1` per `packageManager`); installed `bun` and the `turso` CLI (both missing on the base image).
- **`.env`**: created locally with dummy dev values (gitignored). Required to boot because `src/lib/auth.ts` throws without `BETTER_AUTH_SECRET` + non-placeholder Google OAuth values.
- **DB**: `turso dev --db-file ./db/db.sqlite` (local libSQL HTTP server on `:8080`); schema loaded from `better-auth_migrations/*.sql`.

## Verified

| Step | Command | Result |
|------|---------|--------|
| Lint | `bun run lint` | 0 errors (warnings only) |
| Test | `bun run test:run` | 118 files, 2452 tests passed |
| Build | `bun run build` | Success |
| Run | `bun run db:dev` + `bun run web:dev` | Homepage/game pages 200; leaderboard API returns JSON |

## Hello-world

Played the 2048 game end-to-end in the browser: started the game, pressed arrow keys, tiles merged, score increased to 32.

[cetus_2048_gameplay_demo.mp4](https://cursor.com/agents/bc-03ad3d77-8ff9-4601-a73a-edfc0668ac06/artifacts?path=%2Fopt%2Fcursor%2Fartifacts%2Fcetus_2048_gameplay_demo.mp4)

[2048 gameplay with score 32](https://cursor.com/agents/bc-03ad3d77-8ff9-4601-a73a-edfc0668ac06/artifacts?path=%2Fopt%2Fcursor%2Fartifacts%2Fcetus_2048_score32.webp)

## Auth note

Login is Google-only and requires real Google OAuth credentials; games are playable without login (scores only persist when authenticated).

<sub>To show artifacts inline, <a href="https://cursor.com/dashboard/cloud-agents#my-pull-requests">enable</a> in settings.</sub>
<!-- CURSOR_AGENT_PR_BODY_END -->

<div><a href="https://cursor.com/agents/bc-03ad3d77-8ff9-4601-a73a-edfc0668ac06"><picture><source media="(prefers-color-scheme: dark)" srcset="https://cursor.com/assets/images/open-in-web-dark.png"><source media="(prefers-color-scheme: light)" srcset="https://cursor.com/assets/images/open-in-web-light.png"><img alt="Open in Web" width="114" height="28" src="https://cursor.com/assets/images/open-in-web-dark.png"></picture></a>&nbsp;<a href="https://cursor.com/background-agent?bcId=bc-03ad3d77-8ff9-4601-a73a-edfc0668ac06"><picture><source media="(prefers-color-scheme: dark)" srcset="https://cursor.com/assets/images/open-in-cursor-dark.png"><source media="(prefers-color-scheme: light)" srcset="https://cursor.com/assets/images/open-in-cursor-light.png"><img alt="Open in Cursor" width="131" height="28" src="https://cursor.com/assets/images/open-in-cursor-dark.png"></picture></a>&nbsp;</div>

