### PR TITLE
feat(scores): versioned score context and scoped leaderboards (HPA-484)

### DIFF
--- a/better-auth_migrations/2025-07-06-schema-consolidation.sql
+++ b/better-auth_migrations/2025-07-06-schema-consolidation.sql
@@ -46,6 +46,10 @@ CREATE TABLE IF NOT EXISTS "game_scores" (
     "user_id" TEXT NOT NULL REFERENCES "user" ("id") ON DELETE CASCADE,
     "game_id" TEXT NOT NULL,
     "score" INTEGER NOT NULL,
+    "mode" TEXT,
+    "competition_key" TEXT,
+    "ruleset_version" INTEGER,
+    "game_data_json" TEXT,
     "created_at" DATE NOT NULL DEFAULT CURRENT_TIMESTAMP
 );
 
@@ -61,4 +65,12 @@ CREATE TABLE IF NOT EXISTS "user_achievements" (
 -- Create indexes for better query performance
 CREATE INDEX IF NOT EXISTS "idx_game_scores_user_id" ON "game_scores" ("user_id");
 CREATE INDEX IF NOT EXISTS "idx_game_scores_game_id" ON "game_scores" ("game_id");
+CREATE INDEX IF NOT EXISTS "idx_game_scores_scoped_ranking"
+    ON "game_scores" (
+        "game_id",
+        "mode",
+        "competition_key",
+        "score" DESC,
+        "created_at" ASC
+    );
 CREATE INDEX IF NOT EXISTS "idx_user_achievements_user_id" ON "user_achievements" ("user_id");

--- a/docs/superpowers/plans/2026-07-31-versioned-score-context-and-scoped-leaderboards.md
+++ b/docs/superpowers/plans/2026-07-31-versioned-score-context-and-scoped-leaderboards.md
@@ -1485,11 +1485,12 @@ git commit -m "feat(scores): propagate contextual write failures"
 - Modify: `src/lib/server/db/queries.integration.test.ts`
 - Create: `src/lib/server/db/queries.score-context-read-failure.test.ts`
 - Modify: `src/lib/services/achievementService.test.ts`
+- Modify: `src/pages/api/leaderboard.ts`, `src/pages/leaderboard/index.astro` (narrow the new discriminated result)
 
 **Interfaces:**
 - Confirmed complete schema adds `mode IS NULL` and `competition_key IS NULL`.
 - Confirmed legacy/incomplete schema uses the existing no-predicate query.
-- Unknown capability without a cached snapshot returns `[]` for leaderboard and `null` for personal best.
+- Unknown capability without a cached snapshot returns a discriminated `unavailable` result (`{ status: 'unavailable', code: 'SCORE_CONTEXT_UNAVAILABLE' }`) from both `getGameLeaderboard` and `getUserBestScore`, distinct from a genuine empty result (`[]` / `null`). `getGameLeaderboard`'s return type becomes `GameLeaderboardResult = GameLeaderboardEntry[] | { status: 'unavailable'; code: 'SCORE_CONTEXT_UNAVAILABLE' }` with an `isGameLeaderboardAvailable` type guard.
 - `getUserBestScoreByGame` and `getUserBestScoreForGame` remain aliases/wrappers and inherit isolation.
 
 - [ ] **Step 1: Extend the integration fixture to the complete schema**
@@ -1576,6 +1577,8 @@ it('retains raw-attempt semantics for unscoped rows', async () => {
 })
 ```
 
+> **Type-narrowing note:** because `getGameLeaderboard` now returns a `GameLeaderboardResult` union, the integration tests narrow with a small `asEntries()` helper (throws if the result is the `unavailable` branch) before indexing or calling `.map()`. The assertions above express the intended behavior; the helper is the mechanism that satisfies TypeScript under the revised contract.
+
 Add an achievement-service test that mocks `getUserBestScore()` to an unscoped value and verifies progress remains derived from that value even when `earned` is true.
 
 - [ ] **Step 3: Write the unknown-capability fail-closed test**
@@ -1583,10 +1586,18 @@ Add an achievement-service test that mocks `getUserBestScore()` to an unscoped v
 Create `src/lib/server/db/queries.score-context-read-failure.test.ts`. Mock `game-score-context` to return `{ known: false }`, mock the database query chain, and assert:
 
 ```ts
-await expect(getGameLeaderboard('tetris', 10)).resolves.toEqual([])
-await expect(getUserBestScore('u1', 'tetris')).resolves.toBeNull()
+await expect(getGameLeaderboard('tetris', 10)).resolves.toEqual({
+    status: 'unavailable',
+    code: 'SCORE_CONTEXT_UNAVAILABLE',
+})
+await expect(getUserBestScore('u1', 'tetris')).resolves.toEqual({
+    status: 'unavailable',
+    code: 'SCORE_CONTEXT_UNAVAILABLE',
+})
 expect(mockSelectFrom).not.toHaveBeenCalled()
 ```
+
+> **Design note (post-spec revision):** the original plan called for `getGameLeaderboard` to return `[]` on a failed probe and `getUserBestScore` to return `null`. The implemented contract instead surfaces a discriminated `unavailable` result from both functions (and `getScopedGameLeaderboard` already did via `{ success: false, code: 'SCOPED_LEADERBOARD_UNAVAILABLE' }`), so callers can emit a coded 503 distinct from a genuine empty result. See spec §9 and §10.1 for the revised contract.
 
 - [ ] **Step 4: Run tests to verify they fail**
 
@@ -1615,20 +1626,20 @@ async function getConfirmedScoreContextCapabilities():
 ```
 
 Interpret:
-- `undefined`: unknown probe; return the existing defensive result.
+- `undefined`: unknown probe; return the discriminated `unavailable` result.
 - complete columns: add both unscoped predicates.
 - known incomplete columns: use the legacy no-predicate query.
 
-In both `getGameLeaderboard()` and `getUserBestScore()`:
+In `getUserBestScore()`:
 
 ```ts
 const capabilities = await getConfirmedScoreContextCapabilities()
 if (capabilities === undefined) {
-    return []
+    return { status: 'unavailable', code: 'SCORE_CONTEXT_UNAVAILABLE' }
 }
 ```
 
-Use `return null` in `getUserBestScore()`.
+In `getGameLeaderboard()`, return the same discriminated `unavailable` result (its return type is `GameLeaderboardResult = GameLeaderboardEntry[] | { status: 'unavailable'; code: 'SCORE_CONTEXT_UNAVAILABLE' }`). Export `GameLeaderboardEntry`, `GameLeaderboardResult`, and an `isGameLeaderboardAvailable` type guard so callers can narrow. Query-execution errors in the catch block still swallow to `[]` to preserve graceful degradation for transient read failures.
 
 After building the existing query, conditionally add:
 
@@ -1641,6 +1652,8 @@ if (hasCompleteGameScoresContextColumns(capabilities)) {
 ```
 
 For `getUserBestScore()`, use unqualified column names matching its single-table query.
+
+Callers (`/api/leaderboard`, `src/pages/leaderboard/index.astro`) must narrow with `isGameLeaderboardAvailable`: the API emits a coded 503 on the `unavailable` branch (both the single-game and all-games branches); the SSR page degrades to its existing empty state rather than failing the render.
 
 - [ ] **Step 6: Run focused tests**
 
@@ -2495,10 +2508,13 @@ vi.mock('@/lib/server/db/queries', () => ({
     toPublicScopedLeaderboardEntry: vi.fn(
         ({ userId: _userId, ...entry }) => entry
     ),
+    // The endpoint narrows with this type guard; provide it so the mock
+    // matches the real module surface.
+    isGameLeaderboardAvailable: (result: unknown) => Array.isArray(result),
 }))
 ```
 
-Import all three functions and add:
+Import all four symbols and add:
 
 ```ts
 it('returns a mode-only scoped best-per-user leaderboard', async () => {

--- a/docs/superpowers/plans/2026-07-31-versioned-score-context-and-scoped-leaderboards.md
+++ b/docs/superpowers/plans/2026-07-31-versioned-score-context-and-scoped-leaderboards.md
@@ -3063,7 +3063,13 @@ bun run format:check
 bun run build
 ```
 
-Expected: every command exits `0`.
+Expected:
+- `bun run lint`, `bun run format:check`, and `bun run build` must each exit `0`.
+- `bun run typecheck` has three known pre-existing errors in `src/lib/games/ice-slide/*` that are unrelated to this work and predate this branch:
+  1. `src/lib/games/ice-slide/game.crystal-farm.test.ts:3:1` — `Cannot find name 'vi'` (missing Vitest import).
+  2. `src/lib/games/ice-slide/init.test.ts:36:64` — `A spread argument must either have a tuple type or be passed to a rest parameter`.
+  3. `src/lib/games/ice-slide/init.ts:178:21` — `The left-hand side of an 'instanceof' expression must be of type 'any', an object type or a type parameter`.
+- This work must introduce **no additional** typecheck errors beyond those three baseline failures. Either leave the three baseline failures in place (they are out of scope) or fix them within this scope, but do not add new ones. Record the exact `bun run typecheck` error count before and after the work to confirm the delta is zero.
 
 - [ ] **Step 4: Inspect the final diff**
 

--- a/docs/superpowers/plans/2026-07-31-versioned-score-context-and-scoped-leaderboards.md
+++ b/docs/superpowers/plans/2026-07-31-versioned-score-context-and-scoped-leaderboards.md
@@ -1,0 +1,3125 @@
+# Versioned Score Context and Scoped Leaderboards Implementation Plan
+
+> **For agentic workers:** REQUIRED SUB-SKILL: Use superpowers:subagent-driven-development (recommended) or superpowers:executing-plans to implement this plan task-by-task. Steps use checkbox (`- [ ]`) syntax for tracking.
+
+**Goal:** Add backward-compatible, versioned score persistence and deterministic scoped leaderboards without changing existing Campaign score, history, achievement-awarding, aggregate-stat, or daily-challenge behavior.
+
+**Architecture:** Add nullable score-context columns to `game_scores`, guarded by a cached, retryable LibSQL capability layer. Keep one score write function and one achievement pipeline, return discriminated failures through the server and client, preserve existing unscoped raw-attempt queries, and add a separate staged-CTE/window query for scoped best-per-user results. Public APIs map explicit DTOs so internal context, stored JSON, and raw authentication IDs never leak.
+
+**Tech Stack:** Astro 5, TypeScript 6, Bun 1.3.1, Kysely 0.28, LibSQL/Turso, Zod 4, Vitest 3.
+
+## Global Constraints
+
+- Execute implementation on a new isolated worktree/branch from the latest `main` after documentation PR #50 is merged. Do not add runtime implementation commits to the documentation PR.
+- Package manager is **Bun** (`bun@1.3.1`).
+- Do not add dependencies.
+- Context columns are nullable: `mode`, `competition_key`, `ruleset_version`, `game_data_json`.
+- Scoped filtering index is exactly `(game_id, mode, competition_key, score DESC, created_at ASC)`.
+- Context is omit-only. Omitted context means legacy; `context: null` returns `400`.
+- Fully anchored identifiers:
+  - mode: `^[a-z][a-z0-9_-]*$`, 1–32 characters;
+  - competition key: `^[A-Za-z0-9:._-]+$`, 1–128 characters.
+- `rulesetVersion` is required for contextual writes, integer `1..2_147_483_647`, and non-null in scoped public output.
+- Contextual `gameData` is at most 16 KiB by UTF-8 byte length. Legacy transient `gameData` does not receive this new limit.
+- V1 projected tie-break keys are only `elapsedSeconds` and `totalMoves`.
+  - `elapsedSeconds` is a non-negative integer count of floored whole seconds.
+  - `totalMoves` is a non-negative integer count.
+  - Submitted fractions or negative values return `400`.
+  - Malformed historical/external values normalize to `NULL`.
+- Existing unscoped leaderboards remain raw-attempt lists. Scoped leaderboards return one best row per user.
+- Existing personal-best and best-score-derived achievement progress use only unscoped rows.
+- Scoped submissions still run score-threshold and in-game achievement awarding against the submitted score and `gameData`.
+- Scoped submissions still update total score, game-count/favorite-game side effects, history/activity, and current daily challenges.
+- Public APIs must never expose `game_data_json`, raw `user_id`, or widened internal `GameScore` rows.
+- Public scoped timestamps remain `created_at`.
+- Missing contextual write capability returns HTTP `500` with code `SCORE_CONTEXT_UNAVAILABLE`.
+- Scoped leaderboard capability/query failure returns HTTP `500` with code `SCOPED_LEADERBOARD_UNAVAILABLE`.
+- Unknown capability state must fail closed to each legacy query’s existing defensive result; never run an unfiltered query that might mix scoped rows.
+- Performance-only index creation retries use process-local exponential backoff from one minute to one hour.
+- HPA-487/HPA-488 own Ice Slide generation, semantic admission, current-user highlighting, and UI.
+- Full verification commands:
+  - `bun run test:run`
+  - `bun run lint`
+  - `bun run typecheck`
+  - `bun run build`
+
+## File Structure
+
+**Create**
+
+- `src/lib/server/db/game-score-context.ts` — context types, discriminated write/result codes, schema capability cache, migration, and index retry backoff.
+- `src/lib/server/db/game-score-schema-files.test.ts` — executes the extracted `game_scores` DDL from both checked-in schema sources.
+- `src/lib/server/db/game-score-context.migrations.test.ts` — real-LibSQL fresh, legacy, partial, idempotent, concurrent, and unknown-probe behavior.
+- `src/lib/server/db/game-score-context.index-retry.test.ts` — real-LibSQL performance-index retry/backoff behavior.
+- `src/lib/server/db/scoped-leaderboard.ts` — staged JSON normalization, window ranking, internal row/result types, and public DTO mapping.
+- `src/lib/server/db/scoped-leaderboard.integration.test.ts` — real-LibSQL scoped ranking and malformed-data coverage.
+
+**Modify**
+
+- `scripts/init-db.sql`
+- `better-auth_migrations/2025-07-06-schema-consolidation.sql`
+- `src/lib/server/db/types.ts`
+- `src/lib/server/db/queries.ts`
+- `src/lib/server/db/queries.integration.test.ts`
+- `src/lib/server/db/queries.test.ts`
+- `src/lib/server/validations.ts`
+- `src/lib/server/validations.test.ts`
+- `src/lib/server/api-utils.ts`
+- `src/lib/services/scoreService.ts`
+- `src/lib/services/scoreService.test.ts`
+- `src/pages/api/scores.ts`
+- `src/pages/api/scores.test.ts`
+- `src/pages/api/leaderboard.ts`
+- `src/pages/api/leaderboard.test.ts`
+- `src/pages/api/scores/history.test.ts`
+- `src/lib/services/achievementService.test.ts`
+
+---
+
+### Task 1: Add the persistent schema and Kysely insert types
+
+**Files:**
+- Modify: `scripts/init-db.sql:9-20, indexes section`
+- Modify: `better-auth_migrations/2025-07-06-schema-consolidation.sql:44-55, indexes section`
+- Modify: `src/lib/server/db/types.ts:1, GameScoresTable, NewGameScore`
+- Create: `src/lib/server/db/game-score-schema-files.test.ts`
+
+**Interfaces:**
+- Produces: nullable `mode`, `competition_key`, `ruleset_version`, and `game_data_json` columns.
+- Produces: `idx_game_scores_scoped_ranking`.
+- Produces: `NewGameScore = Insertable<GameScoresTable>` so legacy inserts may omit nullable context columns while contextual inserts may supply them.
+
+- [ ] **Step 1: Write the failing schema-file test**
+
+Create `src/lib/server/db/game-score-schema-files.test.ts`:
+
+```ts
+import { readFile } from 'node:fs/promises'
+import { resolve } from 'node:path'
+import { createClient } from '@libsql/client'
+import { describe, expect, it } from 'vitest'
+
+const schemaFiles = [
+    'scripts/init-db.sql',
+    'better-auth_migrations/2025-07-06-schema-consolidation.sql',
+] as const
+
+function extractGameScoresDdl(source: string): string {
+    const table = source.match(
+        /CREATE TABLE IF NOT EXISTS\s+"?game_scores"?\s*\([\s\S]*?\n\);/i
+    )?.[0]
+    const index = source.match(
+        /CREATE INDEX IF NOT EXISTS\s+"?idx_game_scores_scoped_ranking"?[\s\S]*?;/i
+    )?.[0]
+
+    if (!table || !index) {
+        throw new Error('game_scores table or scoped index DDL is missing')
+    }
+
+    return `${table}\n${index}`
+}
+
+describe.each(schemaFiles)('%s', schemaPath => {
+    it('creates the complete contextual score schema', async () => {
+        const source = await readFile(resolve(process.cwd(), schemaPath), 'utf8')
+        const client = createClient({ url: ':memory:' })
+
+        await client.executeMultiple(extractGameScoresDdl(source))
+
+        const columns = await client.execute('PRAGMA table_info(game_scores)')
+        expect(columns.rows.map(row => String(row.name))).toEqual(
+            expect.arrayContaining([
+                'id',
+                'user_id',
+                'game_id',
+                'score',
+                'mode',
+                'competition_key',
+                'ruleset_version',
+                'game_data_json',
+                'created_at',
+            ])
+        )
+
+        const index = await client.execute(
+            'PRAGMA index_info(idx_game_scores_scoped_ranking)'
+        )
+        expect(index.rows.map(row => String(row.name))).toEqual([
+            'game_id',
+            'mode',
+            'competition_key',
+            'score',
+            'created_at',
+        ])
+
+        client.close()
+    })
+})
+```
+
+- [ ] **Step 2: Run the test to verify it fails**
+
+Run:
+
+```bash
+bun run test:run src/lib/server/db/game-score-schema-files.test.ts
+```
+
+Expected: FAIL because neither schema file declares the four columns or the scoped index. The `scripts/init-db.sql` extraction may also expose its existing trailing-comma table syntax; fix that within this task.
+
+- [ ] **Step 3: Replace the `game_scores` block in `scripts/init-db.sql`**
+
+Use:
+
+```sql
+CREATE TABLE IF NOT EXISTS game_scores (
+    id INTEGER PRIMARY KEY AUTOINCREMENT,
+    user_id TEXT NOT NULL,
+    game_id TEXT NOT NULL,
+    score INTEGER NOT NULL,
+    mode TEXT,
+    competition_key TEXT,
+    ruleset_version INTEGER,
+    game_data_json TEXT,
+    created_at DATETIME DEFAULT CURRENT_TIMESTAMP,
+    FOREIGN KEY (user_id) REFERENCES user(id) ON DELETE CASCADE
+);
+```
+
+Add with the existing score indexes:
+
+```sql
+CREATE INDEX IF NOT EXISTS idx_game_scores_scoped_ranking
+    ON game_scores(
+        game_id,
+        mode,
+        competition_key,
+        score DESC,
+        created_at ASC
+    );
+```
+
+- [ ] **Step 4: Replace the `game_scores` block in the consolidated migration**
+
+Use:
+
+```sql
+CREATE TABLE IF NOT EXISTS "game_scores" (
+    "id" INTEGER PRIMARY KEY AUTOINCREMENT,
+    "user_id" TEXT NOT NULL REFERENCES "user" ("id") ON DELETE CASCADE,
+    "game_id" TEXT NOT NULL,
+    "score" INTEGER NOT NULL,
+    "mode" TEXT,
+    "competition_key" TEXT,
+    "ruleset_version" INTEGER,
+    "game_data_json" TEXT,
+    "created_at" DATE NOT NULL DEFAULT CURRENT_TIMESTAMP
+);
+```
+
+Add with its existing indexes:
+
+```sql
+CREATE INDEX IF NOT EXISTS "idx_game_scores_scoped_ranking"
+    ON "game_scores" (
+        "game_id",
+        "mode",
+        "competition_key",
+        "score" DESC,
+        "created_at" ASC
+    );
+```
+
+- [ ] **Step 5: Update the Kysely table and insert type**
+
+In `src/lib/server/db/types.ts`, change the import:
+
+```ts
+import type { ColumnType, Insertable, Selectable } from 'kysely'
+```
+
+Replace `GameScoresTable` with:
+
+```ts
+export interface GameScoresTable {
+    id: ColumnType<number, never, never>
+    user_id: string
+    game_id: string
+    score: number
+    mode: ColumnType<
+        string | null,
+        string | null | undefined,
+        string | null
+    >
+    competition_key: ColumnType<
+        string | null,
+        string | null | undefined,
+        string | null
+    >
+    ruleset_version: ColumnType<
+        number | null,
+        number | null | undefined,
+        number | null
+    >
+    game_data_json: ColumnType<
+        string | null,
+        string | null | undefined,
+        string | null
+    >
+    created_at: ColumnType<Date, never, never>
+}
+```
+
+Replace:
+
+```ts
+export type NewGameScore = Omit<GameScoresTable, 'id' | 'created_at'>
+```
+
+with:
+
+```ts
+export type NewGameScore = Insertable<GameScoresTable>
+```
+
+- [ ] **Step 6: Run focused tests**
+
+Run:
+
+```bash
+bun run test:run src/lib/server/db/game-score-schema-files.test.ts
+bun run typecheck
+```
+
+Expected: both commands exit `0`.
+
+- [ ] **Step 7: Commit**
+
+```bash
+git add scripts/init-db.sql \
+  better-auth_migrations/2025-07-06-schema-consolidation.sql \
+  src/lib/server/db/types.ts \
+  src/lib/server/db/game-score-schema-files.test.ts
+git commit -m "feat(scores): add versioned score context schema"
+```
+
+---
+
+### Task 2: Add the cached runtime capability guard and bounded index retry
+
+**Files:**
+- Create: `src/lib/server/db/game-score-context.ts`
+- Create: `src/lib/server/db/game-score-context.migrations.test.ts`
+- Create: `src/lib/server/db/game-score-context.index-retry.test.ts`
+
+**Interfaces:**
+- Produces: `ensureGameScoresContextSchema(): Promise<GameScoresContextState>`.
+- Produces: `getCachedGameScoresContextState(): GameScoresContextState | null`.
+- Produces: `hasCompleteGameScoresContextColumns(capabilities): boolean`.
+- Produces shared DB contracts: `PersistedScoreContext`, `SaveGameScoreResult`, and `SaveGameScoreWithAchievementsResult`.
+- `GameScoresContextState` is `{ known: true; capabilities }` or `{ known: false }`.
+
+- [ ] **Step 1: Write the migration behavior test**
+
+Create `src/lib/server/db/game-score-context.migrations.test.ts` with an in-memory Kysely database and one test that exercises the first-call single flight before module state is cached:
+
+```ts
+import { beforeAll, describe, expect, it, vi } from 'vitest'
+import { sql } from 'kysely'
+
+vi.mock('@/lib/server/db/client', async () => {
+    const { Kysely } = await import('kysely')
+    const { LibsqlDialect, libsql } = await import('@libsql/kysely-libsql')
+    const client = libsql.createClient({ url: ':memory:' })
+    const dialect = new LibsqlDialect({ client })
+    return { db: new Kysely({ dialect }), dialect }
+})
+
+import { db } from '@/lib/server/db/client'
+import {
+    ensureGameScoresContextSchema,
+    getCachedGameScoresContextState,
+    hasCompleteGameScoresContextColumns,
+} from './game-score-context'
+
+beforeAll(async () => {
+    await sql`
+        CREATE TABLE game_scores (
+            id INTEGER PRIMARY KEY AUTOINCREMENT,
+            user_id TEXT NOT NULL,
+            game_id TEXT NOT NULL,
+            score INTEGER NOT NULL,
+            created_at TEXT DEFAULT CURRENT_TIMESTAMP
+        )
+    `.execute(db)
+
+    await sql`
+        INSERT INTO game_scores (user_id, game_id, score)
+        VALUES ('u1', 'tetris', 123)
+    `.execute(db)
+})
+
+describe('ensureGameScoresContextSchema', () => {
+    it('single-flights migration, preserves rows, and caches complete capability', async () => {
+        const executeSpy = vi.spyOn(db, 'executeQuery')
+
+        const states = await Promise.all([
+            ensureGameScoresContextSchema(),
+            ensureGameScoresContextSchema(),
+            ensureGameScoresContextSchema(),
+        ])
+
+        expect(states.every(state => state.known)).toBe(true)
+        const state = states[0]
+        if (!state.known) throw new Error('expected known state')
+
+        expect(hasCompleteGameScoresContextColumns(state.capabilities)).toBe(true)
+        expect(state.capabilities.scopedIndex).toBe(true)
+        expect(getCachedGameScoresContextState()).toEqual(state)
+
+        const tableInfoCalls = executeSpy.mock.calls.filter(([query]) =>
+            query.sql.includes('PRAGMA table_info(game_scores)')
+        )
+        expect(tableInfoCalls).toHaveLength(2)
+
+        const columns =
+            await sql<{ name: string }>`PRAGMA table_info(game_scores)`.execute(
+                db
+            )
+        expect(columns.rows.map(row => row.name)).toEqual(
+            expect.arrayContaining([
+                'mode',
+                'competition_key',
+                'ruleset_version',
+                'game_data_json',
+            ])
+        )
+
+        const rows = await sql<{
+            score: number
+            mode: string | null
+        }>`SELECT score, mode FROM game_scores`.execute(db)
+        expect(rows.rows).toEqual([{ score: 123, mode: null }])
+    })
+})
+```
+
+The two `PRAGMA table_info` calls are the expected inspect-before/inspect-after cycle for one migration run. Three concurrent callers must not multiply that count.
+
+- [ ] **Step 2: Write the index backoff test**
+
+Create `src/lib/server/db/game-score-context.index-retry.test.ts`. Build a table with all four context columns, create a table named `idx_game_scores_scoped_ranking` to force the index DDL to fail, and use fake time:
+
+```ts
+import { beforeAll, describe, expect, it, vi } from 'vitest'
+import { sql } from 'kysely'
+
+vi.mock('@/lib/server/db/client', async () => {
+    const { Kysely } = await import('kysely')
+    const { LibsqlDialect, libsql } = await import('@libsql/kysely-libsql')
+    const client = libsql.createClient({ url: ':memory:' })
+    const dialect = new LibsqlDialect({ client })
+    return { db: new Kysely({ dialect }), dialect }
+})
+
+import { db } from '@/lib/server/db/client'
+import { ensureGameScoresContextSchema } from './game-score-context'
+
+beforeAll(async () => {
+    vi.useFakeTimers()
+    vi.setSystemTime(new Date('2026-08-01T00:00:00Z'))
+
+    await sql`
+        CREATE TABLE game_scores (
+            id INTEGER PRIMARY KEY AUTOINCREMENT,
+            user_id TEXT NOT NULL,
+            game_id TEXT NOT NULL,
+            score INTEGER NOT NULL,
+            mode TEXT,
+            competition_key TEXT,
+            ruleset_version INTEGER,
+            game_data_json TEXT,
+            created_at TEXT DEFAULT CURRENT_TIMESTAMP
+        )
+    `.execute(db)
+
+    await sql`
+        CREATE TABLE idx_game_scores_scoped_ranking (id INTEGER)
+    `.execute(db)
+})
+
+describe('score-context index retry backoff', () => {
+    it('skips hot-path retries inside the delay and succeeds after one minute', async () => {
+        const executeSpy = vi.spyOn(db, 'executeQuery')
+
+        const first = await ensureGameScoresContextSchema()
+        expect(first.known && first.capabilities.scopedIndex).toBe(false)
+
+        executeSpy.mockClear()
+        await ensureGameScoresContextSchema()
+        expect(
+            executeSpy.mock.calls.some(([query]) =>
+                query.sql.includes('CREATE INDEX')
+            )
+        ).toBe(false)
+
+        await sql`DROP TABLE idx_game_scores_scoped_ranking`.execute(db)
+        vi.advanceTimersByTime(60_000)
+
+        const recovered = await ensureGameScoresContextSchema()
+        expect(recovered.known).toBe(true)
+        if (!recovered.known) throw new Error('expected known state')
+        expect(recovered.capabilities.scopedIndex).toBe(true)
+    })
+})
+```
+
+- [ ] **Step 3: Run both tests to verify they fail**
+
+```bash
+bun run test:run \
+  src/lib/server/db/game-score-context.migrations.test.ts \
+  src/lib/server/db/game-score-context.index-retry.test.ts
+```
+
+Expected: FAIL because `game-score-context.ts` does not exist.
+
+- [ ] **Step 4: Implement the context contracts and capability state**
+
+Create `src/lib/server/db/game-score-context.ts` with these exported contracts:
+
+```ts
+import { sql } from 'kysely'
+import { db } from './client'
+
+export interface PersistedScoreContext {
+    mode: string
+    competitionKey: string | null
+    rulesetVersion: number
+    gameDataJson: string | null
+}
+
+export type SaveGameScoreFailureCode =
+    | 'SCORE_CONTEXT_UNAVAILABLE'
+    | 'SCORE_WRITE_FAILED'
+
+export type SaveGameScoreResult =
+    | { success: true }
+    | { success: false; code: SaveGameScoreFailureCode }
+
+export type SaveGameScoreWithAchievementsResult =
+    | { success: true; newAchievements: string[] }
+    | {
+          success: false
+          newAchievements: []
+          code: SaveGameScoreFailureCode
+      }
+
+export interface GameScoresContextCapabilities {
+    mode: boolean
+    competitionKey: boolean
+    rulesetVersion: boolean
+    gameDataJson: boolean
+    scopedIndex: boolean
+}
+
+export type GameScoresContextState =
+    | {
+          known: true
+          capabilities: GameScoresContextCapabilities
+      }
+    | { known: false }
+
+const INDEX_NAME = 'idx_game_scores_scoped_ranking'
+const INDEX_RETRY_MIN_MS = 60_000
+const INDEX_RETRY_MAX_MS = 3_600_000
+
+let cachedState: GameScoresContextState | null = null
+let schemaPromise: Promise<GameScoresContextState> | null = null
+let indexRetryDelayMs = INDEX_RETRY_MIN_MS
+let nextIndexRetryAt = 0
+
+export function hasCompleteGameScoresContextColumns(
+    capabilities: GameScoresContextCapabilities
+): boolean {
+    return (
+        capabilities.mode &&
+        capabilities.competitionKey &&
+        capabilities.rulesetVersion &&
+        capabilities.gameDataJson
+    )
+}
+
+export function getCachedGameScoresContextState():
+    | GameScoresContextState
+    | null {
+    return cachedState
+}
+```
+
+- [ ] **Step 5: Implement inspection, additive migration, and backoff**
+
+Add these private helpers and the exported ensure function in the same file:
+
+```ts
+async function inspectCapabilities(): Promise<GameScoresContextCapabilities> {
+    const columns =
+        await sql<{ name: string }>`PRAGMA table_info(game_scores)`.execute(db)
+    const names = new Set(columns.rows.map(row => row.name))
+
+    const indexes = await sql<{ name: string }>`
+        SELECT name
+        FROM sqlite_master
+        WHERE type = 'index' AND tbl_name = 'game_scores'
+    `.execute(db)
+
+    return {
+        mode: names.has('mode'),
+        competitionKey: names.has('competition_key'),
+        rulesetVersion: names.has('ruleset_version'),
+        gameDataJson: names.has('game_data_json'),
+        scopedIndex: indexes.rows.some(row => row.name === INDEX_NAME),
+    }
+}
+
+async function addMissingColumns(
+    capabilities: GameScoresContextCapabilities
+): Promise<void> {
+    if (!capabilities.mode) {
+        await sql`ALTER TABLE game_scores ADD COLUMN mode TEXT`.execute(db)
+    }
+    if (!capabilities.competitionKey) {
+        await sql`
+            ALTER TABLE game_scores ADD COLUMN competition_key TEXT
+        `.execute(db)
+    }
+    if (!capabilities.rulesetVersion) {
+        await sql`
+            ALTER TABLE game_scores ADD COLUMN ruleset_version INTEGER
+        `.execute(db)
+    }
+    if (!capabilities.gameDataJson) {
+        await sql`
+            ALTER TABLE game_scores ADD COLUMN game_data_json TEXT
+        `.execute(db)
+    }
+}
+
+async function createScopedIndexIfDue(
+    capabilities: GameScoresContextCapabilities
+): Promise<GameScoresContextCapabilities> {
+    if (
+        !hasCompleteGameScoresContextColumns(capabilities) ||
+        capabilities.scopedIndex ||
+        Date.now() < nextIndexRetryAt
+    ) {
+        return capabilities
+    }
+
+    try {
+        await sql`
+            CREATE INDEX IF NOT EXISTS idx_game_scores_scoped_ranking
+            ON game_scores (
+                game_id,
+                mode,
+                competition_key,
+                score DESC,
+                created_at ASC
+            )
+        `.execute(db)
+
+        indexRetryDelayMs = INDEX_RETRY_MIN_MS
+        nextIndexRetryAt = 0
+        return { ...capabilities, scopedIndex: true }
+    } catch (error) {
+        console.warn('[game-score-context] index creation failed:', error)
+        nextIndexRetryAt = Date.now() + indexRetryDelayMs
+        indexRetryDelayMs = Math.min(
+            indexRetryDelayMs * 2,
+            INDEX_RETRY_MAX_MS
+        )
+        return capabilities
+    }
+}
+
+async function inspectAndMigrate(): Promise<GameScoresContextState> {
+    try {
+        let capabilities = await inspectCapabilities()
+        cachedState = { known: true, capabilities }
+
+        if (!hasCompleteGameScoresContextColumns(capabilities)) {
+            await addMissingColumns(capabilities)
+            capabilities = await inspectCapabilities()
+            cachedState = { known: true, capabilities }
+        }
+
+        capabilities = await createScopedIndexIfDue(capabilities)
+        cachedState = { known: true, capabilities }
+        return cachedState
+    } catch (error) {
+        console.warn('[game-score-context] capability probe failed:', error)
+        return cachedState ?? { known: false }
+    }
+}
+
+export function ensureGameScoresContextSchema(): Promise<GameScoresContextState> {
+    const cachedCapabilities =
+        cachedState?.known === true ? cachedState.capabilities : null
+
+    if (
+        cachedCapabilities &&
+        hasCompleteGameScoresContextColumns(cachedCapabilities) &&
+        (cachedCapabilities.scopedIndex || Date.now() < nextIndexRetryAt)
+    ) {
+        return Promise.resolve(cachedState as GameScoresContextState)
+    }
+
+    if (!schemaPromise) {
+        schemaPromise = inspectAndMigrate().finally(() => {
+            schemaPromise = null
+        })
+    }
+
+    return schemaPromise
+}
+```
+
+- [ ] **Step 6: Run focused migration tests**
+
+```bash
+bun run test:run \
+  src/lib/server/db/game-score-context.migrations.test.ts \
+  src/lib/server/db/game-score-context.index-retry.test.ts
+```
+
+Expected: PASS.
+
+- [ ] **Step 7: Commit**
+
+```bash
+git add src/lib/server/db/game-score-context.ts \
+  src/lib/server/db/game-score-context.migrations.test.ts \
+  src/lib/server/db/game-score-context.index-retry.test.ts
+git commit -m "feat(scores): add score-context capability guard"
+```
+
+---
+
+### Task 3: Add strict contextual validation and client context forwarding
+
+**Files:**
+- Modify: `src/lib/server/validations.ts`
+- Modify: `src/lib/server/validations.test.ts`
+- Modify: `src/lib/services/scoreService.ts`
+- Modify: `src/lib/services/scoreService.test.ts`
+
+**Interfaces:**
+- Produces: `ScoreSubmissionContext`.
+- Produces: omit-only `context` in `scoreSubmissionSchema`.
+- Produces: `SaveScoreOptions.context`.
+- Contextual requests validate UTF-8 bytes and allowlisted integer metrics before any database call.
+
+- [ ] **Step 1: Add failing validation tests**
+
+Add to `src/lib/server/validations.test.ts`:
+
+```ts
+describe('scoreSubmissionSchema context', () => {
+    const base = { gameId: GameID.TETRIS, score: 100 }
+
+    it('accepts omitted context and rejects null context', () => {
+        expect(scoreSubmissionSchema.safeParse(base).success).toBe(true)
+        expect(
+            scoreSubmissionSchema.safeParse({ ...base, context: null }).success
+        ).toBe(false)
+    })
+
+    it('uses fully anchored mode and competition-key patterns', () => {
+        const valid = {
+            ...base,
+            context: {
+                mode: 'daily',
+                competitionKey: 'ice-slide:daily:2026-08-01:g1:r1',
+                rulesetVersion: 1,
+            },
+        }
+        expect(scoreSubmissionSchema.safeParse(valid).success).toBe(true)
+
+        expect(
+            scoreSubmissionSchema.safeParse({
+                ...valid,
+                context: { ...valid.context, mode: 'daily!' },
+            }).success
+        ).toBe(false)
+
+        expect(
+            scoreSubmissionSchema.safeParse({
+                ...valid,
+                context: {
+                    ...valid.context,
+                    competitionKey: 'ok#invalid',
+                },
+            }).success
+        ).toBe(false)
+    })
+
+    it('accepts oversized legacy gameData but rejects oversized contextual data', () => {
+        const gameData = { payload: 'x'.repeat(17 * 1024) }
+
+        expect(
+            scoreSubmissionSchema.safeParse({ ...base, gameData }).success
+        ).toBe(true)
+
+        expect(
+            scoreSubmissionSchema.safeParse({
+                ...base,
+                gameData,
+                context: { mode: 'daily', rulesetVersion: 1 },
+            }).success
+        ).toBe(false)
+    })
+
+    it('measures contextual data in UTF-8 bytes', () => {
+        const gameData = { payload: '界'.repeat(6_000) }
+
+        expect(
+            scoreSubmissionSchema.safeParse({
+                ...base,
+                gameData,
+                context: { mode: 'daily', rulesetVersion: 1 },
+            }).success
+        ).toBe(false)
+    })
+
+    it.each([
+        { elapsedSeconds: 12.5 },
+        { elapsedSeconds: -1 },
+        { totalMoves: 4.5 },
+        { totalMoves: -1 },
+    ])('rejects invalid allowlisted metrics: %o', metric => {
+        expect(
+            scoreSubmissionSchema.safeParse({
+                ...base,
+                gameData: metric,
+                context: { mode: 'daily', rulesetVersion: 1 },
+            }).success
+        ).toBe(false)
+    })
+
+    it('accepts whole-second elapsed time and integer moves', () => {
+        expect(
+            scoreSubmissionSchema.safeParse({
+                ...base,
+                gameData: { elapsedSeconds: 12, totalMoves: 34 },
+                context: { mode: 'daily', rulesetVersion: 1 },
+            }).success
+        ).toBe(true)
+    })
+})
+```
+
+- [ ] **Step 2: Add failing client forwarding tests**
+
+Add to `src/lib/services/scoreService.test.ts`:
+
+```ts
+it('forwards context through SaveScoreOptions without a new positional argument', async () => {
+    global.fetch = vi.fn().mockResolvedValue({
+        ok: true,
+        json: () => Promise.resolve({ success: true }),
+    })
+
+    await saveGameScore(
+        GameID.TETRIS,
+        100,
+        undefined,
+        undefined,
+        { elapsedSeconds: 12, totalMoves: 34 },
+        {
+            context: {
+                mode: 'daily',
+                competitionKey: 'ice-slide:daily:2026-08-01:g1:r1',
+                rulesetVersion: 1,
+            },
+        }
+    )
+
+    const request = vi.mocked(global.fetch).mock.calls[0][1] as RequestInit
+    expect(JSON.parse(String(request.body))).toEqual({
+        gameId: GameID.TETRIS,
+        score: 100,
+        gameData: { elapsedSeconds: 12, totalMoves: 34 },
+        context: {
+            mode: 'daily',
+            competitionKey: 'ice-slide:daily:2026-08-01:g1:r1',
+            rulesetVersion: 1,
+        },
+    })
+})
+
+it('keeps the legacy request body free of a context property', async () => {
+    global.fetch = vi.fn().mockResolvedValue({
+        ok: true,
+        json: () => Promise.resolve({ success: true }),
+    })
+
+    await saveGameScore(GameID.TETRIS, 100)
+
+    const request = vi.mocked(global.fetch).mock.calls[0][1] as RequestInit
+    expect(JSON.parse(String(request.body))).toEqual({
+        gameId: GameID.TETRIS,
+        score: 100,
+    })
+})
+```
+
+- [ ] **Step 3: Run tests to verify they fail**
+
+```bash
+bun run test:run \
+  src/lib/server/validations.test.ts \
+  src/lib/services/scoreService.test.ts
+```
+
+Expected: FAIL because context and contextual refinements do not exist.
+
+- [ ] **Step 4: Implement the Zod context and contextual refinements**
+
+In `src/lib/server/validations.ts`, add:
+
+```ts
+const SCORE_CONTEXT_MAX_GAME_DATA_BYTES = 16 * 1024
+const modePattern = /^[a-z][a-z0-9_-]*$/
+const competitionKeyPattern = /^[A-Za-z0-9:._-]+$/
+
+export const scoreContextSchema = z
+    .object({
+        mode: z.string().min(1).max(32).regex(modePattern),
+        competitionKey: z
+            .string()
+            .min(1)
+            .max(128)
+            .regex(competitionKeyPattern)
+            .optional(),
+        rulesetVersion: z.number().int().min(1).max(2_147_483_647),
+    })
+    .strict()
+
+export type ScoreSubmissionContext = z.infer<typeof scoreContextSchema>
+
+function addContextualGameDataIssues(
+    data: Record<string, unknown>,
+    ctx: z.RefinementCtx
+): void {
+    for (const key of ['elapsedSeconds', 'totalMoves'] as const) {
+        const value = data[key]
+        if (
+            value !== undefined &&
+            (typeof value !== 'number' ||
+                !Number.isInteger(value) ||
+                value < 0)
+        ) {
+            ctx.addIssue({
+                code: 'custom',
+                path: ['gameData', key],
+                message: `${key} must be a non-negative integer`,
+            })
+        }
+    }
+
+    const serialized = JSON.stringify(data)
+    const byteLength = new TextEncoder().encode(serialized).byteLength
+    if (byteLength > SCORE_CONTEXT_MAX_GAME_DATA_BYTES) {
+        ctx.addIssue({
+            code: 'custom',
+            path: ['gameData'],
+            message: 'Contextual gameData exceeds 16 KiB',
+        })
+    }
+}
+```
+
+Replace `scoreSubmissionSchema` with:
+
+```ts
+export const scoreSubmissionSchema = z
+    .object({
+        gameId: z.enum(gameIdValues, {
+            message: 'Invalid game ID',
+        }),
+        score: z
+            .number()
+            .int()
+            .min(0, {
+                message: 'Score must be a non-negative integer',
+            })
+            .max(999_999_999, {
+                message: 'Score exceeds maximum allowed value',
+            }),
+        gameData: z.record(z.string(), z.unknown()).optional(),
+        context: scoreContextSchema.optional(),
+    })
+    .superRefine((data, ctx) => {
+        if (data.context && data.gameData) {
+            addContextualGameDataIssues(data.gameData, ctx)
+        }
+    })
+```
+
+- [ ] **Step 5: Extend the client contracts without changing positional arguments**
+
+In `src/lib/services/scoreService.ts`, import the context type:
+
+```ts
+import type { ScoreSubmissionContext } from '@/lib/server/validations'
+```
+
+Extend:
+
+```ts
+export interface ScoreData {
+    gameId: GameType
+    score: number
+    gameData?: GameData | Record<string, unknown>
+    context?: ScoreSubmissionContext
+}
+
+export interface SaveScoreOptions {
+    isStale?: () => boolean
+    context?: ScoreSubmissionContext
+}
+```
+
+Change the submit call in `saveGameScore()` to:
+
+```ts
+const scoreData: ScoreData = { gameId, score }
+if (gameData !== undefined) {
+    scoreData.gameData = gameData
+}
+if (options?.context !== undefined) {
+    scoreData.context = options.context
+}
+const result = await submitScore(scoreData)
+```
+
+- [ ] **Step 6: Run focused tests**
+
+```bash
+bun run test:run \
+  src/lib/server/validations.test.ts \
+  src/lib/services/scoreService.test.ts
+```
+
+Expected: PASS.
+
+- [ ] **Step 7: Commit**
+
+```bash
+git add src/lib/server/validations.ts \
+  src/lib/server/validations.test.ts \
+  src/lib/services/scoreService.ts \
+  src/lib/services/scoreService.test.ts
+git commit -m "feat(scores): validate and forward score context"
+```
+
+---
+
+### Task 4: Preserve discriminated write failures through the server and client
+
+**Files:**
+- Modify: `src/lib/server/db/queries.ts: saveGameScore, saveGameScoreWithAchievements`
+- Modify: `src/lib/server/db/queries.test.ts`
+- Modify: `src/lib/server/api-utils.ts`
+- Modify: `src/pages/api/scores.ts`
+- Modify: `src/pages/api/scores.test.ts`
+- Modify: `src/lib/services/scoreService.ts`
+- Modify: `src/lib/services/scoreService.test.ts`
+
+**Interfaces:**
+- Consumes: `PersistedScoreContext`, `SaveGameScoreResult`, and `SaveGameScoreWithAchievementsResult`.
+- Produces: one write path for legacy and contextual inserts.
+- Produces: public client code `SCORE_CONTEXT_UNAVAILABLE`.
+- Generic DB/stat failures remain `SCORE_WRITE_FAILED` internally and preserve the current generic client message.
+
+- [ ] **Step 1: Write failing query-layer tests**
+
+At the top of `src/lib/server/db/queries.test.ts`, mock the new capability module while retaining its real types/helpers:
+
+```ts
+vi.mock('@/lib/server/db/game-score-context', async importOriginal => {
+    const actual = await importOriginal<
+        typeof import('@/lib/server/db/game-score-context')
+    >()
+    return {
+        ...actual,
+        ensureGameScoresContextSchema: vi.fn(),
+    }
+})
+```
+
+Import `ensureGameScoresContextSchema` and `saveGameScoreWithAchievements`.
+
+Add these tests to the existing `saveGameScore` describe block, using its fluent `db.insertInto`, `db.selectFrom`, and `db.updateTable` mocks:
+
+```ts
+it('returns SCORE_CONTEXT_UNAVAILABLE and does not insert when columns are unavailable', async () => {
+    vi.mocked(ensureGameScoresContextSchema).mockResolvedValue({
+        known: true,
+        capabilities: {
+            mode: true,
+            competitionKey: true,
+            rulesetVersion: false,
+            gameDataJson: true,
+            scopedIndex: false,
+        },
+    })
+
+    const result = await saveGameScore('u1', 'tetris', 100, {
+        mode: 'daily',
+        competitionKey: 'ice-slide:daily:2026-08-01:g1:r1',
+        rulesetVersion: 1,
+        gameDataJson: '{"elapsedSeconds":12,"totalMoves":34}',
+    })
+
+    expect(result).toEqual({
+        success: false,
+        code: 'SCORE_CONTEXT_UNAVAILABLE',
+    })
+    expect(db.insertInto).not.toHaveBeenCalled()
+})
+
+it('inserts context and uses the existing stats update chain', async () => {
+    vi.mocked(ensureGameScoresContextSchema).mockResolvedValue({
+        known: true,
+        capabilities: {
+            mode: true,
+            competitionKey: true,
+            rulesetVersion: true,
+            gameDataJson: true,
+            scopedIndex: true,
+        },
+    })
+
+    const insert = {
+        values: vi.fn().mockReturnThis(),
+        execute: vi.fn().mockResolvedValue({}),
+    }
+    vi.mocked(db.insertInto).mockReturnValue(insert as never)
+
+    const updateSet = vi.fn().mockReturnThis()
+    vi.mocked(db.updateTable).mockReturnValue({
+        set: updateSet,
+        where: vi.fn().mockReturnThis(),
+        execute: vi.fn().mockResolvedValue({}),
+    } as never)
+
+    const existingStats = {
+        id: 1,
+        user_id: 'u1',
+        total_games_played: 2,
+        total_score: 500,
+        favorite_game: 'snake',
+        streak_days: 0,
+        xp: 0,
+        level: 1,
+        challenge_streak: 0,
+        last_challenge_date: null,
+        login_streak: 0,
+        last_login_reward_date: null,
+        total_login_cycles: 0,
+        email_notifications: 1,
+        push_notifications: 0,
+        challenge_reminders: 1,
+        created_at: new Date(),
+        updated_at: new Date(),
+    }
+
+    vi.mocked(db.selectFrom)
+        .mockReturnValueOnce({
+            selectAll: vi.fn().mockReturnThis(),
+            where: vi.fn().mockReturnThis(),
+            executeTakeFirst: vi.fn().mockResolvedValue(existingStats),
+        } as never)
+        .mockReturnValueOnce({
+            select: vi.fn().mockReturnThis(),
+            distinct: vi.fn().mockReturnThis(),
+            where: vi.fn().mockReturnThis(),
+            execute: vi.fn().mockResolvedValue([{ game_id: 'tetris' }]),
+        } as never)
+        .mockReturnValueOnce({
+            selectAll: vi.fn().mockReturnThis(),
+            where: vi.fn().mockReturnThis(),
+            executeTakeFirst: vi.fn().mockResolvedValue(existingStats),
+        } as never)
+        .mockReturnValueOnce({
+            select: vi.fn().mockReturnThis(),
+            distinct: vi.fn().mockReturnThis(),
+            where: vi.fn().mockReturnThis(),
+            execute: vi.fn().mockResolvedValue([{ game_id: 'tetris' }]),
+        } as never)
+
+    const result = await saveGameScore('u1', 'tetris', 100, {
+        mode: 'daily',
+        competitionKey: null,
+        rulesetVersion: 1,
+        gameDataJson: null,
+    })
+
+    expect(result).toEqual({ success: true })
+    expect(insert.values).toHaveBeenCalledWith({
+        user_id: 'u1',
+        game_id: 'tetris',
+        score: 100,
+        mode: 'daily',
+        competition_key: null,
+        ruleset_version: 1,
+        game_data_json: null,
+    })
+    expect(updateSet).toHaveBeenCalledWith(
+        expect.objectContaining({
+            total_score: 600,
+            favorite_game: 'tetris',
+        })
+    )
+})
+
+it('preserves capability failure through the achievement wrapper', async () => {
+    vi.mocked(ensureGameScoresContextSchema).mockResolvedValue({
+        known: false,
+    })
+
+    const result = await saveGameScoreWithAchievements(
+        'u1',
+        'tetris',
+        100,
+        { elapsedSeconds: 12 },
+        {
+            mode: 'daily',
+            competitionKey: null,
+            rulesetVersion: 1,
+            gameDataJson: '{"elapsedSeconds":12}',
+        }
+    )
+
+    expect(result).toEqual({
+        success: false,
+        newAchievements: [],
+        code: 'SCORE_CONTEXT_UNAVAILABLE',
+    })
+    expect(db.insertInto).not.toHaveBeenCalled()
+})
+```
+
+Update the existing boolean assertions in this file:
+- successful writes expect `{ success: true }`;
+- database failures expect `{ success: false, code: 'SCORE_WRITE_FAILED' }`.
+
+- [ ] **Step 2: Write failing route and client tests**
+
+In `src/pages/api/scores.test.ts` add:
+
+```ts
+it('returns SCORE_CONTEXT_UNAVAILABLE when contextual storage is unavailable', async () => {
+    vi.mocked(auth.api.getSession).mockResolvedValue(mockSession as never)
+    vi.mocked(getGameById).mockReturnValue(mockGame)
+    vi.mocked(saveGameScoreWithAchievements).mockResolvedValue({
+        success: false,
+        newAchievements: [],
+        code: 'SCORE_CONTEXT_UNAVAILABLE',
+    })
+
+    const request = new Request('http://localhost/api/scores', {
+        method: 'POST',
+        headers: { 'Content-Type': 'application/json' },
+        body: JSON.stringify({
+            gameId: 'tetris',
+            score: 100,
+            context: { mode: 'daily', rulesetVersion: 1 },
+        }),
+    })
+
+    const response = await POST({ request } as never)
+    expect(response.status).toBe(500)
+    expect(await response.json()).toEqual({
+        error: 'Score context is unavailable',
+        code: 'SCORE_CONTEXT_UNAVAILABLE',
+    })
+})
+```
+
+In `src/lib/services/scoreService.test.ts` add:
+
+```ts
+it('propagates recognized server error codes', async () => {
+    global.fetch = vi.fn().mockResolvedValue({
+        ok: false,
+        status: 500,
+        json: () =>
+            Promise.resolve({
+                error: 'Score context is unavailable',
+                code: 'SCORE_CONTEXT_UNAVAILABLE',
+            }),
+    })
+
+    const result = await submitScore({
+        gameId: GameID.TETRIS,
+        score: 100,
+        context: { mode: 'daily', rulesetVersion: 1 },
+    })
+
+    expect(result).toMatchObject({
+        success: false,
+        code: 'SCORE_CONTEXT_UNAVAILABLE',
+    })
+})
+
+it('does not invent a server code for network failures', async () => {
+    global.fetch = vi.fn().mockRejectedValue(new Error('offline'))
+
+    const result = await submitScore({
+        gameId: GameID.TETRIS,
+        score: 100,
+    })
+
+    expect(result.success).toBe(false)
+    expect(result.code).toBeUndefined()
+})
+```
+
+- [ ] **Step 3: Run tests to verify they fail**
+
+```bash
+bun run test:run \
+  src/lib/server/db/queries.test.ts \
+  src/pages/api/scores.test.ts \
+  src/lib/services/scoreService.test.ts
+```
+
+Expected: FAIL because writes return booleans and error bodies/codes are not propagated.
+
+- [ ] **Step 4: Implement the single discriminated write path**
+
+In `src/lib/server/db/queries.ts`, import:
+
+```ts
+import {
+    ensureGameScoresContextSchema,
+    hasCompleteGameScoresContextColumns,
+    type PersistedScoreContext,
+    type SaveGameScoreResult,
+    type SaveGameScoreWithAchievementsResult,
+} from './game-score-context'
+```
+
+Replace `saveGameScore()` with:
+
+```ts
+export async function saveGameScore(
+    userId: string,
+    gameId: string,
+    score: number,
+    context?: PersistedScoreContext
+): Promise<SaveGameScoreResult> {
+    try {
+        if (context) {
+            const state = await ensureGameScoresContextSchema()
+            if (
+                !state.known ||
+                !hasCompleteGameScoresContextColumns(state.capabilities)
+            ) {
+                return {
+                    success: false,
+                    code: 'SCORE_CONTEXT_UNAVAILABLE',
+                }
+            }
+        }
+
+        const newScore: NewGameScore = {
+            user_id: userId,
+            game_id: gameId,
+            score,
+        }
+
+        if (context) {
+            newScore.mode = context.mode
+            newScore.competition_key = context.competitionKey
+            newScore.ruleset_version = context.rulesetVersion
+            newScore.game_data_json = context.gameDataJson
+        }
+
+        await db.insertInto('game_scores').values(newScore).execute()
+
+        const currentStats = await getUserStats(userId)
+        await upsertUserStats(userId, {
+            total_games_played:
+                (currentStats?.total_games_played || 0) + 1,
+            total_score: (currentStats?.total_score || 0) + score,
+            favorite_game: gameId,
+        })
+
+        return { success: true }
+    } catch (error) {
+        console.error('[saveGameScore] Database error:', sanitizeError(error))
+        return { success: false, code: 'SCORE_WRITE_FAILED' }
+    }
+}
+```
+
+Update `saveGameScoreWithAchievements()` to accept `context?: PersistedScoreContext`, delegate once, and preserve `saveResult.code` before running achievements.
+
+- [ ] **Step 5: Add a coded JSON error helper**
+
+In `src/lib/server/api-utils.ts` add:
+
+```ts
+export function codedErrorResponse<C extends string>(
+    message: string,
+    code: C,
+    status: number = 500
+): Response {
+    return jsonResponse({ error: message, code }, status)
+}
+```
+
+- [ ] **Step 6: Map validated context in the score route**
+
+In `src/pages/api/scores.ts`:
+1. Destructure `context`.
+2. Build `PersistedScoreContext` only when context exists.
+3. Serialize validated contextual `gameData` once.
+4. Pass `gameData` and the normalized context to `saveGameScoreWithAchievements()`.
+5. Return the coded response only for `SCORE_CONTEXT_UNAVAILABLE`.
+
+Use:
+
+```ts
+const persistedContext: PersistedScoreContext | undefined = context
+    ? {
+          mode: context.mode,
+          competitionKey: context.competitionKey ?? null,
+          rulesetVersion: context.rulesetVersion,
+          gameDataJson:
+              gameData === undefined ? null : JSON.stringify(gameData),
+      }
+    : undefined
+
+const result = await saveGameScoreWithAchievements(
+    session.user.id,
+    validatedGameId,
+    score,
+    gameData,
+    persistedContext
+)
+
+if (!result.success) {
+    if (result.code === 'SCORE_CONTEXT_UNAVAILABLE') {
+        return codedErrorResponse(
+            'Score context is unavailable',
+            'SCORE_CONTEXT_UNAVAILABLE'
+        )
+    }
+    return errorResponse('Failed to save score')
+}
+```
+
+- [ ] **Step 7: Parse recognized codes in the client**
+
+In `scoreService.ts` add:
+
+```ts
+export type ScoreSubmissionPublicErrorCode =
+    | 'SCORE_CONTEXT_UNAVAILABLE'
+```
+
+Add `code?: ScoreSubmissionPublicErrorCode` to `ScoreSubmissionResult`.
+
+For a non-2xx response, parse JSON defensively even when a test response or proxy does not provide a `json()` method:
+
+```ts
+let body: { code?: unknown } | null = null
+try {
+    body = (await response.json()) as { code?: unknown }
+} catch {
+    body = null
+}
+
+const code =
+    body?.code === 'SCORE_CONTEXT_UNAVAILABLE'
+        ? body.code
+        : undefined
+```
+
+Include `code` in the returned failure object. Preserve the existing user-facing 401/400/500 messages.
+
+- [ ] **Step 8: Run focused tests**
+
+```bash
+bun run test:run \
+  src/lib/server/db/queries.test.ts \
+  src/pages/api/scores.test.ts \
+  src/lib/services/scoreService.test.ts
+```
+
+Expected: PASS.
+
+- [ ] **Step 9: Commit**
+
+```bash
+git add src/lib/server/db/queries.ts \
+  src/lib/server/db/queries.test.ts \
+  src/lib/server/api-utils.ts \
+  src/pages/api/scores.ts \
+  src/pages/api/scores.test.ts \
+  src/lib/services/scoreService.ts \
+  src/lib/services/scoreService.test.ts
+git commit -m "feat(scores): propagate contextual write failures"
+```
+
+---
+
+### Task 5: Isolate Campaign leaderboards and personal bests safely
+
+**Files:**
+- Modify: `src/lib/server/db/queries.ts: getGameLeaderboard, getUserBestScore`
+- Modify: `src/lib/server/db/queries.integration.test.ts`
+- Create: `src/lib/server/db/queries.score-context-read-failure.test.ts`
+- Modify: `src/lib/services/achievementService.test.ts`
+
+**Interfaces:**
+- Confirmed complete schema adds `mode IS NULL` and `competition_key IS NULL`.
+- Confirmed legacy/incomplete schema uses the existing no-predicate query.
+- Unknown capability without a cached snapshot returns `[]` for leaderboard and `null` for personal best.
+- `getUserBestScoreByGame` and `getUserBestScoreForGame` remain aliases/wrappers and inherit isolation.
+
+- [ ] **Step 1: Extend the integration fixture to the complete schema**
+
+In `queries.integration.test.ts`, add the four nullable columns to its `game_scores` table and extend `seedScore()` with an optional context object:
+
+```ts
+async function seedScore(
+    userId: string,
+    gameId: string,
+    score: number,
+    options: {
+        createdAt?: string
+        mode?: string
+        competitionKey?: string
+        rulesetVersion?: number
+        gameDataJson?: string
+    } = {}
+): Promise<void> {
+    await sql`
+        INSERT INTO game_scores (
+            user_id,
+            game_id,
+            score,
+            mode,
+            competition_key,
+            ruleset_version,
+            game_data_json,
+            created_at
+        )
+        VALUES (
+            ${userId},
+            ${gameId},
+            ${score},
+            ${options.mode ?? null},
+            ${options.competitionKey ?? null},
+            ${options.rulesetVersion ?? null},
+            ${options.gameDataJson ?? null},
+            ${options.createdAt ?? new Date().toISOString()}
+        )
+    `.execute(db)
+}
+```
+
+- [ ] **Step 2: Write failing isolation tests**
+
+Add integration tests:
+
+```ts
+it('keeps scoped rows out of the default raw-attempt leaderboard', async () => {
+    await seedUser('u1', 'Player')
+    await seedScore('u1', 'tetris', 100)
+    await seedScore('u1', 'tetris', 999, {
+        mode: 'daily',
+        competitionKey: 'daily:1',
+        rulesetVersion: 1,
+    })
+
+    const result = await getGameLeaderboard('tetris', 10)
+
+    expect(result.map(entry => entry.score)).toEqual([100])
+})
+
+it('keeps scoped rows out of every personal-best alias', async () => {
+    await seedScore('u1', 'tetris', 100)
+    await seedScore('u1', 'tetris', 999, {
+        mode: 'daily',
+        rulesetVersion: 1,
+    })
+
+    await expect(getUserBestScore('u1', 'tetris')).resolves.toBe(100)
+    await expect(getUserBestScoreForGame('u1', 'tetris')).resolves.toBe(100)
+    await expect(getUserBestScoreByGame('u1', 'tetris')).resolves.toBe(100)
+})
+
+it('retains raw-attempt semantics for unscoped rows', async () => {
+    await seedUser('u1', 'Player')
+    await seedScore('u1', 'tetris', 100)
+    await seedScore('u1', 'tetris', 200)
+
+    const result = await getGameLeaderboard('tetris', 10)
+
+    expect(result.map(entry => entry.score)).toEqual([200, 100])
+})
+```
+
+Add an achievement-service test that mocks `getUserBestScore()` to an unscoped value and verifies progress remains derived from that value even when `earned` is true.
+
+- [ ] **Step 3: Write the unknown-capability fail-closed test**
+
+Create `src/lib/server/db/queries.score-context-read-failure.test.ts`. Mock `game-score-context` to return `{ known: false }`, mock the database query chain, and assert:
+
+```ts
+await expect(getGameLeaderboard('tetris', 10)).resolves.toEqual([])
+await expect(getUserBestScore('u1', 'tetris')).resolves.toBeNull()
+expect(mockSelectFrom).not.toHaveBeenCalled()
+```
+
+- [ ] **Step 4: Run tests to verify they fail**
+
+```bash
+bun run test:run \
+  src/lib/server/db/queries.integration.test.ts \
+  src/lib/server/db/queries.score-context-read-failure.test.ts \
+  src/lib/services/achievementService.test.ts
+```
+
+Expected: scoped scores currently appear in default leaderboard/personal-best results.
+
+- [ ] **Step 5: Implement a shared read-state decision**
+
+In `queries.ts`, add:
+
+```ts
+async function getConfirmedScoreContextCapabilities():
+    Promise<GameScoresContextCapabilities | undefined> {
+    const state = await ensureGameScoresContextSchema()
+    if (!state.known) {
+        return undefined
+    }
+    return state.capabilities
+}
+```
+
+Interpret:
+- `undefined`: unknown probe; return the existing defensive result.
+- complete columns: add both unscoped predicates.
+- known incomplete columns: use the legacy no-predicate query.
+
+In both `getGameLeaderboard()` and `getUserBestScore()`:
+
+```ts
+const capabilities = await getConfirmedScoreContextCapabilities()
+if (capabilities === undefined) {
+    return []
+}
+```
+
+Use `return null` in `getUserBestScore()`.
+
+After building the existing query, conditionally add:
+
+```ts
+if (hasCompleteGameScoresContextColumns(capabilities)) {
+    query = query
+        .where('game_scores.mode', 'is', null)
+        .where('game_scores.competition_key', 'is', null)
+}
+```
+
+For `getUserBestScore()`, use unqualified column names matching its single-table query.
+
+- [ ] **Step 6: Run focused tests**
+
+```bash
+bun run test:run \
+  src/lib/server/db/queries.integration.test.ts \
+  src/lib/server/db/queries.score-context-read-failure.test.ts \
+  src/lib/services/achievementService.test.ts
+```
+
+Expected: PASS.
+
+- [ ] **Step 7: Commit**
+
+```bash
+git add src/lib/server/db/queries.ts \
+  src/lib/server/db/queries.integration.test.ts \
+  src/lib/server/db/queries.score-context-read-failure.test.ts \
+  src/lib/services/achievementService.test.ts
+git commit -m "feat(scores): isolate unscoped leaderboard and best scores"
+```
+
+---
+
+### Task 6: Add the real-LibSQL scoped best-per-user query
+
+**Files:**
+- Create: `src/lib/server/db/scoped-leaderboard.ts`
+- Create: `src/lib/server/db/scoped-leaderboard.integration.test.ts`
+- Modify: `src/lib/server/db/queries.ts` to re-export the scoped query contracts
+
+**Interfaces:**
+- Produces: `getScopedGameLeaderboard(query): Promise<ScopedLeaderboardResult>`.
+- Produces: internal rows with `userId`.
+- Produces: `toPublicScopedLeaderboardEntry(row)` that strips `userId`.
+- Failure code is `SCOPED_LEADERBOARD_UNAVAILABLE`.
+- Scoped public `rulesetVersion` is non-null.
+
+- [ ] **Step 1: Write the in-memory schema and seed helpers**
+
+Start `src/lib/server/db/scoped-leaderboard.integration.test.ts` with:
+
+```ts
+import { afterEach, beforeAll, describe, expect, it, vi } from 'vitest'
+import { sql } from 'kysely'
+
+vi.mock('@/lib/server/db/client', async () => {
+    const { Kysely } = await import('kysely')
+    const { LibsqlDialect, libsql } = await import('@libsql/kysely-libsql')
+    const client = libsql.createClient({ url: ':memory:' })
+    const dialect = new LibsqlDialect({ client })
+    return { db: new Kysely({ dialect }), dialect }
+})
+
+import { db } from '@/lib/server/db/client'
+import {
+    getScopedGameLeaderboard,
+    toPublicScopedLeaderboardEntry,
+} from './scoped-leaderboard'
+
+interface SeedScoreOptions {
+    mode: string
+    competitionKey: string | null
+    rulesetVersion: number | null
+    createdAt?: string
+    gameData?: Record<string, unknown>
+    rawGameDataJson?: string
+}
+
+beforeAll(async () => {
+    await sql`
+        CREATE TABLE "user" (
+            id TEXT PRIMARY KEY,
+            name TEXT NOT NULL,
+            username TEXT,
+            displayName TEXT,
+            image TEXT
+        )
+    `.execute(db)
+
+    await sql`
+        CREATE TABLE game_scores (
+            id INTEGER PRIMARY KEY AUTOINCREMENT,
+            user_id TEXT NOT NULL,
+            game_id TEXT NOT NULL,
+            score INTEGER NOT NULL,
+            mode TEXT,
+            competition_key TEXT,
+            ruleset_version INTEGER,
+            game_data_json TEXT,
+            created_at TEXT DEFAULT CURRENT_TIMESTAMP
+        )
+    `.execute(db)
+
+    await sql`
+        CREATE INDEX idx_game_scores_scoped_ranking
+        ON game_scores (
+            game_id,
+            mode,
+            competition_key,
+            score DESC,
+            created_at ASC
+        )
+    `.execute(db)
+})
+
+afterEach(async () => {
+    await sql`DELETE FROM game_scores`.execute(db)
+    await sql`DELETE FROM "user"`.execute(db)
+})
+
+async function seedUser(
+    id: string,
+    name: string,
+    options: {
+        username?: string
+        displayName?: string
+        image?: string
+    } = {}
+): Promise<void> {
+    await sql`
+        INSERT INTO "user" (id, name, username, displayName, image)
+        VALUES (
+            ${id},
+            ${name},
+            ${options.username ?? null},
+            ${options.displayName ?? null},
+            ${options.image ?? null}
+        )
+    `.execute(db)
+}
+
+async function seedScopedScore(
+    userId: string,
+    score: number,
+    options: SeedScoreOptions
+): Promise<void> {
+    const gameDataJson =
+        options.rawGameDataJson ??
+        (options.gameData === undefined
+            ? null
+            : JSON.stringify(options.gameData))
+
+    await sql`
+        INSERT INTO game_scores (
+            user_id,
+            game_id,
+            score,
+            mode,
+            competition_key,
+            ruleset_version,
+            game_data_json,
+            created_at
+        )
+        VALUES (
+            ${userId},
+            'tetris',
+            ${score},
+            ${options.mode},
+            ${options.competitionKey},
+            ${options.rulesetVersion},
+            ${gameDataJson},
+            ${options.createdAt ?? '2026-08-01T00:00:00Z'}
+        )
+    `.execute(db)
+}
+```
+
+The tests deliberately use `tetris` so HPA-484 remains independent of the not-yet-landed Ice Slide runtime.
+
+- [ ] **Step 2: Write failing scope/deduplication tests**
+
+Add:
+
+```ts
+it('returns one best row per user for an exact competition key', async () => {
+    await seedUser('u1', 'One')
+    await seedUser('u2', 'Two')
+    await seedScopedScore('u1', 100, {
+        mode: 'daily',
+        competitionKey: 'daily:1',
+        rulesetVersion: 1,
+        gameData: { elapsedSeconds: 20, totalMoves: 10 },
+    })
+    await seedScopedScore('u1', 200, {
+        mode: 'daily',
+        competitionKey: 'daily:1',
+        rulesetVersion: 1,
+        gameData: { elapsedSeconds: 30, totalMoves: 20 },
+    })
+    await seedScopedScore('u2', 150, {
+        mode: 'daily',
+        competitionKey: 'daily:1',
+        rulesetVersion: 1,
+        gameData: { elapsedSeconds: 25, totalMoves: 12 },
+    })
+
+    const result = await getScopedGameLeaderboard({
+        gameId: 'tetris',
+        mode: 'daily',
+        competitionKey: 'daily:1',
+        limit: 10,
+    })
+
+    expect(result.success).toBe(true)
+    if (!result.success) throw new Error('expected success')
+    expect(result.rows.map(row => [row.userId, row.score])).toEqual([
+        ['u1', 200],
+        ['u2', 150],
+    ])
+})
+
+it('mode-only ranking spans keys and ruleset versions', async () => {
+    await seedUser('u1', 'One')
+    await seedScopedScore('u1', 100, {
+        mode: 'daily',
+        competitionKey: 'daily:1',
+        rulesetVersion: 1,
+    })
+    await seedScopedScore('u1', 200, {
+        mode: 'daily',
+        competitionKey: 'daily:2',
+        rulesetVersion: 2,
+    })
+
+    const result = await getScopedGameLeaderboard({
+        gameId: 'tetris',
+        mode: 'daily',
+        limit: 10,
+    })
+
+    expect(result.success).toBe(true)
+    if (!result.success) throw new Error('expected success')
+    expect(result.rows[0].rulesetVersion).toBe(2)
+})
+```
+
+- [ ] **Step 3: Write every tie-break and malformed-data test**
+
+Add this table-driven best-attempt test. Use `rulesetVersion` only as an observable marker for which stored attempt won; it is not part of the ordering:
+
+```ts
+it.each([
+    {
+        name: 'higher score',
+        first: {
+            score: 100,
+            rulesetVersion: 1,
+            elapsedSeconds: 10,
+            totalMoves: 10,
+            createdAt: '2026-08-01T00:00:00Z',
+        },
+        second: {
+            score: 200,
+            rulesetVersion: 2,
+            elapsedSeconds: 99,
+            totalMoves: 99,
+            createdAt: '2026-08-01T00:00:01Z',
+        },
+        expectedRuleset: 2,
+    },
+    {
+        name: 'lower valid elapsed time',
+        first: {
+            score: 100,
+            rulesetVersion: 1,
+            elapsedSeconds: 10,
+            totalMoves: 20,
+            createdAt: '2026-08-01T00:00:01Z',
+        },
+        second: {
+            score: 100,
+            rulesetVersion: 2,
+            elapsedSeconds: 20,
+            totalMoves: 1,
+            createdAt: '2026-08-01T00:00:00Z',
+        },
+        expectedRuleset: 1,
+    },
+    {
+        name: 'lower valid move count',
+        first: {
+            score: 100,
+            rulesetVersion: 1,
+            elapsedSeconds: 10,
+            totalMoves: 5,
+            createdAt: '2026-08-01T00:00:01Z',
+        },
+        second: {
+            score: 100,
+            rulesetVersion: 2,
+            elapsedSeconds: 10,
+            totalMoves: 9,
+            createdAt: '2026-08-01T00:00:00Z',
+        },
+        expectedRuleset: 1,
+    },
+    {
+        name: 'earlier created_at',
+        first: {
+            score: 100,
+            rulesetVersion: 1,
+            elapsedSeconds: 10,
+            totalMoves: 5,
+            createdAt: '2026-08-01T00:00:00Z',
+        },
+        second: {
+            score: 100,
+            rulesetVersion: 2,
+            elapsedSeconds: 10,
+            totalMoves: 5,
+            createdAt: '2026-08-01T00:00:01Z',
+        },
+        expectedRuleset: 1,
+    },
+    {
+        name: 'lower row id for equal second-resolution timestamps',
+        first: {
+            score: 100,
+            rulesetVersion: 1,
+            elapsedSeconds: 10,
+            totalMoves: 5,
+            createdAt: '2026-08-01T00:00:00Z',
+        },
+        second: {
+            score: 100,
+            rulesetVersion: 2,
+            elapsedSeconds: 10,
+            totalMoves: 5,
+            createdAt: '2026-08-01T00:00:00Z',
+        },
+        expectedRuleset: 1,
+    },
+])('selects by $name', async ({ first, second, expectedRuleset }) => {
+    await seedUser('u1', 'One')
+    await seedScopedScore('u1', first.score, {
+        mode: 'daily',
+        competitionKey: 'daily:tie',
+        rulesetVersion: first.rulesetVersion,
+        createdAt: first.createdAt,
+        gameData: {
+            elapsedSeconds: first.elapsedSeconds,
+            totalMoves: first.totalMoves,
+        },
+    })
+    await seedScopedScore('u1', second.score, {
+        mode: 'daily',
+        competitionKey: 'daily:tie',
+        rulesetVersion: second.rulesetVersion,
+        createdAt: second.createdAt,
+        gameData: {
+            elapsedSeconds: second.elapsedSeconds,
+            totalMoves: second.totalMoves,
+        },
+    })
+
+    const result = await getScopedGameLeaderboard({
+        gameId: 'tetris',
+        mode: 'daily',
+        competitionKey: 'daily:tie',
+        limit: 10,
+    })
+
+    expect(result.success).toBe(true)
+    if (!result.success) throw new Error('expected success')
+    expect(result.rows[0].rulesetVersion).toBe(expectedRuleset)
+})
+```
+
+Add explicit invalid/missing ordering coverage:
+
+```ts
+it('sorts valid metrics before missing, fractional, negative, and malformed values', async () => {
+    await seedUser('valid', 'Valid')
+    await seedUser('invalid', 'Invalid')
+    await seedUser('broken', 'Broken')
+
+    await seedScopedScore('valid', 100, {
+        mode: 'daily',
+        competitionKey: 'daily:invalid',
+        rulesetVersion: 1,
+        gameData: { elapsedSeconds: 12, totalMoves: 20 },
+    })
+    await seedScopedScore('invalid', 100, {
+        mode: 'daily',
+        competitionKey: 'daily:invalid',
+        rulesetVersion: 1,
+        rawGameDataJson: '{"elapsedSeconds":12.5,"totalMoves":-1}',
+    })
+    await seedScopedScore('broken', 100, {
+        mode: 'daily',
+        competitionKey: 'daily:invalid',
+        rulesetVersion: 1,
+        rawGameDataJson: '{not-json',
+    })
+
+    const result = await getScopedGameLeaderboard({
+        gameId: 'tetris',
+        mode: 'daily',
+        competitionKey: 'daily:invalid',
+        limit: 10,
+    })
+
+    expect(result.success).toBe(true)
+    if (!result.success) throw new Error('expected success')
+    expect(result.rows[0].userId).toBe('valid')
+    expect(result.rows.slice(1)).toEqual(
+        expect.arrayContaining([
+            expect.objectContaining({
+                userId: 'invalid',
+                elapsedSeconds: null,
+                totalMoves: null,
+            }),
+            expect.objectContaining({
+                userId: 'broken',
+                elapsedSeconds: null,
+                totalMoves: null,
+            }),
+        ])
+    )
+})
+
+it('excludes null-version rows and does not project unknown JSON keys', async () => {
+    await seedUser('u1', 'One')
+    await seedUser('u2', 'Two')
+    await seedScopedScore('u1', 100, {
+        mode: 'daily',
+        competitionKey: 'daily:version',
+        rulesetVersion: null,
+        gameData: { elapsedSeconds: 1, combo: 99 },
+    })
+    await seedScopedScore('u2', 90, {
+        mode: 'daily',
+        competitionKey: 'daily:version',
+        rulesetVersion: 1,
+        gameData: { elapsedSeconds: 2, combo: 100 },
+    })
+
+    const result = await getScopedGameLeaderboard({
+        gameId: 'tetris',
+        mode: 'daily',
+        competitionKey: 'daily:version',
+        limit: 10,
+    })
+
+    expect(result.success).toBe(true)
+    if (!result.success) throw new Error('expected success')
+    expect(result.rows.map(row => row.userId)).toEqual(['u2'])
+    expect(result.rows[0]).not.toHaveProperty('combo')
+})
+```
+
+Define the seed helper options so `rulesetVersion` accepts `number | null` and `rawGameDataJson` bypasses normal JSON serialization only for historical-corruption fixtures.
+
+- [ ] **Step 4: Write the high-attempt/limit test**
+
+Seed at least 100 users and three attempts per user:
+
+```ts
+it('applies limit after best-per-user partitioning', async () => {
+    for (let user = 0; user < 100; user += 1) {
+        const userId = `u-${user}`
+        await seedUser(userId, `Player ${user}`)
+        for (let attempt = 0; attempt < 3; attempt += 1) {
+            await seedScopedScore(userId, user * 10 + attempt, {
+                mode: 'daily',
+                competitionKey: 'daily:bulk',
+                rulesetVersion: 1,
+                gameData: {
+                    elapsedSeconds: 100 - attempt,
+                    totalMoves: 50 - attempt,
+                },
+            })
+        }
+    }
+
+    const result = await getScopedGameLeaderboard({
+        gameId: 'tetris',
+        mode: 'daily',
+        competitionKey: 'daily:bulk',
+        limit: 10,
+    })
+
+    expect(result.success).toBe(true)
+    if (!result.success) throw new Error('expected success')
+    expect(result.rows).toHaveLength(10)
+    expect(new Set(result.rows.map(row => row.userId)).size).toBe(10)
+    expect(result.rows[0].score).toBe(992)
+})
+```
+
+- [ ] **Step 5: Run tests to verify they fail**
+
+```bash
+bun run test:run src/lib/server/db/scoped-leaderboard.integration.test.ts
+```
+
+Expected: FAIL because the module does not exist.
+
+- [ ] **Step 6: Implement the scoped query contracts**
+
+Create `src/lib/server/db/scoped-leaderboard.ts`:
+
+```ts
+import { sql } from 'kysely'
+import { db } from './client'
+import {
+    ensureGameScoresContextSchema,
+    hasCompleteGameScoresContextColumns,
+} from './game-score-context'
+
+export interface ScopedLeaderboardQuery {
+    gameId: string
+    mode: string
+    competitionKey?: string
+    limit?: number
+}
+
+export interface ScopedLeaderboardRow {
+    userId: string
+    name: string
+    username: string | null
+    image: string | null
+    score: number
+    created_at: string
+    mode: string
+    competitionKey: string | null
+    rulesetVersion: number
+    elapsedSeconds: number | null
+    totalMoves: number | null
+}
+
+export type ScopedLeaderboardEntry = Omit<
+    ScopedLeaderboardRow,
+    'userId'
+>
+
+export type ScopedLeaderboardResult =
+    | { success: true; rows: ScopedLeaderboardRow[] }
+    | {
+          success: false
+          code: 'SCOPED_LEADERBOARD_UNAVAILABLE'
+      }
+
+export function toPublicScopedLeaderboardEntry(
+    row: ScopedLeaderboardRow
+): ScopedLeaderboardEntry {
+    const { userId: _userId, ...entry } = row
+    return entry
+}
+```
+
+- [ ] **Step 7: Implement staged JSON normalization and window ranking**
+
+Add the raw row type and complete function in `scoped-leaderboard.ts`:
+
+```ts
+interface RawScopedLeaderboardRow {
+    user_id: string
+    name: string | null
+    username: string | null
+    image: string | null
+    score: number
+    created_at: string | Date
+    mode: string
+    competition_key: string | null
+    ruleset_version: number
+    elapsed_seconds: number | null
+    total_moves: number | null
+}
+
+export async function getScopedGameLeaderboard(
+    query: ScopedLeaderboardQuery
+): Promise<ScopedLeaderboardResult> {
+    const state = await ensureGameScoresContextSchema()
+    if (
+        !state.known ||
+        !hasCompleteGameScoresContextColumns(state.capabilities)
+    ) {
+        return {
+            success: false,
+            code: 'SCOPED_LEADERBOARD_UNAVAILABLE',
+        }
+    }
+
+    const competitionFilter =
+        query.competitionKey === undefined
+            ? sql``
+            : sql`AND gs.competition_key = ${query.competitionKey}`
+    const limit = query.limit ?? 10
+
+    try {
+        const result = await sql<RawScopedLeaderboardRow>`
+            WITH scoped AS (
+                SELECT
+                    gs.id,
+                    gs.user_id,
+                    gs.score,
+                    gs.created_at,
+                    gs.mode,
+                    gs.competition_key,
+                    gs.ruleset_version,
+                    CASE
+                        WHEN json_valid(gs.game_data_json) = 1
+                        THEN gs.game_data_json
+                        ELSE NULL
+                    END AS valid_json
+                FROM game_scores AS gs
+                WHERE gs.game_id = ${query.gameId}
+                  AND gs.mode = ${query.mode}
+                  AND gs.ruleset_version IS NOT NULL
+                  ${competitionFilter}
+            ),
+            metrics AS (
+                SELECT
+                    *,
+                    CASE
+                        WHEN json_type(
+                            valid_json,
+                            '$.elapsedSeconds'
+                        ) = 'integer'
+                         AND json_extract(
+                            valid_json,
+                            '$.elapsedSeconds'
+                         ) >= 0
+                        THEN CAST(
+                            json_extract(
+                                valid_json,
+                                '$.elapsedSeconds'
+                            ) AS INTEGER
+                        )
+                        ELSE NULL
+                    END AS elapsed_seconds,
+                    CASE
+                        WHEN json_type(
+                            valid_json,
+                            '$.totalMoves'
+                        ) = 'integer'
+                         AND json_extract(
+                            valid_json,
+                            '$.totalMoves'
+                         ) >= 0
+                        THEN CAST(
+                            json_extract(
+                                valid_json,
+                                '$.totalMoves'
+                            ) AS INTEGER
+                        )
+                        ELSE NULL
+                    END AS total_moves
+                FROM scoped
+            ),
+            ranked AS (
+                SELECT
+                    *,
+                    ROW_NUMBER() OVER (
+                        PARTITION BY user_id
+                        ORDER BY
+                            score DESC,
+                            CASE
+                                WHEN elapsed_seconds IS NULL
+                                THEN 1
+                                ELSE 0
+                            END ASC,
+                            elapsed_seconds ASC,
+                            CASE
+                                WHEN total_moves IS NULL
+                                THEN 1
+                                ELSE 0
+                            END ASC,
+                            total_moves ASC,
+                            created_at ASC,
+                            id ASC
+                    ) AS user_attempt_rank
+                FROM metrics
+            ),
+            best AS (
+                SELECT *
+                FROM ranked
+                WHERE user_attempt_rank = 1
+            )
+            SELECT
+                best.user_id AS user_id,
+                COALESCE(
+                    "user".displayName,
+                    "user".username,
+                    "user".name,
+                    'Anonymous'
+                ) AS name,
+                "user".username AS username,
+                "user".image AS image,
+                best.score AS score,
+                best.created_at AS created_at,
+                best.mode AS mode,
+                best.competition_key AS competition_key,
+                best.ruleset_version AS ruleset_version,
+                best.elapsed_seconds AS elapsed_seconds,
+                best.total_moves AS total_moves
+            FROM best
+            LEFT JOIN "user" ON "user".id = best.user_id
+            ORDER BY
+                best.score DESC,
+                CASE
+                    WHEN best.elapsed_seconds IS NULL
+                    THEN 1
+                    ELSE 0
+                END ASC,
+                best.elapsed_seconds ASC,
+                CASE
+                    WHEN best.total_moves IS NULL
+                    THEN 1
+                    ELSE 0
+                END ASC,
+                best.total_moves ASC,
+                best.created_at ASC,
+                best.id ASC
+            LIMIT ${limit}
+        `.execute(db)
+
+        return {
+            success: true,
+            rows: result.rows.map(row => ({
+                userId: row.user_id,
+                name: row.name ?? 'Anonymous',
+                username: row.username ?? null,
+                image: row.image ?? null,
+                score: Number(row.score),
+                created_at: new Date(row.created_at).toISOString(),
+                mode: row.mode,
+                competitionKey: row.competition_key ?? null,
+                rulesetVersion: Number(row.ruleset_version),
+                elapsedSeconds:
+                    row.elapsed_seconds === null
+                        ? null
+                        : Number(row.elapsed_seconds),
+                totalMoves:
+                    row.total_moves === null
+                        ? null
+                        : Number(row.total_moves),
+            })),
+        }
+    } catch (error) {
+        console.error(
+            '[getScopedGameLeaderboard] Database error:',
+            error instanceof Error ? error.message : String(error)
+        )
+        return {
+            success: false,
+            code: 'SCOPED_LEADERBOARD_UNAVAILABLE',
+        }
+    }
+}
+```
+
+Do not add a `ruleset_version = value` predicate to the mode-only branch. The only ruleset condition is `IS NOT NULL`.
+
+- [ ] **Step 8: Re-export from the existing query surface**
+
+At the end of `queries.ts` add:
+
+```ts
+export {
+    getScopedGameLeaderboard,
+    toPublicScopedLeaderboardEntry,
+} from './scoped-leaderboard'
+
+export type {
+    ScopedLeaderboardEntry,
+    ScopedLeaderboardQuery,
+    ScopedLeaderboardResult,
+    ScopedLeaderboardRow,
+} from './scoped-leaderboard'
+```
+
+- [ ] **Step 9: Run focused tests**
+
+```bash
+bun run test:run src/lib/server/db/scoped-leaderboard.integration.test.ts
+```
+
+Expected: PASS.
+
+- [ ] **Step 10: Commit**
+
+```bash
+git add src/lib/server/db/scoped-leaderboard.ts \
+  src/lib/server/db/scoped-leaderboard.integration.test.ts \
+  src/lib/server/db/queries.ts
+git commit -m "feat(scores): add scoped best-per-user leaderboard query"
+```
+
+---
+
+### Task 7: Expose validated scoped leaderboard API forms
+
+**Files:**
+- Modify: `src/lib/server/validations.ts`
+- Modify: `src/lib/server/validations.test.ts`
+- Modify: `src/pages/api/leaderboard.ts`
+- Modify: `src/pages/api/leaderboard.test.ts`
+
+**Interfaces:**
+- Produces one schema for all-games, single-game, mode-only scoped, and exact-key scoped forms.
+- Scoped output uses the existing `{ gameId, gameName, leaderboard }` wrapper and additive entry fields.
+- Scoped API adds `rank` after the database has selected one row per user.
+
+- [ ] **Step 1: Write failing leaderboard-query validation tests**
+
+Add:
+
+```ts
+describe('leaderboardQuerySchema', () => {
+    it('accepts the all-games form', () => {
+        expect(leaderboardQuerySchema.parse({})).toEqual({ limit: 10 })
+    })
+
+    it('accepts game-only, mode-only scoped, and exact-key forms', () => {
+        expect(
+            leaderboardQuerySchema.safeParse({
+                gameId: GameID.TETRIS,
+                mode: 'daily',
+            }).success
+        ).toBe(true)
+
+        expect(
+            leaderboardQuerySchema.safeParse({
+                gameId: GameID.TETRIS,
+                mode: 'daily',
+                competitionKey: 'daily:1',
+            }).success
+        ).toBe(true)
+    })
+
+    it.each([
+        { mode: 'daily' },
+        { competitionKey: 'daily:1' },
+        { gameId: GameID.TETRIS, competitionKey: 'daily:1' },
+    ])('rejects invalid cross-field combinations: %o', params => {
+        expect(leaderboardQuerySchema.safeParse(params).success).toBe(false)
+    })
+})
+```
+
+- [ ] **Step 2: Write failing API tests**
+
+Extend the query mock:
+
+```ts
+vi.mock('@/lib/server/db/queries', () => ({
+    getGameLeaderboard: vi.fn(),
+    getScopedGameLeaderboard: vi.fn(),
+    toPublicScopedLeaderboardEntry: vi.fn(
+        ({ userId: _userId, ...entry }) => entry
+    ),
+}))
+```
+
+Import all three functions and add:
+
+```ts
+it('returns a mode-only scoped best-per-user leaderboard', async () => {
+    vi.mocked(getScopedGameLeaderboard).mockResolvedValue({
+        success: true,
+        rows: [
+            {
+                userId: 'u1',
+                name: 'Player',
+                username: 'player',
+                image: null,
+                score: 500,
+                created_at: '2026-08-01T00:00:00.000Z',
+                mode: 'daily',
+                competitionKey: null,
+                rulesetVersion: 2,
+                elapsedSeconds: 12,
+                totalMoves: 34,
+            },
+        ],
+    })
+
+    const response = await GET({
+        url: new URL(
+            'http://localhost/api/leaderboard?gameId=tetris&mode=daily'
+        ),
+    } as never)
+
+    expect(response.status).toBe(200)
+    expect(getScopedGameLeaderboard).toHaveBeenCalledWith({
+        gameId: 'tetris',
+        mode: 'daily',
+        competitionKey: undefined,
+        limit: 10,
+    })
+
+    const body = await response.json()
+    expect(body.leaderboard).toEqual([
+        {
+            rank: 1,
+            name: 'Player',
+            username: 'player',
+            image: null,
+            score: 500,
+            created_at: '2026-08-01T00:00:00.000Z',
+            mode: 'daily',
+            competitionKey: null,
+            rulesetVersion: 2,
+            elapsedSeconds: 12,
+            totalMoves: 34,
+        },
+    ])
+    expect(body.leaderboard[0]).not.toHaveProperty('userId')
+})
+
+it('forwards an exact competition key', async () => {
+    vi.mocked(getScopedGameLeaderboard).mockResolvedValue({
+        success: true,
+        rows: [],
+    })
+
+    await GET({
+        url: new URL(
+            'http://localhost/api/leaderboard' +
+                '?gameId=tetris&mode=daily&competitionKey=daily%3A1'
+        ),
+    } as never)
+
+    expect(getScopedGameLeaderboard).toHaveBeenCalledWith({
+        gameId: 'tetris',
+        mode: 'daily',
+        competitionKey: 'daily:1',
+        limit: 10,
+    })
+})
+
+it.each([
+    'http://localhost/api/leaderboard?mode=daily',
+    'http://localhost/api/leaderboard?competitionKey=daily%3A1',
+    'http://localhost/api/leaderboard?gameId=tetris&competitionKey=daily%3A1',
+])('rejects invalid scoped parameter combinations: %s', async url => {
+    const response = await GET({ url: new URL(url) } as never)
+    expect(response.status).toBe(400)
+    expect(getScopedGameLeaderboard).not.toHaveBeenCalled()
+})
+
+it('returns a stable scoped-unavailable code', async () => {
+    vi.mocked(getScopedGameLeaderboard).mockResolvedValue({
+        success: false,
+        code: 'SCOPED_LEADERBOARD_UNAVAILABLE',
+    })
+
+    const response = await GET({
+        url: new URL(
+            'http://localhost/api/leaderboard?gameId=tetris&mode=daily'
+        ),
+    } as never)
+
+    expect(response.status).toBe(500)
+    expect(await response.json()).toEqual({
+        error: 'Scoped leaderboard is unavailable',
+        code: 'SCOPED_LEADERBOARD_UNAVAILABLE',
+    })
+})
+```
+
+Keep the existing all-games and game-only tests unchanged except for using the unified validation error messages. Add one assertion that two unscoped rows from the same user remain two response entries.
+
+- [ ] **Step 3: Run tests to verify they fail**
+
+```bash
+bun run test:run \
+  src/lib/server/validations.test.ts \
+  src/pages/api/leaderboard.test.ts
+```
+
+Expected: FAIL because the schema requires `gameId` and the route has no scoped branch.
+
+- [ ] **Step 4: Replace `leaderboardQuerySchema`**
+
+Use:
+
+```ts
+export const leaderboardQuerySchema = z
+    .object({
+        gameId: z.enum(gameIdValues).optional(),
+        limit: z
+            .string()
+            .transform(value => Number.parseInt(value, 10))
+            .pipe(z.number().int().min(1).max(100))
+            .optional()
+            .default(10),
+        mode: z
+            .string()
+            .min(1)
+            .max(32)
+            .regex(modePattern)
+            .optional(),
+        competitionKey: z
+            .string()
+            .min(1)
+            .max(128)
+            .regex(competitionKeyPattern)
+            .optional(),
+    })
+    .superRefine((data, ctx) => {
+        if (data.mode && !data.gameId) {
+            ctx.addIssue({
+                code: 'custom',
+                path: ['mode'],
+                message: 'mode requires gameId',
+            })
+        }
+
+        if (
+            data.competitionKey &&
+            (!data.gameId || !data.mode)
+        ) {
+            ctx.addIssue({
+                code: 'custom',
+                path: ['competitionKey'],
+                message: 'competitionKey requires gameId and mode',
+            })
+        }
+    })
+```
+
+- [ ] **Step 5: Replace manual route parsing with `validateQuery()`**
+
+In `leaderboard.ts`:
+1. Validate once.
+2. Preserve the existing all-games branch when `gameId` is absent.
+3. Preserve the existing unscoped branch when `mode` is absent.
+4. Call the scoped query when `mode` is present.
+5. Map internal rows to public entries, then add ranks.
+6. Return the coded error on a scoped failure.
+
+The scoped branch must use:
+
+```ts
+const scoped = await getScopedGameLeaderboard({
+    gameId,
+    mode,
+    competitionKey,
+    limit,
+})
+
+if (!scoped.success) {
+    return codedErrorResponse(
+        'Scoped leaderboard is unavailable',
+        'SCOPED_LEADERBOARD_UNAVAILABLE'
+    )
+}
+
+const leaderboard = scoped.rows.map((row, index) => ({
+    rank: index + 1,
+    ...toPublicScopedLeaderboardEntry(row),
+}))
+```
+
+- [ ] **Step 6: Run focused tests**
+
+```bash
+bun run test:run \
+  src/lib/server/validations.test.ts \
+  src/pages/api/leaderboard.test.ts
+```
+
+Expected: PASS.
+
+- [ ] **Step 7: Commit**
+
+```bash
+git add src/lib/server/validations.ts \
+  src/lib/server/validations.test.ts \
+  src/pages/api/leaderboard.ts \
+  src/pages/api/leaderboard.test.ts
+git commit -m "feat(scores): expose validated scoped leaderboards"
+```
+
+---
+
+### Task 8: Prove activity, achievements, and public DTO compatibility
+
+**Files:**
+- Modify: `src/lib/server/db/queries.integration.test.ts`
+- Modify: `src/pages/api/scores/history.test.ts`
+- Modify: `src/pages/api/scores.test.ts`
+- Modify: `src/lib/services/achievementService.test.ts`
+
+**Interfaces:**
+- No new production interface.
+- This task closes regression coverage for the intentional semantic split.
+
+- [ ] **Step 1: Add contextual write side-effect coverage**
+
+Import `saveGameScore`, `getUserGameHistory`, `getUserDailyActivity`, `getGamesPlayedCountToday`, `getUniqueGamesPlayedToday`, and `getTotalScoreToday` into `queries.integration.test.ts`.
+
+Add:
+
+```ts
+it('persists scoped context while retaining platform activity side effects', async () => {
+    await seedUser('scoped-user', 'Scoped Player')
+    await seedUserStats('scoped-user')
+
+    const result = await saveGameScore('scoped-user', 'tetris', 500, {
+        mode: 'daily',
+        competitionKey: 'daily:activity',
+        rulesetVersion: 1,
+        gameDataJson: JSON.stringify({
+            elapsedSeconds: 12,
+            totalMoves: 34,
+        }),
+    })
+    expect(result).toEqual({ success: true })
+
+    const scoreRows = await sql<{
+        mode: string | null
+        competition_key: string | null
+        ruleset_version: number | null
+        game_data_json: string | null
+    }>`
+        SELECT
+            mode,
+            competition_key,
+            ruleset_version,
+            game_data_json
+        FROM game_scores
+        WHERE user_id = 'scoped-user'
+    `.execute(db)
+    expect(scoreRows.rows).toEqual([
+        {
+            mode: 'daily',
+            competition_key: 'daily:activity',
+            ruleset_version: 1,
+            game_data_json:
+                '{"elapsedSeconds":12,"totalMoves":34}',
+        },
+    ])
+
+    const stats = await sql<{
+        total_games_played: number
+        total_score: number
+        favorite_game: string | null
+    }>`
+        SELECT total_games_played, total_score, favorite_game
+        FROM user_stats
+        WHERE user_id = 'scoped-user'
+    `.execute(db)
+    expect(stats.rows[0]).toEqual({
+        total_games_played: 1,
+        total_score: 500,
+        favorite_game: 'tetris',
+    })
+
+    const history = await getUserGameHistory('scoped-user', 10)
+    expect(history).toHaveLength(1)
+    expect(Object.keys(history[0]).sort()).toEqual([
+        'created_at',
+        'game_id',
+        'game_name',
+        'score',
+    ])
+
+    expect(await getGamesPlayedCountToday('scoped-user')).toBe(1)
+    expect(await getUniqueGamesPlayedToday('scoped-user')).toBe(1)
+    expect(await getTotalScoreToday('scoped-user')).toBe(500)
+
+    const activity = await getUserDailyActivity(
+        'scoped-user',
+        new Date().getUTCFullYear()
+    )
+    expect(activity.reduce((sum, day) => sum + day.count, 0)).toBe(1)
+})
+```
+
+Use the test process's current UTC year because the inserted score uses `CURRENT_TIMESTAMP`.
+
+- [ ] **Step 2: Add achievement awarding/progress asymmetry coverage**
+
+Add to `achievementService.test.ts`:
+
+```ts
+it('treats earned as authoritative when scoped awarding exceeds unscoped progress', async () => {
+    const achievement: Achievement = {
+        id: 'tetris_master',
+        name: 'Tetris Master',
+        description: 'Score 1000 points in Tetris',
+        logo: '👑',
+        gameId: GameID.TETRIS,
+        condition: {
+            type: 'score_threshold',
+            threshold: 1000,
+        },
+        rarity: AchievementRarity.EPIC,
+    }
+
+    mockGetAchievementsByGame.mockReturnValue([achievement])
+    mockHasUserEarnedAchievement
+        .mockResolvedValueOnce(false)
+        .mockResolvedValueOnce(true)
+    mockAwardAchievement.mockResolvedValue(true)
+    mockGetUserBestScore.mockResolvedValue(250)
+
+    await expect(
+        checkAndAwardAchievements('user123', GameID.TETRIS, 1200)
+    ).resolves.toEqual(['tetris_master'])
+
+    const progress = await getUserGameAchievementProgress(
+        'user123',
+        GameID.TETRIS
+    )
+
+    expect(progress).toEqual([
+        {
+            achievement,
+            earned: true,
+            progress: 25,
+        },
+    ])
+})
+```
+
+This test does not label the award as Campaign or Daily; it proves the shared service uses submitted score for awarding and the unscoped best-score query for progress.
+
+- [ ] **Step 3: Add public history leakage tests**
+
+In `history.test.ts`, make the mocked database result intentionally include internal fields:
+
+```ts
+vi.mocked(getUserGameHistory).mockResolvedValue([
+    {
+        game_id: 'tetris',
+        game_name: 'Tetris Challenge',
+        score: 100,
+        created_at: '2026-08-01T00:00:00.000Z',
+    },
+])
+```
+
+Then assert the response entry has exactly these keys:
+
+```ts
+expect(Object.keys(result.history[0]).sort()).toEqual([
+    'created_at',
+    'game_id',
+    'game_name',
+    'score',
+])
+```
+
+Also add a real-query assertion in `queries.integration.test.ts` that `getUserGameHistory()` omits `mode`, `competition_key`, `ruleset_version`, and `game_data_json`.
+
+- [ ] **Step 4: Add route sequencing coverage**
+
+Add to `scores.test.ts`:
+
+```ts
+it('normalizes context and updates challenges after a successful contextual save', async () => {
+    vi.mocked(auth.api.getSession).mockResolvedValue(mockSession as never)
+    vi.mocked(getGameById).mockReturnValue(mockGame)
+    vi.mocked(saveGameScoreWithAchievements).mockResolvedValue({
+        success: true,
+        newAchievements: [],
+    })
+    vi.mocked(updateChallengeProgress).mockResolvedValue({
+        completedChallenges: [],
+        xpEarned: 0,
+        levelUp: false,
+    })
+
+    const request = new Request('http://localhost/api/scores', {
+        method: 'POST',
+        headers: { 'Content-Type': 'application/json' },
+        body: JSON.stringify({
+            gameId: 'tetris',
+            score: 500,
+            gameData: {
+                elapsedSeconds: 12,
+                totalMoves: 34,
+            },
+            context: {
+                mode: 'daily',
+                competitionKey: 'daily:route',
+                rulesetVersion: 1,
+            },
+        }),
+    })
+
+    const response = await POST({ request } as never)
+    expect(response.status).toBe(200)
+
+    expect(saveGameScoreWithAchievements).toHaveBeenCalledWith(
+        'user-123',
+        'tetris',
+        500,
+        {
+            elapsedSeconds: 12,
+            totalMoves: 34,
+        },
+        {
+            mode: 'daily',
+            competitionKey: 'daily:route',
+            rulesetVersion: 1,
+            gameDataJson:
+                '{"elapsedSeconds":12,"totalMoves":34}',
+        }
+    )
+    expect(updateChallengeProgress).toHaveBeenCalledWith(
+        'user-123',
+        'tetris',
+        500
+    )
+    expect(
+        vi.mocked(saveGameScoreWithAchievements).mock.invocationCallOrder[0]
+    ).toBeLessThan(
+        vi.mocked(updateChallengeProgress).mock.invocationCallOrder[0]
+    )
+})
+
+it('does not update challenges after contextual capability failure', async () => {
+    vi.mocked(auth.api.getSession).mockResolvedValue(mockSession as never)
+    vi.mocked(getGameById).mockReturnValue(mockGame)
+    vi.mocked(saveGameScoreWithAchievements).mockResolvedValue({
+        success: false,
+        newAchievements: [],
+        code: 'SCORE_CONTEXT_UNAVAILABLE',
+    })
+
+    const request = new Request('http://localhost/api/scores', {
+        method: 'POST',
+        headers: { 'Content-Type': 'application/json' },
+        body: JSON.stringify({
+            gameId: 'tetris',
+            score: 500,
+            context: {
+                mode: 'daily',
+                rulesetVersion: 1,
+            },
+        }),
+    })
+
+    const response = await POST({ request } as never)
+
+    expect(response.status).toBe(500)
+    expect(updateChallengeProgress).not.toHaveBeenCalled()
+})
+```
+
+Retain the existing legacy success test and its challenge best-effort behavior.
+
+- [ ] **Step 5: Run the semantic regression suite**
+
+```bash
+bun run test:run \
+  src/lib/server/db/queries.integration.test.ts \
+  src/lib/services/achievementService.test.ts \
+  src/pages/api/scores.test.ts \
+  src/pages/api/scores/history.test.ts
+```
+
+Expected: PASS.
+
+- [ ] **Step 6: Commit**
+
+```bash
+git add src/lib/server/db/queries.integration.test.ts \
+  src/lib/services/achievementService.test.ts \
+  src/pages/api/scores.test.ts \
+  src/pages/api/scores/history.test.ts
+git commit -m "test(scores): lock scoped compatibility boundaries"
+```
+
+---
+
+### Task 9: Run full verification and update tracking
+
+**Files:**
+- Modify only if verification reveals an actual defect.
+- Update PR description/checklist and HPA-484 after all commands pass.
+
+**Interfaces:**
+- Produces verified implementation evidence.
+- Does not change the approved public contract.
+
+- [ ] **Step 1: Run all score-focused tests together**
+
+```bash
+bun run test:run \
+  src/lib/server/db/game-score-schema-files.test.ts \
+  src/lib/server/db/game-score-context.migrations.test.ts \
+  src/lib/server/db/game-score-context.index-retry.test.ts \
+  src/lib/server/db/queries.test.ts \
+  src/lib/server/db/queries.integration.test.ts \
+  src/lib/server/db/queries.score-context-read-failure.test.ts \
+  src/lib/server/db/scoped-leaderboard.integration.test.ts \
+  src/lib/server/validations.test.ts \
+  src/lib/services/scoreService.test.ts \
+  src/lib/services/achievementService.test.ts \
+  src/pages/api/scores.test.ts \
+  src/pages/api/leaderboard.test.ts \
+  src/pages/api/scores/history.test.ts \
+  src/pages/api/scores/best.test.ts
+```
+
+Expected: zero failing tests.
+
+- [ ] **Step 2: Run the full unit/integration suite**
+
+```bash
+bun run test:run
+```
+
+Expected: exit `0`.
+
+- [ ] **Step 3: Run static verification**
+
+```bash
+bun run lint
+bun run typecheck
+bun run format:check
+bun run build
+```
+
+Expected: every command exits `0`.
+
+- [ ] **Step 4: Inspect the final diff**
+
+```bash
+git status --short
+git diff --check
+git diff --stat main...HEAD
+```
+
+Expected:
+- no uncommitted files;
+- no whitespace errors;
+- only HPA-484 implementation, tests, and approved documentation changes.
+
+- [ ] **Step 5: Perform the spec-coverage checklist**
+
+Confirm each statement with a test name or diff location:
+- both bootstrap schemas;
+- non-destructive migration;
+- bounded index retry;
+- omit-only context;
+- legacy payload compatibility;
+- discriminated failure propagation;
+- same write/stat/achievement/challenge path;
+- unscoped leaderboard and best-score isolation;
+- scoped exact-key and mode-only behavior;
+- every tie-break;
+- integer producer contract and fractional historical normalization;
+- high-attempt limit after partition;
+- public ID/JSON/history isolation;
+- explicit scoped unavailable response.
+
+- [ ] **Step 6: Stop on any verification failure**
+
+When any command in Steps 1–5 fails, record the failing command and assertion, return to the task that owns that behavior, add a failing regression test there, and repeat that task's red/green cycle. Do not publish or claim completion while any verification command is failing.
+
+- [ ] **Step 7: Publish the implementation PR**
+
+Push the implementation branch and open a draft PR against `main`. Include:
+- HPA-484;
+- link to the design and this plan;
+- task-by-task commit summary;
+- exact verification commands and results;
+- explicit statement that HPA-487/HPA-488 UI/semantic admission remain out of scope.
+
+- [ ] **Step 8: Update Linear**
+
+Add the implementation PR link to HPA-484 and post:
+- branch and head commit;
+- verification results;
+- any deliberate deviations from this plan;
+- remaining blockers for HPA-487/HPA-488.
+
+## Plan Self-Review
+
+- **Spec coverage:** Tasks 1–8 cover every acceptance criterion in the approved design; Task 9 verifies them together.
+- **Placeholder scan:** No unresolved markers, deferred implementation instructions, or unspecified test steps remain.
+- **Type consistency:** `ScoreSubmissionContext`, `PersistedScoreContext`, `SaveGameScoreResult`, `ScopedLeaderboardRow`, and the two public error codes use the same names across producer, route, query, tests, and client.
+- **Scope:** The plan adds no Ice Slide runtime, semantic admission, UI, arbitrary metric engine, second mode-only index, anti-cheat, or transaction redesign.

--- a/docs/superpowers/specs/2026-07-31-versioned-score-context-design.md
+++ b/docs/superpowers/specs/2026-07-31-versioned-score-context-design.md
@@ -4,7 +4,7 @@
 - **Status:** Approved for implementation planning
 - **Repository:** `cwchanap/cetus`
 - **Linear issue:** [HPA-484 — Persist versioned game score context and add scoped leaderboard queries](https://linear.app/cwchanap/issue/HPA-484/persist-versioned-game-score-context-and-add-scoped-leaderboard)
-- **Parent design:** [Ice Slide replayability design](https://github.com/cwchanap/cetus/blob/docs/ice-slide-replayability-spec/docs/superpowers/specs/2026-07-30-ice-slide-replayability-design.md)
+- **Canonical parent design:** [Ice Slide Replayability, Daily Challenge, and Seeded Expedition](https://linear.app/cwchanap/document/ice-slide-replayability-daily-challenge-and-seeded-expedition-design-261fb6695310)
 
 ## 1. Summary
 
@@ -27,16 +27,25 @@ The current implementation has these relevant properties:
 - The score API subsequently updates platform daily-challenge progress.
 - `getGameLeaderboard()` returns score rows directly, ordered by score descending; repeated attempts from one user may occupy multiple positions.
 - `/api/leaderboard` supports both a single-game response and an all-games response when `gameId` is omitted.
+- The leaderboard route currently parses query parameters manually. The existing `leaderboardQuerySchema` requires `gameId` and therefore does not model the route's all-games path.
 - `getUserBestScore()` and compatibility aliases are reused by the personal-best API and achievement-progress calculations.
 - History, activity, aggregate-score, and challenge queries intentionally derive data from the complete `game_scores` activity stream.
+- Each score updates the existing aggregate-stat side effects, including total score and favorite-game assignment.
 - The database layer already uses defensive, lazy, idempotent LibSQL migrations with process-local single-flight promises and retry after incomplete migration.
 - Database behavior is tested both through mocked Kysely chains and real in-memory LibSQL integration tests.
+- The current score schema already requires `gameData` to be an object through Zod's record schema, but it does not impose a serialized-byte limit.
 
 The change must preserve those contracts unless this design explicitly narrows a query to unscoped rows.
 
+### 2.1 Existing game-data size audit
+
+Current game-owned payloads are JSON objects and are generally compact. Most contain only scalar counters. Reflex is the largest naturally bounded payload: it records `gameHistory`, but the default game lasts 60 seconds and spawns at one-second intervals. Word Scramble records a list of correct words during a 60-second game, but neither its client logic nor the public score API provides a universal server-enforced upper bound on the number of entries a modified client could submit.
+
+Therefore, repository inspection cannot prove that every valid legacy request is below an arbitrary new 16 KiB threshold. To preserve the existing contract rather than rely on normal-play assumptions, the byte-size limit introduced by this design applies only when `gameData` will be persisted as part of a contextual submission. Legacy transient `gameData` keeps its existing validation behavior.
+
 ## 3. Goals
 
-1. Persist optional score mode, competition identity, ruleset version, and bounded game data.
+1. Persist optional score mode, competition identity, ruleset version, and bounded contextual game data.
 2. Keep every existing submission caller valid without modification.
 3. Keep historical and new Campaign scores comparable through the existing unscoped leaderboard.
 4. Prevent Daily and Expedition rows from changing Campaign leaderboards, personal bests, or Campaign-oriented achievement progress.
@@ -44,7 +53,8 @@ The change must preserve those contracts unless this design explicitly narrows a
 6. Provide a reusable scoped query that returns one deterministic best attempt per user.
 7. Migrate existing and partially migrated LibSQL schemas without table rebuilds or destructive rewrites.
 8. Make malformed stored JSON and partial migration states fail safely.
-9. Keep Ice Slide-specific completion and run-identity verification outside the shared score layer.
+9. Keep raw authentication identifiers out of public leaderboard responses.
+10. Keep Ice Slide-specific completion and run-identity verification outside the shared score layer.
 
 ## 4. Non-goals
 
@@ -56,18 +66,23 @@ The change must preserve those contracts unless this design explicitly narrows a
 - Historical Daily navigation, seasonal leagues, or cross-seed Expedition ranking.
 - Redesigning the existing score-insert/stat-update transaction boundary.
 - Changing platform daily-challenge definitions or challenge rotation.
+- Publishing Better Auth user IDs for leaderboard highlighting or profile navigation.
+- Adding a second mode-only ranking index before a measured use case requires it.
 
 ## 5. Fixed Product and Platform Decisions
 
 | Decision | Requirement |
 |---|---|
-| Legacy path | A submission without `context` uses the current unscoped path. |
+| Legacy path | A submission without `context` uses the current unscoped path and existing input-validation contract. |
 | Context ownership | Context is an explicit sibling of `gameData`; it is never inferred from game data. |
 | Game-data persistence | `gameData` is persisted only for a validated contextual submission. |
+| Contextual data bound | The 16 KiB serialized limit applies only to contextual game data that may be stored. |
 | Campaign ranking | Default/global leaderboards include only unscoped rows. |
 | Personal best | Existing best-score queries and Campaign-oriented achievement progress include only unscoped rows. |
-| Platform activity | Scoped rows still count toward history, activity, aggregates, and existing daily challenges. |
+| Platform activity | Scoped rows still count toward history, activity, aggregates, favorite-game updates, and existing daily challenges. |
 | Scoped ranking | One best row per user, selected and ordered deterministically. |
+| Public identity | Public scoped output exposes display identity but never raw `user_id`. |
+| Ruleset column | `ruleset_version` is audit/display metadata, not a ranking predicate or tie-break. |
 | Daily admission | Ice Slide-specific solved/run/version checks belong to HPA-488. |
 | Invalid context | Reject with `400`; never silently downgrade to an unscoped score. |
 | Missing schema | Legacy operations continue where possible; contextual operations fail explicitly. |
@@ -88,6 +103,7 @@ Add reusable scope/version columns and persist game-specific tie-break data as J
 **Costs**
 
 - Tie-break extraction requires guarded SQLite JSON functions.
+- The exact-key index does not fully order mode-only queries.
 - Indexes optimize scope and score, but not arbitrary JSON metrics.
 
 ### 6.2 Normalize elapsed time and moves into shared columns
@@ -120,6 +136,16 @@ Query scoped attempts, deserialize every payload, sort in TypeScript, and retain
 - Applying `limit` before deduplication produces incorrect rankings.
 - It moves a relational ranking problem out of the database and is harder to test for deterministic pagination behavior.
 
+### 6.4 Apply the contextual byte limit to legacy requests
+
+Apply the new 16 KiB UTF-8 limit to every `gameData` object, including transient legacy submissions.
+
+**Rejected because**
+
+- It changes an existing API validation contract unrelated to persistence.
+- A code audit cannot prove an absolute upper bound for modified clients or future legacy callers.
+- HPA-484 can bound newly stored data without tightening existing transient achievement input.
+
 ## 7. Data Model
 
 Add nullable columns to `game_scores`:
@@ -144,7 +170,9 @@ ON game_scores (
 );
 ```
 
-The index intentionally omits `ruleset_version`: exact competitive callers such as Ice Slide Daily encode generator and ruleset identity into `competition_key`. A mode-only query is a generic platform primitive and may span multiple competition keys by explicit caller choice.
+Exact competitive callers such as Ice Slide Daily encode generator and ruleset identity into `competition_key`. `ruleset_version` is intentionally non-indexed and non-filtered in HPA-484; it is retained as audit/display metadata so stored attempts remain inspectable without making it a second source of competition identity. Version isolation is enforced through an exact `competition_key`, not through an implicit ruleset predicate.
+
+A mode-only query uses the `(game_id, mode)` prefix but cannot use this index to provide the complete score ordering because `competition_key` lies between `mode` and `score`. That path may require a temporary sort. This is accepted because the shipped Daily ranking path always supplies an exact key, while mode-only ranking is a generic, non-latency-critical primitive with no current UI consumer. A second index is deferred until query plans and measured production volume justify its write/storage cost; the design does not invent an unsupported row-volume estimate.
 
 Update Kysely types additively:
 
@@ -192,8 +220,11 @@ A request without `context`:
 - inserts `user_id`, `game_id`, and `score` through the existing unscoped path;
 - leaves all four context columns `NULL`;
 - may include `gameData` for transient achievement evaluation;
+- keeps the existing object-shape validation and does not add a new serialized-byte limit;
 - does not persist `gameData`;
 - runs the existing statistics, achievement, and challenge flows unchanged.
+
+"Unchanged" here covers both downstream behavior and the request contract: HPA-484 does not reject a legacy object solely because its serialized form exceeds the contextual storage limit.
 
 ### 8.2 Contextual submission
 
@@ -201,9 +232,10 @@ A request with `context`:
 
 - validates the complete context before any insert;
 - validates and serializes `gameData` when supplied;
+- requires serialized contextual `gameData` to fit the storage bound;
 - inserts mode, optional competition key, ruleset version, and serialized game data;
 - stores `NULL` in `game_data_json` when game data is omitted;
-- runs the same statistics, achievement, and challenge flows as a legacy submission.
+- runs the same existing aggregate-stat, favorite-game, achievement, and challenge side effects as a legacy submission.
 
 Context is never derived from `gameData`, and fields inside `gameData` never override explicit context.
 
@@ -217,12 +249,12 @@ Use a strict context schema and preserve the open, game-specific shape of `gameD
 | `competitionKey` | Optional; 1–128 characters; letters, digits, `:`, `.`, `_`, and `-` |
 | `rulesetVersion` | Required integer; `1..2_147_483_647` |
 | `context` | Strict object; unknown fields rejected |
-| `gameData` | Plain JSON object; arrays and primitives rejected |
-| serialized `gameData` | At most 16 KiB measured as UTF-8 bytes |
+| `gameData` | Preserve the current record/object validation; arrays and primitives remain rejected |
+| serialized contextual `gameData` | At most 16 KiB measured as UTF-8 bytes |
 
-The `gameData` object and byte-size validation applies to both legacy and contextual requests. This bounds the existing transient input as well as newly persisted JSON while preserving all current game-specific object shapes.
+The byte-size check runs only when `context` is present and `gameData` will be persisted. It must measure `TextEncoder().encode(serialized).byteLength` or an equivalent server-safe UTF-8 byte count, not JavaScript string length.
 
-Malformed JSON, invalid context, oversized data, and unknown context fields return `400` before inserting a score or updating statistics. A contextual validation failure is never retried as a legacy submission.
+Malformed request JSON, invalid context, oversized contextual data, and unknown context fields return `400` before inserting a score or updating statistics. A contextual validation failure is never retried as a legacy submission. An oversized legacy object remains subject to existing request/infrastructure limits but is not newly rejected by HPA-484's score schema.
 
 ## 9. Runtime Schema Compatibility
 
@@ -247,7 +279,7 @@ export interface GameScoresContextCapabilities {
 5. Cache concurrent callers behind one process-local promise.
 6. Record success only for capabilities that actually exist.
 7. Reset the shared promise when any required column migration is incomplete so a later request retries.
-8. Log index creation failure and retry it later without treating otherwise available contextual columns as absent.
+8. If only index creation fails, retain the column capabilities but leave the guard retryable until `scopedIndex=true`; do not permanently cache a performance-only failure.
 
 No path rebuilds or rewrites `game_scores`, and existing rows remain valid with `NULL` context.
 
@@ -283,6 +315,7 @@ Do not add unscoped predicates to:
 - recent and paginated score history;
 - user activity calendars;
 - aggregate total-score and activity statistics;
+- the existing stored `total_games_played`, `total_score`, and `favorite_game` update path;
 - games-played, unique-games, and total-score challenge queries;
 - submission-time score and in-game achievement checks;
 - existing daily-challenge progress updates.
@@ -291,7 +324,7 @@ A Daily or Expedition attempt is still a real platform play even when it belongs
 
 ### 10.3 Scoped best-per-user query
 
-Add a separate reusable query:
+Add a separate reusable query. The database-layer row may retain `userId` internally because partitioning and later authenticated-user matching require it, but that identifier must be stripped before producing a public API entry.
 
 ```ts
 export interface ScopedLeaderboardQuery {
@@ -301,30 +334,40 @@ export interface ScopedLeaderboardQuery {
     limit?: number
 }
 
-export interface ScopedLeaderboardEntry {
-    userId: string
+interface ScopedLeaderboardRow {
+    userId: string // internal only; never serialized publicly
     name: string
     username: string | null
     image: string | null
     score: number
-    createdAt: string
+    created_at: string
     mode: string
     competitionKey: string | null
     rulesetVersion: number | null
     elapsedSeconds: number | null
     totalMoves: number | null
 }
+
+export type ScopedLeaderboardEntry = Omit<ScopedLeaderboardRow, 'userId'>
 ```
 
-The query filters by exact `game_id` and `mode`; when `competitionKey` is supplied it also requires an exact `competition_key` match. A mode-only query intentionally spans keys in that mode.
+The query filters by exact `game_id` and `mode`; when `competitionKey` is supplied it also requires an exact `competition_key` match. A mode-only query intentionally spans keys and ruleset versions in that mode.
 
 Use a parameterized CTE with `ROW_NUMBER() OVER (PARTITION BY user_id ...)`. Apply `limit` only after selecting one row per user.
+
+The API mapping must remove `userId`. If HPA-488 needs authenticated-player highlighting, it should compare the internal row to the optional session server-side and expose a safe boolean such as `isCurrentUser`; it must not publish the Better Auth identifier.
 
 ### 10.4 Tie-break extraction
 
 The reusable query recognizes `elapsedSeconds` and `totalMoves` only when each stored value is a non-negative JSON integer. Missing, malformed, negative, non-integer, or otherwise invalid values become `NULL` for ranking and output.
 
-Guard every JSON extraction with `json_valid(game_data_json)` so a malformed historical or externally written row cannot abort the leaderboard query. JSON validity must be established before invoking path extraction or type inspection.
+Use staged CTEs:
+
+1. An initial CTE filters the requested scope and exposes `game_data_json` only when `json_valid(game_data_json)=1`; invalid JSON becomes `NULL`.
+2. A later CTE invokes `json_type`/`json_extract` only against the valid JSON value.
+3. The ranking CTE consumes the normalized nullable integers.
+
+Do not depend on SQL boolean-expression short-circuiting to protect JSON functions. A malformed historical or externally written row must never abort the leaderboard query.
 
 ### 10.5 Deterministic ranking order
 
@@ -346,18 +389,42 @@ The query keeps the existing player identity precedence:
 displayName -> username -> name -> "Anonymous"
 ```
 
+### 10.6 Public field naming
+
+Shared public leaderboard fields retain the existing contract exactly, including `created_at`. The scoped response does not rename that field to `createdAt`.
+
+New opt-in fields use the existing API's TypeScript-facing camelCase convention:
+
+```text
+mode
+competitionKey
+rulesetVersion
+elapsedSeconds
+totalMoves
+```
+
+This means consumers can reuse the existing rank/player/score/timestamp rendering and feature-detect only the additive scoped fields.
+
 ## 11. API Contracts
 
 ### 11.1 `POST /api/scores`
 
-- Existing request bodies without `context` remain valid.
+- Existing request bodies without `context` remain valid under the existing legacy validation contract.
+- The contextual byte limit does not apply to a request that omits `context`.
 - Contextual validation errors return `400` and insert nothing.
 - Missing contextual schema capability returns a server error and inserts nothing.
 - The success response shape remains unchanged.
-- Achievement and challenge processing receives the same `gameId`, score, and game-data inputs as before.
+- Aggregate stats, favorite-game assignment, achievement processing, and challenge processing receive the same `gameId`, score, and game-data inputs as before.
 - A contextual score is not semantically admitted to a game-specific ranked competition here; that validation belongs to the consuming game issue.
 
 ### 11.2 `GET /api/leaderboard`
+
+Replace the route's manual parameter parsing with one validation schema that models both existing and scoped forms. The schema must keep `gameId` optional for the all-games request, parse/default `limit`, validate `mode` and `competitionKey`, and enforce cross-field combinations with a refinement:
+
+- `mode` requires `gameId`;
+- `competitionKey` requires both `gameId` and `mode`.
+
+The route must call the shared `validateQuery()` helper or an equivalent single schema-validation entry point for all query parameters; it must not validate `limit` manually while handling scope parameters separately.
 
 | Query | Behavior |
 |---|---|
@@ -371,20 +438,21 @@ displayName -> username -> name -> "Anonymous"
 | scoped schema unavailable | server error |
 | scoped database query failure | server error, not an empty-success response |
 
-The existing unscoped response remains shape-compatible. The scoped response may add explicit `mode`, `competitionKey`, `elapsedSeconds`, and `totalMoves` fields because it is a new opt-in contract.
+The existing unscoped response remains shape-compatible. Scoped entries retain `created_at`, never expose `userId`, and add only `mode`, `competitionKey`, `rulesetVersion`, `elapsedSeconds`, and `totalMoves`.
 
 The legacy query may retain its current defensive empty-array behavior for compatibility. The new scoped query must preserve failure information so HPA-488 can distinguish an unavailable leaderboard from a legitimately empty competition.
 
 ## 12. Error Handling
 
-- Invalid or oversized request data fails before any database mutation.
+- Invalid context or oversized contextual data fails before any database mutation.
+- Legacy game-data objects retain their existing score-schema validation and are not subject to the new contextual byte cap.
 - A contextual migration failure is logged and surfaced; no unscoped substitute is written.
 - Legacy submissions continue with the original insert columns where possible.
 - A partial schema never causes a query to reference a missing column.
 - Malformed persisted JSON is treated as missing tie-break data rather than a query failure.
 - An unavailable scoped leaderboard is distinguishable from an empty scoped leaderboard.
-- Existing score, achievement, statistics, and challenge side-effect ordering is preserved; transactional redesign is outside this issue.
-- Database and validation errors must not expose serialized game data or secrets in client responses.
+- Existing score, aggregate-stat, favorite-game, achievement, and challenge side-effect ordering is preserved; transactional redesign is outside this issue.
+- Database and validation errors must not expose serialized game data, raw user IDs, or secrets in client responses.
 
 ## 13. Testing Strategy
 
@@ -393,11 +461,12 @@ Use mocked query tests for call boundaries and real in-memory LibSQL tests for s
 ### 13.1 Validation and client tests
 
 - Legacy payload without context remains valid.
+- A legacy object larger than 16 KiB remains accepted by the score schema, proving HPA-484 did not tighten the existing contract.
 - Contextual payload with and without game data is valid.
 - Mode, competition-key, and ruleset-version boundaries are covered.
 - Unknown context fields are rejected.
-- Arrays and primitives are rejected as game data.
-- Oversized ASCII and multibyte UTF-8 payloads are rejected by encoded byte size.
+- Arrays and primitives remain rejected as game data through the existing record/object validation.
+- Oversized contextual ASCII and multibyte UTF-8 payloads are rejected by encoded byte size.
 - Context is forwarded by `scoreService` without changing legacy request bodies.
 - Invalid context returns the existing client-facing invalid-score failure path.
 
@@ -405,7 +474,9 @@ Use mocked query tests for call boundaries and real in-memory LibSQL tests for s
 
 - Fresh initialization contains all four columns and the scoped index.
 - A legacy four-column table gains all columns without rewriting existing rows.
-- Every partial-column permutation needed for realistic interrupted migration completes correctly.
+- Unscoped fallback behavior covers the four meaningful scope-column states: neither `mode` nor `competition_key`, `mode` only, `competition_key` only, and both.
+- Representative interrupted states missing `ruleset_version` or `game_data_json` prove contextual operations fail and the next guard call completes migration.
+- Exhaustively testing all 16 column-presence permutations is not required because every state missing any contextual column has the same contextual fail/no-downgrade contract.
 - Repeated calls are idempotent.
 - Concurrent calls share one migration execution.
 - A failed column addition causes the next call to retry.
@@ -417,11 +488,13 @@ Use mocked query tests for call boundaries and real in-memory LibSQL tests for s
 
 - Legacy and contextual submissions round-trip the expected nullable columns.
 - Contextual game data is persisted exactly once; legacy game data remains transient.
+- Contextual submissions execute the existing aggregate-stat and favorite-game side effects.
 - Default game and all-games leaderboards exclude scoped rows.
 - Every personal-best function and compatibility alias excludes scoped rows.
 - Personal-best-derived achievement progress ignores scoped rows.
-- History, activity, aggregate statistics, and daily-challenge source queries include scoped rows.
+- History, activity, aggregate statistics, favorite-game updates, and daily-challenge source queries include scoped rows.
 - Mode and competition-key isolation are exact.
+- `ruleset_version` round-trips as metadata but is not an implicit filter or tie-break.
 - Each user appears at most once in scoped output.
 - A better retry replaces a worse retry in output while both remain stored.
 - Score, elapsed-time, move-count, submission-time, and row-ID tie-break levels are independently covered.
@@ -429,15 +502,20 @@ Use mocked query tests for call boundaries and real in-memory LibSQL tests for s
 - Malformed JSON does not abort the query.
 - `limit` is applied after best-per-user selection.
 - Player identity fallback behavior remains unchanged.
+- The internal row retains `userId` for server use, while the public mapping omits it.
+- Scoped and unscoped public entries both retain `created_at`.
 
 ### 13.4 API tests
 
 - Existing no-`gameId` and single-game unscoped responses remain shape-compatible.
+- The unified leaderboard query schema accepts the all-games path and rejects every invalid scope combination.
+- The route uses the unified validation result rather than separate manual parsing.
 - Scoped mode-only and exact-key requests return the new fields and ranks.
-- Invalid parameter combinations return `400`.
-- Contextual submission returns `400` with no insert for malformed or oversized input.
+- Scoped entries retain `created_at` and do not serialize `userId`.
+- Contextual submission returns `400` with no insert for malformed context or oversized contextual data.
+- Legacy oversized object data is not newly rejected by HPA-484.
 - Scoped schema/query failure returns a server error rather than an empty result.
-- Existing achievement and challenge update calls still occur after successful legacy and contextual submissions.
+- Existing aggregate-stat, favorite-game, achievement, and challenge update calls still occur after successful legacy and contextual submissions.
 
 End-to-end Daily UI coverage belongs to HPA-487 and HPA-488, not this backend foundation.
 
@@ -461,13 +539,13 @@ No Ice Slide runtime module should depend on unfinished HPA-487 data shapes in t
 
 ## 15. Delivery Sequence
 
-1. Add schema types, checked-in schema definitions, runtime capability guard, and migration tests.
-2. Add strict request context and game-data bounds.
-3. Extend score-service and insert paths while preserving existing side effects.
+1. Add schema types, checked-in schema definitions, runtime capability guard, and focused migration tests.
+2. Add strict request context and contextual game-data storage bounds without tightening legacy validation.
+3. Extend score-service and insert paths while preserving all existing aggregate-stat, favorite-game, achievement, and challenge side effects.
 4. Isolate default leaderboard and personal-best queries to unscoped rows.
-5. Add the scoped best-per-user LibSQL query and deterministic tie-break tests.
-6. Extend the leaderboard API with validated opt-in filters.
-7. Run compatibility tests across fresh, legacy, partial, and malformed-data fixtures.
+5. Add the scoped best-per-user LibSQL query, internal/public DTO boundary, and deterministic tie-break tests.
+6. Replace leaderboard manual parameter parsing with one schema and add validated opt-in filters.
+7. Run compatibility tests across fresh, legacy, representative partial, and malformed-data fixtures.
 
 This sequence keeps every intermediate change reviewable and prevents API work from landing before its storage/query invariants exist.
 
@@ -475,33 +553,45 @@ This sequence keeps every intermediate change reviewable and prevents API work f
 
 - Existing rows remain valid and no table is destructively rewritten.
 - Existing score callers require no changes.
-- Legacy `gameData` continues to power achievements without being persisted.
+- Legacy `gameData` keeps its existing validation contract, continues to power achievements, and is not persisted.
 - A contextual submission round-trips mode, optional key, ruleset version, and optional game data.
-- Invalid or oversized context/data returns `400` and inserts nothing.
+- Invalid context or oversized contextual data returns `400` and inserts nothing.
 - Default leaderboards, personal bests, and Campaign-oriented achievement progress exclude scoped rows.
-- History, activity, aggregate statistics, and current daily challenges include scoped rows.
+- History, activity, aggregate statistics, favorite-game updates, and current daily challenges include scoped rows.
 - Scoped output contains at most one row per user.
+- Scoped public output preserves `created_at` and never exposes raw `user_id`.
+- `ruleset_version` is returned as metadata but does not silently define ranking scope.
 - All documented tie-breaks are deterministic and covered against real LibSQL.
 - Missing or malformed tie-break JSON cannot crash the query.
-- Legacy, partial, and concurrent migration paths are covered.
+- Legacy, representative partial, concurrent, and index-retry migration paths are covered.
+- The leaderboard route enforces all parameter combinations through one validation schema.
 - Existing achievement and challenge updates remain intact.
 - HPA-487 and HPA-488 can consume the context and scoped-query primitives without adding Ice Slide rules to the shared database layer.
 
 ## 17. Resolved Decisions
 
 - Personal-best and achievement-progress queries use only unscoped rows.
-- Scoped rows still count as platform plays and daily-challenge activity.
+- Scoped rows still count as platform plays, aggregate-stat/favorite-game updates, and daily-challenge activity.
 - Context is explicit and separate from game data.
+- Legacy transient game data does not receive the new contextual 16 KiB storage bound.
 - Contextual data is never silently discarded or downgraded.
 - Mode-only scoped ranking is allowed as a reusable primitive; competitive Daily callers use an exact competition key.
-- JSON tie-breaks are guarded, nullable, and sorted after valid values.
+- The mode-only path may sort because no second index is justified without a measured consumer.
+- `ruleset_version` is audit/display metadata; exact competition keys provide version isolation.
+- JSON tie-breaks are staged, guarded, nullable, and sorted after valid values.
+- Public scoped output preserves `created_at` and strips raw user IDs.
+- The leaderboard route uses one schema for all-games, single-game, and scoped query forms.
 - The shared layer does not decide whether an Ice Slide Daily submission is solved or trustworthy.
+- The canonical parent requirements live in Linear; the closed GitHub documentation branch is not the durable citation.
 
 ## 18. Spec Self-Review
 
-- **Placeholder scan:** no TBD, TODO, or unresolved field bound remains.
+- **Placeholder scan:** no TBD, TODO, unresolved field bound, or invented production-volume target remains.
 - **Consistency:** Campaign competition is unscoped while platform activity includes all rows; every query family is assigned to one side of that boundary.
-- **Migration safety:** contextual operations require complete capability, while legacy behavior never references unavailable columns.
+- **Legacy compatibility:** the contextual persistence limit does not change the existing transient `gameData` request contract.
+- **Migration safety:** contextual operations require complete capability, while legacy behavior never references unavailable columns; index failure remains retryable.
 - **Determinism:** per-user selection and final ordering use the same complete sequence, including row ID as the final internal fallback.
-- **Scope:** the work remains a shared persistence/query foundation; Ice Slide gameplay, semantic admission, and UI remain in HPA-487/HPA-488.
-- **Ambiguity resolution:** malformed JSON sorts as missing data, mode-only queries intentionally span keys, and index failure affects performance rather than correctness.
+- **API surface:** existing shared fields retain their casing, new fields are additive, and raw auth identifiers remain private.
+- **Version semantics:** competition keys isolate versions; `ruleset_version` is explicit metadata rather than a hidden predicate.
+- **Scope:** the work remains a shared persistence/query foundation; Ice Slide gameplay, semantic admission, highlighting, and UI remain in HPA-487/HPA-488.
+- **Ambiguity resolution:** malformed JSON sorts as missing data, mode-only queries intentionally span keys, and the unified query schema models the all-games path.

--- a/docs/superpowers/specs/2026-07-31-versioned-score-context-design.md
+++ b/docs/superpowers/specs/2026-07-31-versioned-score-context-design.md
@@ -1,0 +1,507 @@
+# Versioned Game Score Context and Scoped Leaderboards — Design
+
+- **Date:** 2026-07-31
+- **Status:** Approved for implementation planning
+- **Repository:** `cwchanap/cetus`
+- **Linear issue:** [HPA-484 — Persist versioned game score context and add scoped leaderboard queries](https://linear.app/cwchanap/issue/HPA-484/persist-versioned-game-score-context-and-add-scoped-leaderboard)
+- **Parent design:** [Ice Slide replayability design](https://github.com/cwchanap/cetus/blob/docs/ice-slide-replayability-spec/docs/superpowers/specs/2026-07-30-ice-slide-replayability-design.md)
+
+## 1. Summary
+
+Cetus currently stores only `user_id`, `game_id`, `score`, and `created_at` for a game submission. Optional `gameData` reaches the score API and is used transiently for achievements, but it is not persisted. That model cannot isolate Campaign, Daily, Expedition, ruleset versions, or date-specific competitions without creating game-specific score tables or polluting existing leaderboards.
+
+This design adds optional, versioned score context to the shared `game_scores` table while preserving the existing unscoped path. Legacy submissions remain unscoped and continue to power Campaign leaderboards and personal-best semantics. Contextual submissions may persist bounded game data and participate in explicitly scoped, best-per-user leaderboard queries.
+
+The platform keeps a deliberate semantic split:
+
+- **Campaign-oriented competition and personal-best views** consider only unscoped rows.
+- **Platform activity, aggregate statistics, score history, and existing daily challenges** continue to count both unscoped and scoped submissions.
+- **Game-specific competitive admission**, such as requiring a solved Ice Slide Daily run with a matching run key, remains outside this generic persistence layer.
+
+## 2. Current State and Constraints
+
+The current implementation has these relevant properties:
+
+- `game_scores` has four meaningful columns: user, game, score, and timestamp.
+- `saveGameScoreWithAchievements()` first inserts the score, then evaluates score and in-game achievements from the submitted `gameData`.
+- The score API subsequently updates platform daily-challenge progress.
+- `getGameLeaderboard()` returns score rows directly, ordered by score descending; repeated attempts from one user may occupy multiple positions.
+- `/api/leaderboard` supports both a single-game response and an all-games response when `gameId` is omitted.
+- `getUserBestScore()` and compatibility aliases are reused by the personal-best API and achievement-progress calculations.
+- History, activity, aggregate-score, and challenge queries intentionally derive data from the complete `game_scores` activity stream.
+- The database layer already uses defensive, lazy, idempotent LibSQL migrations with process-local single-flight promises and retry after incomplete migration.
+- Database behavior is tested both through mocked Kysely chains and real in-memory LibSQL integration tests.
+
+The change must preserve those contracts unless this design explicitly narrows a query to unscoped rows.
+
+## 3. Goals
+
+1. Persist optional score mode, competition identity, ruleset version, and bounded game data.
+2. Keep every existing submission caller valid without modification.
+3. Keep historical and new Campaign scores comparable through the existing unscoped leaderboard.
+4. Prevent Daily and Expedition rows from changing Campaign leaderboards, personal bests, or Campaign-oriented achievement progress.
+5. Continue counting scoped submissions toward platform activity, aggregate statistics, history, and existing daily challenges.
+6. Provide a reusable scoped query that returns one deterministic best attempt per user.
+7. Migrate existing and partially migrated LibSQL schemas without table rebuilds or destructive rewrites.
+8. Make malformed stored JSON and partial migration states fail safely.
+9. Keep Ice Slide-specific completion and run-identity verification outside the shared score layer.
+
+## 4. Non-goals
+
+- Ice Slide mode selection, generation, objectives, or scoring.
+- Daily leaderboard presentation.
+- Server-authoritative replay, anti-cheat, or score recomputation.
+- Migrating existing games to contextual submissions.
+- Normalizing arbitrary game-specific data into dedicated columns.
+- Historical Daily navigation, seasonal leagues, or cross-seed Expedition ranking.
+- Redesigning the existing score-insert/stat-update transaction boundary.
+- Changing platform daily-challenge definitions or challenge rotation.
+
+## 5. Fixed Product and Platform Decisions
+
+| Decision | Requirement |
+|---|---|
+| Legacy path | A submission without `context` uses the current unscoped path. |
+| Context ownership | Context is an explicit sibling of `gameData`; it is never inferred from game data. |
+| Game-data persistence | `gameData` is persisted only for a validated contextual submission. |
+| Campaign ranking | Default/global leaderboards include only unscoped rows. |
+| Personal best | Existing best-score queries and Campaign-oriented achievement progress include only unscoped rows. |
+| Platform activity | Scoped rows still count toward history, activity, aggregates, and existing daily challenges. |
+| Scoped ranking | One best row per user, selected and ordered deterministically. |
+| Daily admission | Ice Slide-specific solved/run/version checks belong to HPA-488. |
+| Invalid context | Reject with `400`; never silently downgrade to an unscoped score. |
+| Missing schema | Legacy operations continue where possible; contextual operations fail explicitly. |
+
+## 6. Alternatives Considered
+
+### 6.1 Recommended: nullable context columns plus bounded JSON
+
+Add reusable scope/version columns and persist game-specific tie-break data as JSON. Use a LibSQL window query to select one best row per user.
+
+**Advantages**
+
+- Additive and compatible with all existing rows.
+- Reusable by multiple games and competition shapes.
+- Avoids schema changes for every game-specific metric.
+- Supports deterministic best-per-user selection in the database.
+
+**Costs**
+
+- Tie-break extraction requires guarded SQLite JSON functions.
+- Indexes optimize scope and score, but not arbitrary JSON metrics.
+
+### 6.2 Normalize elapsed time and moves into shared columns
+
+Add dedicated `elapsed_seconds` and `total_moves` columns alongside the context fields.
+
+**Advantages**
+
+- Simpler ranking SQL and stronger database typing.
+- Potentially indexable tie-break metrics.
+
+**Rejected because**
+
+- It overfits the shared score table to Ice Slide's first ranking contract.
+- Future games may require different secondary metrics.
+- The source design explicitly calls for persisted game data as the reusable extension.
+
+### 6.3 Fetch all attempts and deduplicate in application code
+
+Query scoped attempts, deserialize every payload, sort in TypeScript, and retain the best row per user.
+
+**Advantages**
+
+- Straightforward TypeScript implementation.
+- No window-function SQL.
+
+**Rejected because**
+
+- Work and memory grow with all historical attempts.
+- Applying `limit` before deduplication produces incorrect rankings.
+- It moves a relational ranking problem out of the database and is harder to test for deterministic pagination behavior.
+
+## 7. Data Model
+
+Add nullable columns to `game_scores`:
+
+```sql
+mode TEXT NULL,
+competition_key TEXT NULL,
+ruleset_version INTEGER NULL,
+game_data_json TEXT NULL
+```
+
+Add the scoped ranking index:
+
+```sql
+CREATE INDEX IF NOT EXISTS idx_game_scores_scoped_ranking
+ON game_scores (
+    game_id,
+    mode,
+    competition_key,
+    score DESC,
+    created_at ASC
+);
+```
+
+The index intentionally omits `ruleset_version`: exact competitive callers such as Ice Slide Daily encode generator and ruleset identity into `competition_key`. A mode-only query is a generic platform primitive and may span multiple competition keys by explicit caller choice.
+
+Update Kysely types additively:
+
+```ts
+export interface GameScoresTable {
+    id: ColumnType<number, never, never>
+    user_id: string
+    game_id: string
+    score: number
+    mode: string | null
+    competition_key: string | null
+    ruleset_version: number | null
+    game_data_json: string | null
+    created_at: ColumnType<Date, never, never>
+}
+```
+
+`GameScore` therefore includes the new nullable fields. Existing public history DTOs retain their current response shapes unless a later issue explicitly exposes context.
+
+Both checked-in schema/bootstrap definitions that create `game_scores` must include the new nullable columns and index. Existing databases rely on the runtime compatibility guard described below.
+
+## 8. Submission Contract
+
+Extend the client and server request shape with an optional strict context object:
+
+```ts
+export interface ScoreSubmissionContext {
+    mode: string
+    competitionKey?: string
+    rulesetVersion: number
+}
+
+export interface ScoreData {
+    gameId: GameType
+    score: number
+    gameData?: GameData | Record<string, unknown>
+    context?: ScoreSubmissionContext
+}
+```
+
+### 8.1 Legacy submission
+
+A request without `context`:
+
+- inserts `user_id`, `game_id`, and `score` through the existing unscoped path;
+- leaves all four context columns `NULL`;
+- may include `gameData` for transient achievement evaluation;
+- does not persist `gameData`;
+- runs the existing statistics, achievement, and challenge flows unchanged.
+
+### 8.2 Contextual submission
+
+A request with `context`:
+
+- validates the complete context before any insert;
+- validates and serializes `gameData` when supplied;
+- inserts mode, optional competition key, ruleset version, and serialized game data;
+- stores `NULL` in `game_data_json` when game data is omitted;
+- runs the same statistics, achievement, and challenge flows as a legacy submission.
+
+Context is never derived from `gameData`, and fields inside `gameData` never override explicit context.
+
+### 8.3 Validation
+
+Use a strict context schema and preserve the open, game-specific shape of `gameData`.
+
+| Field | Validation |
+|---|---|
+| `mode` | Required in context; 1–32 characters; `[a-z][a-z0-9_-]*` |
+| `competitionKey` | Optional; 1–128 characters; letters, digits, `:`, `.`, `_`, and `-` |
+| `rulesetVersion` | Required integer; `1..2_147_483_647` |
+| `context` | Strict object; unknown fields rejected |
+| `gameData` | Plain JSON object; arrays and primitives rejected |
+| serialized `gameData` | At most 16 KiB measured as UTF-8 bytes |
+
+The `gameData` object and byte-size validation applies to both legacy and contextual requests. This bounds the existing transient input as well as newly persisted JSON while preserving all current game-specific object shapes.
+
+Malformed JSON, invalid context, oversized data, and unknown context fields return `400` before inserting a score or updating statistics. A contextual validation failure is never retried as a legacy submission.
+
+## 9. Runtime Schema Compatibility
+
+Introduce a focused, lazy `ensureGameScoresContextSchema()` guard independent of `ensureUserStatsSchema()`.
+
+```ts
+export interface GameScoresContextCapabilities {
+    mode: boolean
+    competitionKey: boolean
+    rulesetVersion: boolean
+    gameDataJson: boolean
+    scopedIndex: boolean
+}
+```
+
+### 9.1 Migration behavior
+
+1. Inspect `PRAGMA table_info(game_scores)`.
+2. Add each missing nullable column independently with `ALTER TABLE`.
+3. Re-inspect or update known capabilities after each successful addition.
+4. Create the scoped index only after all four columns exist.
+5. Cache concurrent callers behind one process-local promise.
+6. Record success only for capabilities that actually exist.
+7. Reset the shared promise when any required column migration is incomplete so a later request retries.
+8. Log index creation failure and retry it later without treating otherwise available contextual columns as absent.
+
+No path rebuilds or rewrites `game_scores`, and existing rows remain valid with `NULL` context.
+
+### 9.2 Capability-dependent behavior
+
+- Contextual inserts require all four columns. If any are unavailable, return a server error and do not insert an unscoped replacement.
+- Scoped reads require all four columns. Missing capability is an explicit server failure, not an empty leaderboard or unscoped fallback.
+- Legacy inserts use the original column set and remain available when the context migration is incomplete.
+- Default unscoped reads apply every available isolation predicate:
+  - when both scope columns exist: `mode IS NULL AND competition_key IS NULL`;
+  - when only one exists after a partial migration: filter on the available column;
+  - when neither exists on a legacy schema: all existing rows are necessarily treated as unscoped.
+- An index failure affects performance only. Contextual reads and writes remain valid when the four columns exist.
+
+This fallback is deliberately asymmetric: legacy behavior degrades gracefully, while requested contextual behavior never loses scope silently.
+
+## 10. Query Semantics
+
+### 10.1 Existing unscoped queries
+
+Keep explicit legacy functions rather than introducing a single highly conditional query.
+
+`getGameLeaderboard(gameId, limit)` adds unscoped predicates when available and retains its current public result shape and score-descending behavior.
+
+Every existing function that answers a user's best score for a game, including compatibility aliases and `/api/scores/best`, uses the same unscoped predicate. Personal-best-derived achievement progress therefore remains Campaign-compatible.
+
+The all-games leaderboard endpoint continues to call the unscoped query for every registered game.
+
+### 10.2 Queries that intentionally include scoped rows
+
+Do not add unscoped predicates to:
+
+- recent and paginated score history;
+- user activity calendars;
+- aggregate total-score and activity statistics;
+- games-played, unique-games, and total-score challenge queries;
+- submission-time score and in-game achievement checks;
+- existing daily-challenge progress updates.
+
+A Daily or Expedition attempt is still a real platform play even when it belongs to a separate competitive scope.
+
+### 10.3 Scoped best-per-user query
+
+Add a separate reusable query:
+
+```ts
+export interface ScopedLeaderboardQuery {
+    gameId: string
+    mode: string
+    competitionKey?: string
+    limit?: number
+}
+
+export interface ScopedLeaderboardEntry {
+    userId: string
+    name: string
+    username: string | null
+    image: string | null
+    score: number
+    createdAt: string
+    mode: string
+    competitionKey: string | null
+    rulesetVersion: number | null
+    elapsedSeconds: number | null
+    totalMoves: number | null
+}
+```
+
+The query filters by exact `game_id` and `mode`; when `competitionKey` is supplied it also requires an exact `competition_key` match. A mode-only query intentionally spans keys in that mode.
+
+Use a parameterized CTE with `ROW_NUMBER() OVER (PARTITION BY user_id ...)`. Apply `limit` only after selecting one row per user.
+
+### 10.4 Tie-break extraction
+
+The reusable query recognizes `elapsedSeconds` and `totalMoves` only when each stored value is a non-negative JSON integer. Missing, malformed, negative, non-integer, or otherwise invalid values become `NULL` for ranking and output.
+
+Guard every JSON extraction with `json_valid(game_data_json)` so a malformed historical or externally written row cannot abort the leaderboard query. JSON validity must be established before invoking path extraction or type inspection.
+
+### 10.5 Deterministic ranking order
+
+Use the same order when selecting a user's best attempt and when ordering the final best-per-user leaderboard:
+
+1. `score DESC`
+2. valid elapsed time before missing/invalid elapsed time
+3. `elapsedSeconds ASC`
+4. valid move count before missing/invalid move count
+5. `totalMoves ASC`
+6. `created_at ASC`
+7. `id ASC`
+
+The row ID is an internal final determinant for equal timestamps. It does not replace or reorder the documented product tie-breaks.
+
+The query keeps the existing player identity precedence:
+
+```text
+displayName -> username -> name -> "Anonymous"
+```
+
+## 11. API Contracts
+
+### 11.1 `POST /api/scores`
+
+- Existing request bodies without `context` remain valid.
+- Contextual validation errors return `400` and insert nothing.
+- Missing contextual schema capability returns a server error and inserts nothing.
+- The success response shape remains unchanged.
+- Achievement and challenge processing receives the same `gameId`, score, and game-data inputs as before.
+- A contextual score is not semantically admitted to a game-specific ranked competition here; that validation belongs to the consuming game issue.
+
+### 11.2 `GET /api/leaderboard`
+
+| Query | Behavior |
+|---|---|
+| no scope parameters | Preserve current unscoped behavior |
+| `gameId` only | Preserve current single-game unscoped response |
+| `gameId` + `mode` | Return scoped best-per-user results for that mode |
+| `gameId` + `mode` + `competitionKey` | Return exact scoped competition results |
+| `competitionKey` without `mode` | `400` |
+| scope parameter without `gameId` | `400` |
+| invalid game, limit, mode, or key | `400` |
+| scoped schema unavailable | server error |
+| scoped database query failure | server error, not an empty-success response |
+
+The existing unscoped response remains shape-compatible. The scoped response may add explicit `mode`, `competitionKey`, `elapsedSeconds`, and `totalMoves` fields because it is a new opt-in contract.
+
+The legacy query may retain its current defensive empty-array behavior for compatibility. The new scoped query must preserve failure information so HPA-488 can distinguish an unavailable leaderboard from a legitimately empty competition.
+
+## 12. Error Handling
+
+- Invalid or oversized request data fails before any database mutation.
+- A contextual migration failure is logged and surfaced; no unscoped substitute is written.
+- Legacy submissions continue with the original insert columns where possible.
+- A partial schema never causes a query to reference a missing column.
+- Malformed persisted JSON is treated as missing tie-break data rather than a query failure.
+- An unavailable scoped leaderboard is distinguishable from an empty scoped leaderboard.
+- Existing score, achievement, statistics, and challenge side-effect ordering is preserved; transactional redesign is outside this issue.
+- Database and validation errors must not expose serialized game data or secrets in client responses.
+
+## 13. Testing Strategy
+
+Use mocked query tests for call boundaries and real in-memory LibSQL tests for schema and ranking behavior.
+
+### 13.1 Validation and client tests
+
+- Legacy payload without context remains valid.
+- Contextual payload with and without game data is valid.
+- Mode, competition-key, and ruleset-version boundaries are covered.
+- Unknown context fields are rejected.
+- Arrays and primitives are rejected as game data.
+- Oversized ASCII and multibyte UTF-8 payloads are rejected by encoded byte size.
+- Context is forwarded by `scoreService` without changing legacy request bodies.
+- Invalid context returns the existing client-facing invalid-score failure path.
+
+### 13.2 Migration tests
+
+- Fresh initialization contains all four columns and the scoped index.
+- A legacy four-column table gains all columns without rewriting existing rows.
+- Every partial-column permutation needed for realistic interrupted migration completes correctly.
+- Repeated calls are idempotent.
+- Concurrent calls share one migration execution.
+- A failed column addition causes the next call to retry.
+- Index creation failure leaves column capabilities available and retries later.
+- Legacy inserts and default reads remain functional during incomplete migration.
+- Contextual operations fail rather than downgrade when schema capability is incomplete.
+
+### 13.3 Real LibSQL query tests
+
+- Legacy and contextual submissions round-trip the expected nullable columns.
+- Contextual game data is persisted exactly once; legacy game data remains transient.
+- Default game and all-games leaderboards exclude scoped rows.
+- Every personal-best function and compatibility alias excludes scoped rows.
+- Personal-best-derived achievement progress ignores scoped rows.
+- History, activity, aggregate statistics, and daily-challenge source queries include scoped rows.
+- Mode and competition-key isolation are exact.
+- Each user appears at most once in scoped output.
+- A better retry replaces a worse retry in output while both remain stored.
+- Score, elapsed-time, move-count, submission-time, and row-ID tie-break levels are independently covered.
+- Valid tie-break values sort before missing or invalid values.
+- Malformed JSON does not abort the query.
+- `limit` is applied after best-per-user selection.
+- Player identity fallback behavior remains unchanged.
+
+### 13.4 API tests
+
+- Existing no-`gameId` and single-game unscoped responses remain shape-compatible.
+- Scoped mode-only and exact-key requests return the new fields and ranks.
+- Invalid parameter combinations return `400`.
+- Contextual submission returns `400` with no insert for malformed or oversized input.
+- Scoped schema/query failure returns a server error rather than an empty result.
+- Existing achievement and challenge update calls still occur after successful legacy and contextual submissions.
+
+End-to-end Daily UI coverage belongs to HPA-487 and HPA-488, not this backend foundation.
+
+## 14. Implementation Boundaries
+
+Likely touched areas are intentionally limited to:
+
+```text
+scripts/init-db.sql
+better-auth_migrations/...
+src/lib/server/db/types.ts
+src/lib/server/db/queries.ts
+src/lib/server/validations.ts
+src/lib/services/scoreService.ts
+src/pages/api/scores.ts
+src/pages/api/leaderboard.ts
+focused unit, API, migration, legacy-schema, and LibSQL integration tests
+```
+
+No Ice Slide runtime module should depend on unfinished HPA-487 data shapes in this issue. The platform contract must be usable independently by later games.
+
+## 15. Delivery Sequence
+
+1. Add schema types, checked-in schema definitions, runtime capability guard, and migration tests.
+2. Add strict request context and game-data bounds.
+3. Extend score-service and insert paths while preserving existing side effects.
+4. Isolate default leaderboard and personal-best queries to unscoped rows.
+5. Add the scoped best-per-user LibSQL query and deterministic tie-break tests.
+6. Extend the leaderboard API with validated opt-in filters.
+7. Run compatibility tests across fresh, legacy, partial, and malformed-data fixtures.
+
+This sequence keeps every intermediate change reviewable and prevents API work from landing before its storage/query invariants exist.
+
+## 16. Acceptance Criteria
+
+- Existing rows remain valid and no table is destructively rewritten.
+- Existing score callers require no changes.
+- Legacy `gameData` continues to power achievements without being persisted.
+- A contextual submission round-trips mode, optional key, ruleset version, and optional game data.
+- Invalid or oversized context/data returns `400` and inserts nothing.
+- Default leaderboards, personal bests, and Campaign-oriented achievement progress exclude scoped rows.
+- History, activity, aggregate statistics, and current daily challenges include scoped rows.
+- Scoped output contains at most one row per user.
+- All documented tie-breaks are deterministic and covered against real LibSQL.
+- Missing or malformed tie-break JSON cannot crash the query.
+- Legacy, partial, and concurrent migration paths are covered.
+- Existing achievement and challenge updates remain intact.
+- HPA-487 and HPA-488 can consume the context and scoped-query primitives without adding Ice Slide rules to the shared database layer.
+
+## 17. Resolved Decisions
+
+- Personal-best and achievement-progress queries use only unscoped rows.
+- Scoped rows still count as platform plays and daily-challenge activity.
+- Context is explicit and separate from game data.
+- Contextual data is never silently discarded or downgraded.
+- Mode-only scoped ranking is allowed as a reusable primitive; competitive Daily callers use an exact competition key.
+- JSON tie-breaks are guarded, nullable, and sorted after valid values.
+- The shared layer does not decide whether an Ice Slide Daily submission is solved or trustworthy.
+
+## 18. Spec Self-Review
+
+- **Placeholder scan:** no TBD, TODO, or unresolved field bound remains.
+- **Consistency:** Campaign competition is unscoped while platform activity includes all rows; every query family is assigned to one side of that boundary.
+- **Migration safety:** contextual operations require complete capability, while legacy behavior never references unavailable columns.
+- **Determinism:** per-user selection and final ordering use the same complete sequence, including row ID as the final internal fallback.
+- **Scope:** the work remains a shared persistence/query foundation; Ice Slide gameplay, semantic admission, and UI remain in HPA-487/HPA-488.
+- **Ambiguity resolution:** malformed JSON sorts as missing data, mode-only queries intentionally span keys, and index failure affects performance rather than correctness.

--- a/docs/superpowers/specs/2026-07-31-versioned-score-context-design.md
+++ b/docs/superpowers/specs/2026-07-31-versioned-score-context-design.md
@@ -14,7 +14,8 @@ This design adds optional, versioned score context to the shared `game_scores` t
 
 The platform keeps a deliberate semantic split:
 
-- **Campaign-oriented competition and personal-best views** consider only unscoped rows.
+- **Campaign-oriented competition and best-score-derived progress** consider only unscoped rows.
+- **Achievement awarding at submission time** still evaluates every successful legacy or contextual play against the submitted score and `gameData`.
 - **Platform activity, aggregate statistics, score history, and existing daily challenges** continue to count both unscoped and scoped submissions.
 - **Game-specific competitive admission**, such as requiring a solved Ice Slide Daily run with a matching run key, remains outside this generic persistence layer.
 
@@ -23,69 +24,78 @@ The platform keeps a deliberate semantic split:
 The current implementation has these relevant properties:
 
 - `game_scores` has four meaningful columns: user, game, score, and timestamp.
-- `saveGameScoreWithAchievements()` first inserts the score, then evaluates score and in-game achievements from the submitted `gameData`.
+- `saveGameScoreWithAchievements()` calls the single `saveGameScore()` write path, then evaluates score-threshold and in-game achievements from the submitted score and transient `gameData`.
 - The score API subsequently updates platform daily-challenge progress.
 - `getGameLeaderboard()` returns score rows directly, ordered by score descending; repeated attempts from one user may occupy multiple positions.
 - `/api/leaderboard` supports both a single-game response and an all-games response when `gameId` is omitted.
 - The leaderboard route currently parses query parameters manually. The existing `leaderboardQuerySchema` requires `gameId` and therefore does not model the route's all-games path.
 - `getUserBestScore()` and compatibility aliases are reused by the personal-best API and achievement-progress calculations.
 - History, activity, aggregate-score, and challenge queries intentionally derive data from the complete `game_scores` activity stream.
-- Each score updates the existing aggregate-stat side effects, including total score and favorite-game assignment.
+- Each score updates existing aggregate-stat side effects, including total score and favorite-game assignment.
+- Public history queries select explicit fields, but the internal `GameScore` type and `getUserRecentScores().selectAll()` will widen after the schema change; public boundaries must not pass those rows through.
 - The database layer already uses defensive, lazy, idempotent LibSQL migrations with process-local single-flight promises and retry after incomplete migration.
 - Database behavior is tested both through mocked Kysely chains and real in-memory LibSQL integration tests.
 - The current score schema already requires `gameData` to be an object through Zod's record schema, but it does not impose a serialized-byte limit.
+- Repository search finds two non-test schema creation surfaces for `game_scores`: `scripts/init-db.sql` and `better-auth_migrations/2025-07-06-schema-consolidation.sql`. Other matches are historical documentation or test fixtures.
 
-The change must preserve those contracts unless this design explicitly narrows a query to unscoped rows.
+The change must preserve those contracts unless this design explicitly changes them.
 
 ### 2.1 Existing game-data size audit
 
 Current game-owned payloads are JSON objects and are generally compact. Most contain only scalar counters. Reflex is the largest naturally bounded payload: it records `gameHistory`, but the default game lasts 60 seconds and spawns at one-second intervals. Word Scramble records a list of correct words during a 60-second game, but neither its client logic nor the public score API provides a universal server-enforced upper bound on the number of entries a modified client could submit.
 
-Therefore, repository inspection cannot prove that every valid legacy request is below an arbitrary new 16 KiB threshold. To preserve the existing contract rather than rely on normal-play assumptions, the byte-size limit introduced by this design applies only when `gameData` will be persisted as part of a contextual submission. Legacy transient `gameData` keeps its existing validation behavior.
+Therefore, repository inspection cannot prove that every valid legacy request is below an arbitrary new 16 KiB threshold. The byte-size limit introduced by this design applies only when `gameData` will be persisted as part of a contextual submission. Legacy transient `gameData` keeps its existing validation behavior.
 
 ## 3. Goals
 
-1. Persist optional score mode, competition identity, ruleset version, and bounded contextual game data.
+1. Persist optional score mode, competition identity, required audit version, and bounded contextual game data.
 2. Keep every existing submission caller valid without modification.
 3. Keep historical and new Campaign scores comparable through the existing unscoped leaderboard.
-4. Prevent Daily and Expedition rows from changing Campaign leaderboards, personal bests, or Campaign-oriented achievement progress.
-5. Continue counting scoped submissions toward platform activity, aggregate statistics, history, and existing daily challenges.
-6. Provide a reusable scoped query that returns one deterministic best attempt per user.
-7. Migrate existing and partially migrated LibSQL schemas without table rebuilds or destructive rewrites.
-8. Make malformed stored JSON and partial migration states fail safely.
-9. Keep raw authentication identifiers out of public leaderboard responses.
-10. Keep Ice Slide-specific completion and run-identity verification outside the shared score layer.
+4. Prevent Daily and Expedition rows from changing Campaign leaderboards, personal bests, or best-score-derived Campaign progress.
+5. Keep current achievement awarding behavior for contextual submissions unless a game-specific issue explicitly opts out.
+6. Continue counting scoped submissions toward platform activity, aggregate statistics, history, favorite-game updates, and existing daily challenges.
+7. Provide a reusable scoped query that returns one deterministic best attempt per user.
+8. Migrate existing and partially migrated LibSQL schemas without table rebuilds or destructive rewrites.
+9. Make malformed stored JSON and partial migration states fail safely.
+10. Keep raw authentication identifiers and stored game JSON out of public API responses.
+11. Keep Ice Slide-specific completion and run-identity verification outside the shared score layer.
 
 ## 4. Non-goals
 
 - Ice Slide mode selection, generation, objectives, or scoring.
-- Daily leaderboard presentation.
+- Daily leaderboard presentation or current-user highlighting.
 - Server-authoritative replay, anti-cheat, or score recomputation.
 - Migrating existing games to contextual submissions.
 - Normalizing arbitrary game-specific data into dedicated columns.
+- Creating a generic ranking expression language for arbitrary future metrics.
 - Historical Daily navigation, seasonal leagues, or cross-seed Expedition ranking.
 - Redesigning the existing score-insert/stat-update transaction boundary.
 - Changing platform daily-challenge definitions or challenge rotation.
 - Publishing Better Auth user IDs for leaderboard highlighting or profile navigation.
 - Adding a second mode-only ranking index before a measured use case requires it.
+- Introducing Campaign-only achievement rules into the shared score layer.
 
 ## 5. Fixed Product and Platform Decisions
 
 | Decision | Requirement |
 |---|---|
 | Legacy path | A submission without `context` uses the current unscoped path and existing input-validation contract. |
+| Context presence | `context` is omit-only: omitted means legacy; `null` is invalid. |
 | Context ownership | Context is an explicit sibling of `gameData`; it is never inferred from game data. |
 | Game-data persistence | `gameData` is persisted only for a validated contextual submission. |
 | Contextual data bound | The 16 KiB serialized limit applies only to contextual game data that may be stored. |
 | Campaign ranking | Default/global leaderboards include only unscoped rows. |
-| Personal best | Existing best-score queries and Campaign-oriented achievement progress include only unscoped rows. |
+| Personal best | Existing best-score queries and best-score-derived Campaign progress include only unscoped rows. |
+| Achievement awarding | Scoped submissions still run score-threshold and in-game achievement checks against the submitted score and `gameData`. |
 | Platform activity | Scoped rows still count toward history, activity, aggregates, favorite-game updates, and existing daily challenges. |
-| Scoped ranking | One best row per user, selected and ordered deterministically. |
+| Unscoped ranking | Existing leaderboards remain raw-attempt lists; one user may appear multiple times. |
+| Scoped ranking | Scoped leaderboards return one deterministic best row per user. |
 | Public identity | Public scoped output exposes display identity but never raw `user_id`. |
-| Ruleset column | `ruleset_version` is audit/display metadata, not a ranking predicate or tie-break. |
+| Ruleset column | `ruleset_version` is required audit/display metadata, not a ranking predicate or tie-break. |
+| Tie-break projection | `elapsedSeconds` and `totalMoves` are the v1 allowlisted metrics; other game metrics remain in stored JSON. |
 | Daily admission | Ice Slide-specific solved/run/version checks belong to HPA-488. |
 | Invalid context | Reject with `400`; never silently downgrade to an unscoped score. |
-| Missing schema | Legacy operations continue where possible; contextual operations fail explicitly. |
+| Missing schema | Legacy operations continue where possible; contextual operations fail explicitly with `500`. |
 
 ## 6. Alternatives Considered
 
@@ -104,47 +114,23 @@ Add reusable scope/version columns and persist game-specific tie-break data as J
 
 - Tie-break extraction requires guarded SQLite JSON functions.
 - The exact-key index does not fully order mode-only queries.
-- Indexes optimize scope and score, but not arbitrary JSON metrics.
+- The public v1 projection recognizes only two metric keys.
 
 ### 6.2 Normalize elapsed time and moves into shared columns
 
-Add dedicated `elapsed_seconds` and `total_moves` columns alongside the context fields.
-
-**Advantages**
-
-- Simpler ranking SQL and stronger database typing.
-- Potentially indexable tie-break metrics.
-
-**Rejected because**
-
-- It overfits the shared score table to Ice Slide's first ranking contract.
-- Future games may require different secondary metrics.
-- The source design explicitly calls for persisted game data as the reusable extension.
+Rejected because it overfits the shared score table to Ice Slide's first ranking contract and makes every future ranking metric a schema decision.
 
 ### 6.3 Fetch all attempts and deduplicate in application code
 
-Query scoped attempts, deserialize every payload, sort in TypeScript, and retain the best row per user.
-
-**Advantages**
-
-- Straightforward TypeScript implementation.
-- No window-function SQL.
-
-**Rejected because**
-
-- Work and memory grow with all historical attempts.
-- Applying `limit` before deduplication produces incorrect rankings.
-- It moves a relational ranking problem out of the database and is harder to test for deterministic pagination behavior.
+Rejected because work and memory grow with historical attempts, applying `limit` before deduplication is incorrect, and relational ranking belongs in the database.
 
 ### 6.4 Apply the contextual byte limit to legacy requests
 
-Apply the new 16 KiB UTF-8 limit to every `gameData` object, including transient legacy submissions.
+Rejected because it changes an existing API validation contract unrelated to persistence and repository inspection cannot prove an absolute upper bound for modified clients or future legacy callers.
 
-**Rejected because**
+### 6.5 Publish raw user IDs for highlighting
 
-- It changes an existing API validation contract unrelated to persistence.
-- A code audit cannot prove an absolute upper bound for modified clients or future legacy callers.
-- HPA-484 can bound newly stored data without tightening existing transient achievement input.
+Rejected because HPA-488 can compare an internal row to the authenticated session server-side and expose `isCurrentUser` without publishing Better Auth identifiers.
 
 ## 7. Data Model
 
@@ -157,7 +143,7 @@ ruleset_version INTEGER NULL,
 game_data_json TEXT NULL
 ```
 
-Add the scoped ranking index:
+Add the scoped filtering index:
 
 ```sql
 CREATE INDEX IF NOT EXISTS idx_game_scores_scoped_ranking
@@ -170,9 +156,11 @@ ON game_scores (
 );
 ```
 
-Exact competitive callers such as Ice Slide Daily encode generator and ruleset identity into `competition_key`. `ruleset_version` is intentionally non-indexed and non-filtered in HPA-484; it is retained as audit/display metadata so stored attempts remain inspectable without making it a second source of competition identity. Version isolation is enforced through an exact `competition_key`, not through an implicit ruleset predicate.
+Exact competitive callers such as Ice Slide Daily encode generator and ruleset identity into `competition_key`. `ruleset_version` is intentionally non-indexed and non-filtered in HPA-484; it is required so every contextual row records explicit audit/version metadata independently of key parsing. Version isolation is enforced through an exact `competition_key`, not through an implicit ruleset predicate.
 
-A mode-only query uses the `(game_id, mode)` prefix but cannot use this index to provide the complete score ordering because `competition_key` lies between `mode` and `score`. That path may require a temporary sort. This is accepted because the shipped Daily ranking path always supplies an exact key, while mode-only ranking is a generic, non-latency-critical primitive with no current UI consumer. A second index is deferred until query plans and measured production volume justify its write/storage cost; the design does not invent an unsupported row-volume estimate.
+The index is a scope-filter/prefix helper, not a covering representation of the complete ranking order. JSON-derived elapsed time and moves plus row ID are absent from the index. Implementations must filter the candidate scope and then apply the authoritative window ordering; they must not assume an index scan already satisfies ranking.
+
+A mode-only query uses the `(game_id, mode)` prefix but cannot use this index to provide the complete score ordering because `competition_key` lies between `mode` and `score`. That path may require a temporary sort. This is accepted because the shipped Daily ranking path always supplies an exact key, while mode-only ranking is a generic, non-latency-critical primitive with no current UI consumer. A second index is deferred until query plans and measured production volume justify its write/storage cost.
 
 Update Kysely types additively:
 
@@ -190,13 +178,15 @@ export interface GameScoresTable {
 }
 ```
 
-`GameScore` therefore includes the new nullable fields. Existing public history DTOs retain their current response shapes unless a later issue explicitly exposes context.
+`GameScore` therefore includes the new nullable fields for internal database use. Public history and activity DTOs remain explicitly defined projections and never expose `mode`, `competition_key`, `ruleset_version`, or `game_data_json` unless a later issue deliberately changes that contract.
 
-Both checked-in schema/bootstrap definitions that create `game_scores` must include the new nullable columns and index. Existing databases rely on the runtime compatibility guard described below.
+Both non-test schema/bootstrap definitions that create `game_scores`—`scripts/init-db.sql` and `better-auth_migrations/2025-07-06-schema-consolidation.sql`—must include the new nullable columns and index. Existing databases rely on the runtime compatibility guard.
 
-## 8. Submission Contract
+## 8. Submission and Write Contracts
 
-Extend the client and server request shape with an optional strict context object:
+### 8.1 Client request shape
+
+Extend the object request shape:
 
 ```ts
 export interface ScoreSubmissionContext {
@@ -213,20 +203,61 @@ export interface ScoreData {
 }
 ```
 
-### 8.1 Legacy submission
+`submitScore(scoreData)` remains the canonical object-based transport call.
+
+The existing client `saveGameScore(gameId, score, onSuccess, onError, gameData, options)` helper must not gain another positional argument. Extend its existing options bag instead:
+
+```ts
+export interface SaveScoreOptions {
+    isStale?: () => boolean
+    context?: ScoreSubmissionContext
+}
+```
+
+The helper forwards `options.context` through `ScoreData`. Existing callers that omit it produce byte-equivalent request bodies.
+
+### 8.2 Single server write path
+
+Keep one database score-write function and one side-effect pipeline:
+
+```ts
+export interface PersistedScoreContext {
+    mode: string
+    competitionKey: string | null
+    rulesetVersion: number
+    gameDataJson: string | null
+}
+
+export async function saveGameScore(
+    userId: string,
+    gameId: string,
+    score: number,
+    context?: PersistedScoreContext
+): Promise<boolean>
+```
+
+Requirements:
+
+- The optional structured argument controls only additional inserted columns.
+- A contextual call checks complete schema capability before insertion.
+- Legacy calls insert the original columns and do not require the contextual schema.
+- Both paths continue through the same existing `getUserStats()` / `upsertUserStats()` update block.
+- `saveGameScoreWithAchievements()` delegates exactly once to this function, then executes the same score-threshold and in-game achievement checks.
+- Do not create a second contextual insert function with duplicated statistics or favorite-game behavior.
+- Serialization and validation happen before entering the write function; it receives normalized values only.
+
+### 8.3 Legacy submission
 
 A request without `context`:
 
-- inserts `user_id`, `game_id`, and `score` through the existing unscoped path;
+- inserts `user_id`, `game_id`, and `score` through the existing path;
 - leaves all four context columns `NULL`;
 - may include `gameData` for transient achievement evaluation;
-- keeps the existing object-shape validation and does not add a new serialized-byte limit;
+- keeps the existing object-shape validation and does not add a serialized-byte limit;
 - does not persist `gameData`;
-- runs the existing statistics, achievement, and challenge flows unchanged.
+- runs existing aggregate-stat, favorite-game, achievement, and challenge flows unchanged.
 
-"Unchanged" here covers both downstream behavior and the request contract: HPA-484 does not reject a legacy object solely because its serialized form exceeds the contextual storage limit.
-
-### 8.2 Contextual submission
+### 8.4 Contextual submission
 
 A request with `context`:
 
@@ -235,26 +266,32 @@ A request with `context`:
 - requires serialized contextual `gameData` to fit the storage bound;
 - inserts mode, optional competition key, ruleset version, and serialized game data;
 - stores `NULL` in `game_data_json` when game data is omitted;
-- runs the same existing aggregate-stat, favorite-game, achievement, and challenge side effects as a legacy submission.
+- runs the same aggregate-stat, favorite-game, score-threshold achievement, in-game achievement, and challenge side effects as a legacy submission.
 
-Context is never derived from `gameData`, and fields inside `gameData` never override explicit context.
+A contextual high score may award an existing score-threshold achievement even though best-score-derived Campaign progress ignores that scoped score. Likewise, contextual `gameData` may award an existing in-game achievement. The `earned` flag remains authoritative; a best-score-derived percentage may remain below 100 after an achievement was earned from a scoped play. Game-specific Campaign-only unlock rules, if ever required, belong in a later issue rather than being inferred by this shared layer.
 
-### 8.3 Validation
-
-Use a strict context schema and preserve the open, game-specific shape of `gameData`.
+### 8.5 Validation
 
 | Field | Validation |
 |---|---|
 | `mode` | Required in context; 1–32 characters; `[a-z][a-z0-9_-]*` |
 | `competitionKey` | Optional; 1–128 characters; letters, digits, `:`, `.`, `_`, and `-` |
 | `rulesetVersion` | Required integer; `1..2_147_483_647` |
-| `context` | Strict object; unknown fields rejected |
-| `gameData` | Preserve the current record/object validation; arrays and primitives remain rejected |
+| `context` | Strict optional object; omitted is valid and `null` is rejected |
+| `gameData` | Preserve current record/object validation; arrays and primitives remain rejected |
 | serialized contextual `gameData` | At most 16 KiB measured as UTF-8 bytes |
+
+The competition-key charset covers the canonical parent format:
+
+```text
+ice-slide:daily:YYYY-MM-DD:g<generatorVersion>:r<rulesetVersion>
+```
+
+No `/` or `#` character is required by the approved Daily key contract.
 
 The byte-size check runs only when `context` is present and `gameData` will be persisted. It must measure `TextEncoder().encode(serialized).byteLength` or an equivalent server-safe UTF-8 byte count, not JavaScript string length.
 
-Malformed request JSON, invalid context, oversized contextual data, and unknown context fields return `400` before inserting a score or updating statistics. A contextual validation failure is never retried as a legacy submission. An oversized legacy object remains subject to existing request/infrastructure limits but is not newly rejected by HPA-484's score schema.
+Malformed request JSON, `context: null`, invalid context, oversized contextual data, and unknown context fields return `400` before inserting a score or updating statistics. A contextual validation failure is never retried as a legacy submission.
 
 ## 9. Runtime Schema Compatibility
 
@@ -279,19 +316,20 @@ export interface GameScoresContextCapabilities {
 5. Cache concurrent callers behind one process-local promise.
 6. Record success only for capabilities that actually exist.
 7. Reset the shared promise when any required column migration is incomplete so a later request retries.
-8. If only index creation fails, retain the column capabilities but leave the guard retryable until `scopedIndex=true`; do not permanently cache a performance-only failure.
+8. If only index creation fails, retain column capabilities but leave the guard retryable until `scopedIndex=true`; do not permanently cache a performance-only failure.
 
 No path rebuilds or rewrites `game_scores`, and existing rows remain valid with `NULL` context.
 
 ### 9.2 Capability-dependent behavior
 
-- Contextual inserts require all four columns. If any are unavailable, return a server error and do not insert an unscoped replacement.
-- Scoped reads require all four columns. Missing capability is an explicit server failure, not an empty leaderboard or unscoped fallback.
-- Legacy inserts use the original column set and remain available when the context migration is incomplete.
+- Contextual inserts require all four columns. If any are unavailable, return `500` with public code `SCORE_CONTEXT_UNAVAILABLE`; do not insert an unscoped replacement.
+- Scoped reads require all four columns. Missing capability or a scoped query failure returns `500` with public code `SCOPED_LEADERBOARD_UNAVAILABLE`, not an empty leaderboard or unscoped fallback.
+- Public codes distinguish unavailable behavior from a legitimate empty result without exposing whether the internal cause was migration or query execution.
+- Legacy inserts use the original column set and remain available when context migration is incomplete.
 - Default unscoped reads apply every available isolation predicate:
   - when both scope columns exist: `mode IS NULL AND competition_key IS NULL`;
   - when only one exists after a partial migration: filter on the available column;
-  - when neither exists on a legacy schema: all existing rows are necessarily treated as unscoped.
+  - when neither exists on a legacy schema: all existing rows are treated as unscoped.
 - An index failure affects performance only. Contextual reads and writes remain valid when the four columns exist.
 
 This fallback is deliberately asymmetric: legacy behavior degrades gracefully, while requested contextual behavior never loses scope silently.
@@ -300,11 +338,9 @@ This fallback is deliberately asymmetric: legacy behavior degrades gracefully, w
 
 ### 10.1 Existing unscoped queries
 
-Keep explicit legacy functions rather than introducing a single highly conditional query.
+`getGameLeaderboard(gameId, limit)` adds unscoped predicates when available and retains its current public result shape, score-descending ordering, and raw-attempt semantics. The same user may occupy multiple entries.
 
-`getGameLeaderboard(gameId, limit)` adds unscoped predicates when available and retains its current public result shape and score-descending behavior.
-
-Every existing function that answers a user's best score for a game, including compatibility aliases and `/api/scores/best`, uses the same unscoped predicate. Personal-best-derived achievement progress therefore remains Campaign-compatible.
+Every existing function that answers a user's best score for a game, including compatibility aliases and `/api/scores/best`, uses the same unscoped predicate. Best-score-derived achievement progress therefore remains Campaign-compatible.
 
 The all-games leaderboard endpoint continues to call the unscoped query for every registered game.
 
@@ -317,14 +353,10 @@ Do not add unscoped predicates to:
 - aggregate total-score and activity statistics;
 - the existing stored `total_games_played`, `total_score`, and `favorite_game` update path;
 - games-played, unique-games, and total-score challenge queries;
-- submission-time score and in-game achievement checks;
+- submission-time score-threshold and in-game achievement checks;
 - existing daily-challenge progress updates.
 
-A Daily or Expedition attempt is still a real platform play even when it belongs to a separate competitive scope.
-
 ### 10.3 Scoped best-per-user query
-
-Add a separate reusable query. The database-layer row may retain `userId` internally because partitioning and later authenticated-user matching require it, but that identifier must be stripped before producing a public API entry.
 
 ```ts
 export interface ScopedLeaderboardQuery {
@@ -351,27 +383,37 @@ interface ScopedLeaderboardRow {
 export type ScopedLeaderboardEntry = Omit<ScopedLeaderboardRow, 'userId'>
 ```
 
-The query filters by exact `game_id` and `mode`; when `competitionKey` is supplied it also requires an exact `competition_key` match. A mode-only query intentionally spans keys and ruleset versions in that mode.
+The query filters by exact `game_id` and `mode`; when `competitionKey` is supplied it also requires an exact `competition_key` match. A mode-only query intentionally spans competition keys and ruleset eras. Mode-only SQL must not add an implicit `ruleset_version` predicate.
 
-Use a parameterized CTE with `ROW_NUMBER() OVER (PARTITION BY user_id ...)`. Apply `limit` only after selecting one row per user.
+Use parameterized staged CTEs and `ROW_NUMBER() OVER (PARTITION BY user_id ...)`. Apply `limit` only after selecting one row per user.
 
-The API mapping must remove `userId`. If HPA-488 needs authenticated-player highlighting, it should compare the internal row to the optional session server-side and expose a safe boolean such as `isCurrentUser`; it must not publish the Better Auth identifier.
+The API mapping removes `userId`. HPA-488 may compare the internal row to the session server-side and add `isCurrentUser`.
 
-### 10.4 Tie-break extraction
+### 10.4 V1 tie-break projection
 
-The reusable query recognizes `elapsedSeconds` and `totalMoves` only when each stored value is a non-negative JSON integer. Missing, malformed, negative, non-integer, or otherwise invalid values become `NULL` for ranking and output.
+The shared query recognizes only these allowlisted JSON keys in v1:
+
+- `elapsedSeconds`
+- `totalMoves`
+
+Unknown current or future game-specific metrics remain inside `game_data_json` and are not projected, filtered, or sorted until a later approved extension updates the allowlist and query contract.
+
+Each recognized value is accepted only when it is a non-negative JSON integer. Missing, malformed, negative, non-integer, or otherwise invalid values become `NULL`.
+
+A public `NULL` means **not available to this shared projection**. It may mean the game does not use that metric, the contextual submission omitted it, or the stored value was invalid. Consumers must use `gameId`/`mode` knowledge before labeling a null as “no time” or “no moves.”
 
 Use staged CTEs:
 
-1. An initial CTE filters the requested scope and exposes `game_data_json` only when `json_valid(game_data_json)=1`; invalid JSON becomes `NULL`.
-2. A later CTE invokes `json_type`/`json_extract` only against the valid JSON value.
-3. The ranking CTE consumes the normalized nullable integers.
+1. Filter the requested scope and expose `game_data_json` only when `json_valid(game_data_json)=1`; invalid JSON becomes `NULL`.
+2. Invoke `json_type`/`json_extract` only against the valid JSON value.
+3. Normalize allowlisted values to nullable integers.
+4. Apply the window ranking.
 
-Do not depend on SQL boolean-expression short-circuiting to protect JSON functions. A malformed historical or externally written row must never abort the leaderboard query.
+Do not depend on SQL boolean-expression short-circuiting to protect JSON functions.
 
 ### 10.5 Deterministic ranking order
 
-Use the same order when selecting a user's best attempt and when ordering the final best-per-user leaderboard:
+Use the same order when selecting a user's best attempt and ordering the final best-per-user leaderboard:
 
 1. `score DESC`
 2. valid elapsed time before missing/invalid elapsed time
@@ -381,19 +423,11 @@ Use the same order when selecting a user's best attempt and when ordering the fi
 6. `created_at ASC`
 7. `id ASC`
 
-The row ID is an internal final determinant for equal timestamps. It does not replace or reorder the documented product tie-breaks.
+The row ID is an internal final determinant for equal timestamps.
 
-The query keeps the existing player identity precedence:
+### 10.6 Public field naming and DTO isolation
 
-```text
-displayName -> username -> name -> "Anonymous"
-```
-
-### 10.6 Public field naming
-
-Shared public leaderboard fields retain the existing contract exactly, including `created_at`. The scoped response does not rename that field to `createdAt`.
-
-New opt-in fields use the existing API's TypeScript-facing camelCase convention:
+Shared public leaderboard fields retain the existing contract, including `created_at`. New opt-in fields are additive:
 
 ```text
 mode
@@ -403,56 +437,52 @@ elapsedSeconds
 totalMoves
 ```
 
-This means consumers can reuse the existing rank/player/score/timestamp rendering and feature-detect only the additive scoped fields.
+Public history and activity endpoints remain shape-identical. Implementations must select or map explicit fields at API/service boundaries and must never serialize `game_data_json`, raw `user_id`, or newly added context columns through an internal `selectAll()` result.
 
 ## 11. API Contracts
 
 ### 11.1 `POST /api/scores`
 
-- Existing request bodies without `context` remain valid under the existing legacy validation contract.
-- The contextual byte limit does not apply to a request that omits `context`.
+- Existing bodies without `context` remain valid under the legacy contract.
+- `context: null` is invalid.
+- The contextual byte limit does not apply when `context` is omitted.
 - Contextual validation errors return `400` and insert nothing.
-- Missing contextual schema capability returns a server error and inserts nothing.
+- Missing contextual schema capability returns `500` with `{ error, code: 'SCORE_CONTEXT_UNAVAILABLE' }`.
 - The success response shape remains unchanged.
-- Aggregate stats, favorite-game assignment, achievement processing, and challenge processing receive the same `gameId`, score, and game-data inputs as before.
-- A contextual score is not semantically admitted to a game-specific ranked competition here; that validation belongs to the consuming game issue.
+- Both submission forms use the single write path and identical aggregate-stat, favorite-game, achievement, and challenge sequencing.
 
 ### 11.2 `GET /api/leaderboard`
 
-Replace the route's manual parameter parsing with one validation schema that models both existing and scoped forms. The schema must keep `gameId` optional for the all-games request, parse/default `limit`, validate `mode` and `competitionKey`, and enforce cross-field combinations with a refinement:
+Replace manual parameter parsing with one validation schema that models existing and scoped forms. The schema keeps `gameId` optional for all-games, parses/defaults `limit`, validates `mode` and `competitionKey`, and enforces:
 
 - `mode` requires `gameId`;
-- `competitionKey` requires both `gameId` and `mode`.
-
-The route must call the shared `validateQuery()` helper or an equivalent single schema-validation entry point for all query parameters; it must not validate `limit` manually while handling scope parameters separately.
+- `competitionKey` requires `gameId` and `mode`.
 
 | Query | Behavior |
 |---|---|
-| no scope parameters | Preserve current unscoped behavior |
-| `gameId` only | Preserve current single-game unscoped response |
-| `gameId` + `mode` | Return scoped best-per-user results for that mode |
-| `gameId` + `mode` + `competitionKey` | Return exact scoped competition results |
+| no scope parameters | Existing all-games unscoped raw-attempt leaderboards |
+| `gameId` only | Existing single-game unscoped raw-attempt leaderboard |
+| `gameId` + `mode` | Scoped best-per-user leaderboard spanning that mode |
+| `gameId` + `mode` + `competitionKey` | Exact scoped best-per-user competition |
 | `competitionKey` without `mode` | `400` |
 | scope parameter without `gameId` | `400` |
 | invalid game, limit, mode, or key | `400` |
-| scoped schema unavailable | server error |
-| scoped database query failure | server error, not an empty-success response |
+| scoped capability/query unavailable | `500` with code `SCOPED_LEADERBOARD_UNAVAILABLE` |
 
-The existing unscoped response remains shape-compatible. Scoped entries retain `created_at`, never expose `userId`, and add only `mode`, `competitionKey`, `rulesetVersion`, `elapsedSeconds`, and `totalMoves`.
+The raw-attempt versus best-per-user difference is intentional and part of the public contract. HPA-488 must not assume Campaign/global entries are deduplicated.
 
-The legacy query may retain its current defensive empty-array behavior for compatibility. The new scoped query must preserve failure information so HPA-488 can distinguish an unavailable leaderboard from a legitimately empty competition.
+The legacy query may retain its defensive empty-array behavior for compatibility. Scoped failure must remain distinguishable from a legitimate empty scoped competition.
 
 ## 12. Error Handling
 
-- Invalid context or oversized contextual data fails before any database mutation.
-- Legacy game-data objects retain their existing score-schema validation and are not subject to the new contextual byte cap.
-- A contextual migration failure is logged and surfaced; no unscoped substitute is written.
-- Legacy submissions continue with the original insert columns where possible.
+- Invalid context or oversized contextual data fails before database mutation.
+- Legacy game-data objects are not subject to the new contextual byte cap.
+- Contextual migration failure is logged and surfaced; no unscoped substitute is written.
 - A partial schema never causes a query to reference a missing column.
-- Malformed persisted JSON is treated as missing tie-break data rather than a query failure.
-- An unavailable scoped leaderboard is distinguishable from an empty scoped leaderboard.
-- Existing score, aggregate-stat, favorite-game, achievement, and challenge side-effect ordering is preserved; transactional redesign is outside this issue.
-- Database and validation errors must not expose serialized game data, raw user IDs, or secrets in client responses.
+- Malformed persisted JSON becomes missing tie-break data rather than a query failure.
+- Public error codes identify an unavailable capability without exposing serialized game data, raw user IDs, SQL details, or secrets.
+- Existing side-effect ordering is preserved; transactional redesign remains out of scope.
+- Unscoped empty-on-error and scoped fail-loud behavior are covered separately so later refactoring cannot accidentally “unify” them.
 
 ## 13. Testing Strategy
 
@@ -461,137 +491,170 @@ Use mocked query tests for call boundaries and real in-memory LibSQL tests for s
 ### 13.1 Validation and client tests
 
 - Legacy payload without context remains valid.
-- A legacy object larger than 16 KiB remains accepted by the score schema, proving HPA-484 did not tighten the existing contract.
+- `context: null` is rejected; omission is accepted.
+- A legacy object larger than 16 KiB remains accepted by the score schema.
 - Contextual payload with and without game data is valid.
 - Mode, competition-key, and ruleset-version boundaries are covered.
+- The canonical Ice Slide key passes the competition-key regex; `/` and `#` are rejected.
 - Unknown context fields are rejected.
-- Arrays and primitives remain rejected as game data through the existing record/object validation.
+- Arrays and primitives remain rejected as game data.
 - Oversized contextual ASCII and multibyte UTF-8 payloads are rejected by encoded byte size.
-- Context is forwarded by `scoreService` without changing legacy request bodies.
-- Invalid context returns the existing client-facing invalid-score failure path.
+- `submitScore()` forwards `ScoreData.context`.
+- Client `saveGameScore()` forwards context through `SaveScoreOptions`, with no new positional argument and no change to legacy request bodies.
 
-### 13.2 Migration tests
+### 13.2 Migration and bootstrap tests
 
-- Fresh initialization contains all four columns and the scoped index.
+- Fresh initialization through each non-test schema surface contains all four columns and the index.
 - A legacy four-column table gains all columns without rewriting existing rows.
-- Unscoped fallback behavior covers the four meaningful scope-column states: neither `mode` nor `competition_key`, `mode` only, `competition_key` only, and both.
-- Representative interrupted states missing `ruleset_version` or `game_data_json` prove contextual operations fail and the next guard call completes migration.
-- Exhaustively testing all 16 column-presence permutations is not required because every state missing any contextual column has the same contextual fail/no-downgrade contract.
+- Unscoped fallback covers the four meaningful scope-column states.
+- Representative states missing `ruleset_version` or `game_data_json` fail contextual operations and complete on retry.
 - Repeated calls are idempotent.
 - Concurrent calls share one migration execution.
-- A failed column addition causes the next call to retry.
-- Index creation failure leaves column capabilities available and retries later.
-- Legacy inserts and default reads remain functional during incomplete migration.
-- Contextual operations fail rather than downgrade when schema capability is incomplete.
+- Failed column addition retries.
+- Failed index creation leaves columns usable and retries later.
+- Legacy operations continue during incomplete migration.
+- Contextual operations fail rather than downgrade.
 
-### 13.3 Real LibSQL query tests
+### 13.3 Real LibSQL query and side-effect tests
 
-- Legacy and contextual submissions round-trip the expected nullable columns.
-- Contextual game data is persisted exactly once; legacy game data remains transient.
-- Contextual submissions execute the existing aggregate-stat and favorite-game side effects.
-- Default game and all-games leaderboards exclude scoped rows.
-- Every personal-best function and compatibility alias excludes scoped rows.
-- Personal-best-derived achievement progress ignores scoped rows.
-- History, activity, aggregate statistics, favorite-game updates, and daily-challenge source queries include scoped rows.
+- Legacy and contextual submissions round-trip expected nullable columns through the same insert function.
+- Contextual game data is persisted once; legacy data remains transient.
+- Both paths execute the same aggregate-stat and favorite-game side effects.
+- Both paths execute score-threshold and in-game achievement checks.
+- A scoped score may award an achievement while unscoped best-score-derived percentage remains unchanged.
+- Default game and all-games leaderboards exclude scoped rows and retain raw-attempt semantics.
+- Every personal-best function and alias excludes scoped rows.
+- History, activity, aggregate statistics, favorite-game updates, and daily-challenge sources include scoped rows.
 - Mode and competition-key isolation are exact.
-- `ruleset_version` round-trips as metadata but is not an implicit filter or tie-break.
+- Mode-only queries do not add `ruleset_version` predicates.
+- `ruleset_version` round-trips as metadata and is required on contextual rows.
 - Each user appears at most once in scoped output.
-- A better retry replaces a worse retry in output while both remain stored.
-- Score, elapsed-time, move-count, submission-time, and row-ID tie-break levels are independently covered.
-- Valid tie-break values sort before missing or invalid values.
+- Better retries replace worse retries in output while all attempts remain stored.
+- Every tie-break level is independently covered.
+- Index presence is not treated as proof of complete ranking order.
+- Valid allowlisted values sort before null/invalid values.
+- Unknown JSON metrics remain unprojected.
 - Malformed JSON does not abort the query.
-- `limit` is applied after best-per-user selection.
-- Player identity fallback behavior remains unchanged.
-- The internal row retains `userId` for server use, while the public mapping omits it.
-- Scoped and unscoped public entries both retain `created_at`.
+- `limit` is applied after partitioning, including a fixture with at least 100 users and multiple attempts per user.
+- Internal rows retain `userId`; public mapping omits it.
+- Public history/activity DTOs remain shape-identical and omit all context/JSON fields.
+- Scoped and unscoped public entries retain `created_at`.
 
 ### 13.4 API tests
 
-- Existing no-`gameId` and single-game unscoped responses remain shape-compatible.
-- The unified leaderboard query schema accepts the all-games path and rejects every invalid scope combination.
-- The route uses the unified validation result rather than separate manual parsing.
-- Scoped mode-only and exact-key requests return the new fields and ranks.
-- Scoped entries retain `created_at` and do not serialize `userId`.
-- Contextual submission returns `400` with no insert for malformed context or oversized contextual data.
-- Legacy oversized object data is not newly rejected by HPA-484.
-- Scoped schema/query failure returns a server error rather than an empty result.
-- Existing aggregate-stat, favorite-game, achievement, and challenge update calls still occur after successful legacy and contextual submissions.
+- Existing all-games and single-game unscoped responses remain shape-compatible and raw-attempt based.
+- Unified query validation accepts all-games and rejects every invalid scope combination.
+- Scoped mode-only and exact-key requests return additive fields and best-per-user ranks.
+- Scoped entries retain `created_at` and omit `userId`.
+- Scoped null tie-break fields remain nullable and are not assigned game-independent labels by the backend.
+- Contextual validation failures return `400`.
+- Missing score-context capability returns `500` with `SCORE_CONTEXT_UNAVAILABLE`.
+- Scoped leaderboard failure returns `500` with `SCOPED_LEADERBOARD_UNAVAILABLE`, never empty `200`.
+- Existing side-effect calls still occur after successful legacy and contextual submissions.
+- Public history endpoints do not leak context columns after `GameScore` widens.
 
-End-to-end Daily UI coverage belongs to HPA-487 and HPA-488, not this backend foundation.
+End-to-end Daily UI coverage belongs to HPA-487 and HPA-488.
 
 ## 14. Implementation Boundaries
 
-Likely touched areas are intentionally limited to:
+Likely touched areas:
 
 ```text
 scripts/init-db.sql
-better-auth_migrations/...
+better-auth_migrations/2025-07-06-schema-consolidation.sql
 src/lib/server/db/types.ts
 src/lib/server/db/queries.ts
 src/lib/server/validations.ts
+src/lib/server/api-utils.ts or scoped endpoint response helpers
 src/lib/services/scoreService.ts
 src/pages/api/scores.ts
 src/pages/api/leaderboard.ts
+src/pages/api/scores/history.ts and any public score/history mapping tests
 focused unit, API, migration, legacy-schema, and LibSQL integration tests
 ```
 
-No Ice Slide runtime module should depend on unfinished HPA-487 data shapes in this issue. The platform contract must be usable independently by later games.
+Implementation constraints:
+
+- Extend the existing `saveGameScore()` database write contract with one optional structured context argument.
+- Keep `saveGameScoreWithAchievements()` as the single achievement pipeline.
+- Extend `ScoreData` and the existing client options bag; do not add a seventh positional argument to client `saveGameScore()`.
+- Public queries and endpoints use explicit DTO mapping; no internal `GameScore` pass-through.
+- The scoped window order, not the index declaration, is authoritative.
+- No Ice Slide runtime module depends on unfinished HPA-487 data shapes.
 
 ## 15. Delivery Sequence
 
-1. Add schema types, checked-in schema definitions, runtime capability guard, and focused migration tests.
-2. Add strict request context and contextual game-data storage bounds without tightening legacy validation.
-3. Extend score-service and insert paths while preserving all existing aggregate-stat, favorite-game, achievement, and challenge side effects.
+1. Update both schema creation surfaces, Kysely types, the capability guard, and focused migration/bootstrap tests.
+2. Add strict omit-only request context and contextual game-data storage bounds without tightening legacy validation.
+3. Extend the single score-write function and client options bag while preserving all existing side effects.
 4. Isolate default leaderboard and personal-best queries to unscoped rows.
-5. Add the scoped best-per-user LibSQL query, internal/public DTO boundary, and deterministic tie-break tests.
-6. Replace leaderboard manual parameter parsing with one schema and add validated opt-in filters.
-7. Run compatibility tests across fresh, legacy, representative partial, and malformed-data fixtures.
-
-This sequence keeps every intermediate change reviewable and prevents API work from landing before its storage/query invariants exist.
+5. Add the scoped best-per-user query, v1 metric allowlist, internal/public DTO boundary, and deterministic tie-break tests.
+6. Replace leaderboard manual parsing with one schema and stable scoped error categories.
+7. Audit and test every public history/activity mapping after `GameScore` widens.
+8. Run compatibility tests across fresh, legacy, representative partial, malformed-data, and high-attempt fixtures.
 
 ## 16. Acceptance Criteria
 
 - Existing rows remain valid and no table is destructively rewritten.
+- Both non-test schema creation surfaces include the new columns and index.
 - Existing score callers require no changes.
-- Legacy `gameData` keeps its existing validation contract, continues to power achievements, and is not persisted.
-- A contextual submission round-trips mode, optional key, ruleset version, and optional game data.
+- Client context is carried through the existing options/object contracts, not a new positional argument.
+- Legacy `gameData` keeps its current validation contract, continues to power achievements, and is not persisted.
+- `context: null` is rejected.
+- A contextual submission round-trips mode, optional key, required ruleset version, and optional game data.
 - Invalid context or oversized contextual data returns `400` and inserts nothing.
-- Default leaderboards, personal bests, and Campaign-oriented achievement progress exclude scoped rows.
+- Contextual schema failure returns explicit `500` without downgrade.
+- One score-write function serves legacy and contextual inserts and preserves all existing side effects.
+- Scoped submissions still award existing score-threshold and in-game achievements; only best-score-derived progress is unscoped.
+- Default leaderboards and personal bests exclude scoped rows.
+- Unscoped leaderboards remain raw-attempt lists; scoped leaderboards are best-per-user.
 - History, activity, aggregate statistics, favorite-game updates, and current daily challenges include scoped rows.
-- Scoped output contains at most one row per user.
+- Public history/activity DTOs remain shape-identical and never expose context columns or stored JSON.
 - Scoped public output preserves `created_at` and never exposes raw `user_id`.
-- `ruleset_version` is returned as metadata but does not silently define ranking scope.
+- `ruleset_version` is required metadata and never an implicit mode-only predicate or tie-break.
+- Only allowlisted v1 tie-break metrics are projected; unknown metrics remain stored-only.
+- The index is used for filtering where possible, while window SQL defines complete ranking.
 - All documented tie-breaks are deterministic and covered against real LibSQL.
 - Missing or malformed tie-break JSON cannot crash the query.
-- Legacy, representative partial, concurrent, and index-retry migration paths are covered.
-- The leaderboard route enforces all parameter combinations through one validation schema.
-- Existing achievement and challenge updates remain intact.
-- HPA-487 and HPA-488 can consume the context and scoped-query primitives without adding Ice Slide rules to the shared database layer.
+- Scoped unavailable errors are distinguishable from legitimate empty results.
+- The leaderboard route enforces all parameter combinations through one schema.
+- HPA-487 and HPA-488 can consume these primitives without adding Ice Slide rules to the shared database layer.
 
 ## 17. Resolved Decisions
 
-- Personal-best and achievement-progress queries use only unscoped rows.
-- Scoped rows still count as platform plays, aggregate-stat/favorite-game updates, and daily-challenge activity.
-- Context is explicit and separate from game data.
-- Legacy transient game data does not receive the new contextual 16 KiB storage bound.
+- Scoped submissions still run score-threshold and in-game achievement awarding against the submitted score and `gameData`.
+- Only personal-best/best-score-derived achievement progress is Campaign/unscoped; `earned` remains authoritative if the percentage differs.
+- Scoped rows count as platform plays, aggregate-stat/favorite-game updates, and daily-challenge activity.
+- Context is explicit, omit-only, and separate from game data.
+- Legacy transient game data does not receive the contextual 16 KiB storage bound.
+- One score-write function handles legacy and contextual persistence.
 - Contextual data is never silently discarded or downgraded.
-- Mode-only scoped ranking is allowed as a reusable primitive; competitive Daily callers use an exact competition key.
-- The mode-only path may sort because no second index is justified without a measured consumer.
-- `ruleset_version` is audit/display metadata; exact competition keys provide version isolation.
+- Unscoped ranking remains raw-attempt; scoped ranking is best-per-user.
+- Mode-only ranking intentionally spans keys and ruleset eras and must not add a ruleset predicate.
+- `ruleset_version` is required audit/display metadata so rows are inspectable without parsing keys.
+- The exact-key index assists filtering but does not define the complete ranking order.
+- `elapsedSeconds` and `totalMoves` are an Ice-Slide-first v1 projection allowlist; unknown metrics stay in JSON.
+- Null tie-break values mean unavailable/not-applicable to the shared projection, not a universal gameplay statement.
 - JSON tie-breaks are staged, guarded, nullable, and sorted after valid values.
 - Public scoped output preserves `created_at` and strips raw user IDs.
-- The leaderboard route uses one schema for all-games, single-game, and scoped query forms.
+- Public history/activity DTOs never pass through internal context or JSON fields.
+- Client context extends `ScoreData` and `SaveScoreOptions`, not the positional helper signature.
+- Scoped capability failures return stable public unavailable codes with HTTP 500.
+- The leaderboard route uses one schema for all-games, single-game, and scoped forms.
+- The canonical parent key format fits the approved competition-key charset.
+- The two non-test schema creation surfaces are updated together.
 - The shared layer does not decide whether an Ice Slide Daily submission is solved or trustworthy.
-- The canonical parent requirements live in Linear; the closed GitHub documentation branch is not the durable citation.
 
 ## 18. Spec Self-Review
 
-- **Placeholder scan:** no TBD, TODO, unresolved field bound, or invented production-volume target remains.
-- **Consistency:** Campaign competition is unscoped while platform activity includes all rows; every query family is assigned to one side of that boundary.
-- **Legacy compatibility:** the contextual persistence limit does not change the existing transient `gameData` request contract.
-- **Migration safety:** contextual operations require complete capability, while legacy behavior never references unavailable columns; index failure remains retryable.
-- **Determinism:** per-user selection and final ordering use the same complete sequence, including row ID as the final internal fallback.
-- **API surface:** existing shared fields retain their casing, new fields are additive, and raw auth identifiers remain private.
-- **Version semantics:** competition keys isolate versions; `ruleset_version` is explicit metadata rather than a hidden predicate.
-- **Scope:** the work remains a shared persistence/query foundation; Ice Slide gameplay, semantic admission, highlighting, and UI remain in HPA-487/HPA-488.
-- **Ambiguity resolution:** malformed JSON sorts as missing data, mode-only queries intentionally span keys, and the unified query schema models the all-games path.
+- **Placeholder scan:** no TBD, TODO, unresolved field bound, or invented volume target remains.
+- **Achievement semantics:** awarding and best-score-derived progress are explicitly separated.
+- **Write-path consistency:** one insert function and one side-effect pipeline serve both submission forms.
+- **Legacy compatibility:** contextual persistence limits do not change legacy transient input.
+- **Migration safety:** contextual operations require complete capability; legacy behavior never references unavailable columns; index failure remains retryable.
+- **Determinism:** per-user selection and final ordering use the same complete sequence, including row ID.
+- **API surface:** raw-attempt and best-per-user contracts are explicit; public DTOs retain casing and exclude raw IDs/JSON.
+- **Version semantics:** exact keys isolate versions; `ruleset_version` is required metadata rather than a hidden predicate.
+- **Metric extensibility:** the v1 allowlist is explicit and null semantics are documented.
+- **Bootstrap coverage:** both non-test creation paths and public history mappings are named.
+- **Scope:** Ice Slide gameplay, semantic admission, highlighting, and UI remain in HPA-487/HPA-488.

--- a/docs/superpowers/specs/2026-07-31-versioned-score-context-design.md
+++ b/docs/superpowers/specs/2026-07-31-versioned-score-context-design.md
@@ -359,7 +359,7 @@ No path rebuilds or rewrites `game_scores`, and existing rows remain valid with 
 - Legacy inserts use the original column set and remain available when context migration is incomplete.
 - Confirmed complete schema: default unscoped reads require both `mode IS NULL` and `competition_key IS NULL`.
 - Confirmed legacy/incomplete schema: default unscoped reads use the legacy no-predicate query. The supported write path cannot create contextual rows until all four columns exist, so partial-column permutations do not need distinct read predicates.
-- Unknown capability caused by a failed probe is **not** treated as confirmed legacy. Use the last cached confirmed snapshot when available; otherwise preserve each query's existing defensive failure result (`[]` for leaderboard reads, `null` for personal best) instead of failing open with an unfiltered query that could mix scoped rows after a process restart.
+- Unknown capability caused by a failed probe is **not** treated as confirmed legacy. Use the last cached confirmed snapshot when available; otherwise surface a discriminated `unavailable` result so callers can emit a coded 503 (`SCORE_CONTEXT_UNAVAILABLE`) instead of failing open with an unfiltered query that could mix scoped rows after a process restart. This applies uniformly to personal-best reads (`getUserBestScore` → `{ status: 'unavailable' }`), scoped leaderboard reads (`getScopedGameLeaderboard` → `{ success: false, code: 'SCOPED_LEADERBOARD_UNAVAILABLE' }`), and unscoped leaderboard reads (`getGameLeaderboard` → `{ status: 'unavailable', code: 'SCORE_CONTEXT_UNAVAILABLE' }`). A genuine absence of rows remains a successful empty result (`[]` / `null` / `ok`), distinct from the probe-failure state.
 - An index failure affects performance only. Contextual reads and writes remain valid when the four columns exist.
 
 This fallback is deliberately asymmetric: confirmed legacy schemas degrade gracefully, while unknown or requested contextual behavior never loses scope silently.
@@ -368,7 +368,7 @@ This fallback is deliberately asymmetric: confirmed legacy schemas degrade grace
 
 ### 10.1 Existing unscoped queries
 
-`getGameLeaderboard(gameId, limit)` adds unscoped predicates when available and retains its current public result shape, score-descending ordering, and raw-attempt semantics. The same user may occupy multiple entries.
+`getGameLeaderboard(gameId, limit)` adds unscoped predicates when available and retains its score-descending ordering and raw-attempt semantics. The same user may occupy multiple entries. Its public result shape is a discriminated `GameLeaderboardResult`: `GameLeaderboardEntry[]` on a successful probe (empty array = genuinely no unscoped rows; query-execution errors still swallow to `[]` for graceful degradation), or `{ status: 'unavailable', code: 'SCORE_CONTEXT_UNAVAILABLE' }` on a failed probe. Callers narrow with `isGameLeaderboardAvailable`; `/api/leaderboard` and the SSR leaderboard page handle the `unavailable` branch (the API emits a coded 503; the page degrades to its existing empty state).
 
 Every existing function that answers a user's best score for a game, including compatibility aliases and `/api/scores/best`, uses the same unscoped predicate. Best-score-derived achievement progress therefore remains Campaign-compatible.
 

--- a/docs/superpowers/specs/2026-07-31-versioned-score-context-design.md
+++ b/docs/superpowers/specs/2026-07-31-versioned-score-context-design.md
@@ -37,6 +37,7 @@ The current implementation has these relevant properties:
 - Database behavior is tested both through mocked Kysely chains and real in-memory LibSQL integration tests.
 - The current score schema already requires `gameData` to be an object through Zod's record schema, but it does not impose a serialized-byte limit.
 - Repository search finds two non-test schema creation surfaces for `game_scores`: `scripts/init-db.sql` and `better-auth_migrations/2025-07-06-schema-consolidation.sql`. Other matches are historical documentation or test fixtures.
+- The current branch has no Ice Slide runtime producer for `elapsedSeconds` or `totalMoves`; HPA-487 owns the first producer and must follow the units pinned by this contract.
 
 The change must preserve those contracts unless this design explicitly changes them.
 
@@ -95,7 +96,8 @@ Therefore, repository inspection cannot prove that every valid legacy request is
 | Tie-break projection | `elapsedSeconds` and `totalMoves` are the v1 allowlisted metrics; other game metrics remain in stored JSON. |
 | Daily admission | Ice Slide-specific solved/run/version checks belong to HPA-488. |
 | Invalid context | Reject with `400`; never silently downgrade to an unscoped score. |
-| Missing schema | Legacy operations continue where possible; contextual operations fail explicitly with `500`. |
+| Write failures | The single write path returns a discriminated result so context capability failures remain distinguishable from generic database failures. |
+| Missing schema | Legacy operations continue where safely confirmed; contextual operations fail explicitly with `500`. |
 
 ## 6. Alternatives Considered
 
@@ -201,9 +203,18 @@ export interface ScoreData {
     gameData?: GameData | Record<string, unknown>
     context?: ScoreSubmissionContext
 }
+
+export type ScoreSubmissionPublicErrorCode =
+    | 'SCORE_CONTEXT_UNAVAILABLE'
+
+export interface ScoreSubmissionResult {
+    success: boolean
+    code?: ScoreSubmissionPublicErrorCode
+    // existing notification/update/error fields remain
+}
 ```
 
-`submitScore(scoreData)` remains the canonical object-based transport call.
+`submitScore(scoreData)` remains the canonical object-based transport call. On non-2xx responses it parses the JSON body, copies only recognized public codes into `ScoreSubmissionResult.code`, and leaves `code` absent for transport failures or unrecognized server errors.
 
 The existing client `saveGameScore(gameId, score, onSuccess, onError, gameData, options)` helper must not gain another positional argument. Extend its existing options bag instead:
 
@@ -218,7 +229,7 @@ The helper forwards `options.context` through `ScoreData`. Existing callers that
 
 ### 8.2 Single server write path
 
-Keep one database score-write function and one side-effect pipeline:
+Keep one database score-write function and one side-effect pipeline, but do not preserve the current boolean return because it cannot carry the required capability failure:
 
 ```ts
 export interface PersistedScoreContext {
@@ -228,21 +239,39 @@ export interface PersistedScoreContext {
     gameDataJson: string | null
 }
 
+export type SaveGameScoreFailureCode =
+    | 'SCORE_CONTEXT_UNAVAILABLE'
+    | 'SCORE_WRITE_FAILED'
+
+export type SaveGameScoreResult =
+    | { success: true }
+    | { success: false; code: SaveGameScoreFailureCode }
+
 export async function saveGameScore(
     userId: string,
     gameId: string,
     score: number,
     context?: PersistedScoreContext
-): Promise<boolean>
+): Promise<SaveGameScoreResult>
+
+export type SaveGameScoreWithAchievementsResult =
+    | { success: true; newAchievements: string[] }
+    | {
+          success: false
+          newAchievements: []
+          code: SaveGameScoreFailureCode
+      }
 ```
 
 Requirements:
 
 - The optional structured argument controls only additional inserted columns.
 - A contextual call checks complete schema capability before insertion.
+- Missing contextual capability returns `{ success: false, code: 'SCORE_CONTEXT_UNAVAILABLE' }`.
+- Other insert/stat-update failures return `{ success: false, code: 'SCORE_WRITE_FAILED' }`; the function must not catch every failure and collapse it to bare `false`.
 - Legacy calls insert the original columns and do not require the contextual schema.
 - Both paths continue through the same existing `getUserStats()` / `upsertUserStats()` update block.
-- `saveGameScoreWithAchievements()` delegates exactly once to this function, then executes the same score-threshold and in-game achievement checks.
+- `saveGameScoreWithAchievements()` delegates exactly once to this function, preserves its failure code, and runs achievement checks only after a successful write.
 - Do not create a second contextual insert function with duplicated statistics or favorite-game behavior.
 - Serialization and validation happen before entering the write function; it receives normalized values only.
 
@@ -274,11 +303,13 @@ A contextual high score may award an existing score-threshold achievement even t
 
 | Field | Validation |
 |---|---|
-| `mode` | Required in context; 1–32 characters; `[a-z][a-z0-9_-]*` |
-| `competitionKey` | Optional; 1–128 characters; letters, digits, `:`, `.`, `_`, and `-` |
+| `mode` | Required in context; 1–32 characters; fully anchored `^[a-z][a-z0-9_-]*$` |
+| `competitionKey` | Optional; 1–128 characters; fully anchored `^[A-Za-z0-9:._-]+$` |
 | `rulesetVersion` | Required integer; `1..2_147_483_647` |
 | `context` | Strict optional object; omitted is valid and `null` is rejected |
 | `gameData` | Preserve current record/object validation; arrays and primitives remain rejected |
+| contextual `gameData.elapsedSeconds` | When present, a non-negative integer count of whole elapsed seconds, computed as `Math.floor(totalElapsedMilliseconds / 1000)` |
+| contextual `gameData.totalMoves` | When present, a non-negative integer move count |
 | serialized contextual `gameData` | At most 16 KiB measured as UTF-8 bytes |
 
 The competition-key charset covers the canonical parent format:
@@ -291,7 +322,7 @@ No `/` or `#` character is required by the approved Daily key contract.
 
 The byte-size check runs only when `context` is present and `gameData` will be persisted. It must measure `TextEncoder().encode(serialized).byteLength` or an equivalent server-safe UTF-8 byte count, not JavaScript string length.
 
-Malformed request JSON, `context: null`, invalid context, oversized contextual data, and unknown context fields return `400` before inserting a score or updating statistics. A contextual validation failure is never retried as a legacy submission.
+Malformed request JSON, `context: null`, invalid context, a fractional/negative allowlisted tie-break value, oversized contextual data, and unknown context fields return `400` before inserting a score or updating statistics. A contextual validation failure is never retried as a legacy submission. The query layer still normalizes malformed historical or externally written tie-break values to `NULL`.
 
 ## 9. Runtime Schema Compatibility
 
@@ -313,10 +344,10 @@ export interface GameScoresContextCapabilities {
 2. Add each missing nullable column independently with `ALTER TABLE`.
 3. Re-inspect or update known capabilities after each successful addition.
 4. Create the scoped index only after all four columns exist.
-5. Cache concurrent callers behind one process-local promise.
+5. Cache concurrent callers behind one process-local promise and retain the last confirmed capability snapshot; reads must not execute `PRAGMA` on every request.
 6. Record success only for capabilities that actually exist.
 7. Reset the shared promise when any required column migration is incomplete so a later request retries.
-8. If only index creation fails, retain column capabilities but leave the guard retryable until `scopedIndex=true`; do not permanently cache a performance-only failure.
+8. If only index creation fails, retain complete column capabilities and allow contextual reads/writes. Retry index creation lazily with process-local exponential backoff rather than on every request: start at one minute and cap the delay at one hour. A process restart may reset the backoff.
 
 No path rebuilds or rewrites `game_scores`, and existing rows remain valid with `NULL` context.
 
@@ -326,13 +357,12 @@ No path rebuilds or rewrites `game_scores`, and existing rows remain valid with 
 - Scoped reads require all four columns. Missing capability or a scoped query failure returns `500` with public code `SCOPED_LEADERBOARD_UNAVAILABLE`, not an empty leaderboard or unscoped fallback.
 - Public codes distinguish unavailable behavior from a legitimate empty result without exposing whether the internal cause was migration or query execution.
 - Legacy inserts use the original column set and remain available when context migration is incomplete.
-- Default unscoped reads apply every available isolation predicate:
-  - when both scope columns exist: `mode IS NULL AND competition_key IS NULL`;
-  - when only one exists after a partial migration: filter on the available column;
-  - when neither exists on a legacy schema: all existing rows are treated as unscoped.
+- Confirmed complete schema: default unscoped reads require both `mode IS NULL` and `competition_key IS NULL`.
+- Confirmed legacy/incomplete schema: default unscoped reads use the legacy no-predicate query. The supported write path cannot create contextual rows until all four columns exist, so partial-column permutations do not need distinct read predicates.
+- Unknown capability caused by a failed probe is **not** treated as confirmed legacy. Use the last cached confirmed snapshot when available; otherwise preserve each query's existing defensive failure result (`[]` for leaderboard reads, `null` for personal best) instead of failing open with an unfiltered query that could mix scoped rows after a process restart.
 - An index failure affects performance only. Contextual reads and writes remain valid when the four columns exist.
 
-This fallback is deliberately asymmetric: legacy behavior degrades gracefully, while requested contextual behavior never loses scope silently.
+This fallback is deliberately asymmetric: confirmed legacy schemas degrade gracefully, while unknown or requested contextual behavior never loses scope silently.
 
 ## 10. Query Semantics
 
@@ -375,7 +405,7 @@ interface ScopedLeaderboardRow {
     created_at: string
     mode: string
     competitionKey: string | null
-    rulesetVersion: number | null
+    rulesetVersion: number
     elapsedSeconds: number | null
     totalMoves: number | null
 }
@@ -383,7 +413,7 @@ interface ScopedLeaderboardRow {
 export type ScopedLeaderboardEntry = Omit<ScopedLeaderboardRow, 'userId'>
 ```
 
-The query filters by exact `game_id` and `mode`; when `competitionKey` is supplied it also requires an exact `competition_key` match. A mode-only query intentionally spans competition keys and ruleset eras. Mode-only SQL must not add an implicit `ruleset_version` predicate.
+The query filters by exact `game_id`, `mode`, and `ruleset_version IS NOT NULL`; when `competitionKey` is supplied it also requires an exact `competition_key` match. The non-null check enforces the contextual-row invariant but does not select a particular ruleset version. A mode-only query intentionally spans competition keys and ruleset eras and must not add an equality predicate on `ruleset_version`. Mode-only output is a reusable diagnostic/aggregate view, not an official cross-era competition; no current UI consumes it.
 
 Use parameterized staged CTEs and `ROW_NUMBER() OVER (PARTITION BY user_id ...)`. Apply `limit` only after selecting one row per user.
 
@@ -398,7 +428,7 @@ The shared query recognizes only these allowlisted JSON keys in v1:
 
 Unknown current or future game-specific metrics remain inside `game_data_json` and are not projected, filtered, or sorted until a later approved extension updates the allowlist and query contract.
 
-Each recognized value is accepted only when it is a non-negative JSON integer. Missing, malformed, negative, non-integer, or otherwise invalid values become `NULL`.
+Each recognized value is accepted only when it is a non-negative JSON integer. HPA-487 must emit `elapsedSeconds` as whole seconds using `Math.floor(totalElapsedMilliseconds / 1000)` and `totalMoves` as an integer count. The submission validator rejects fractional or negative allowlisted values with `400`; the query treats missing, malformed historical, or externally written invalid values as `NULL`.
 
 A public `NULL` means **not available to this shared projection**. It may mean the game does not use that metric, the contextual submission omitted it, or the stored value was invalid. Consumers must use `gameId`/`mode` knowledge before labeling a null as “no time” or “no moves.”
 
@@ -448,8 +478,10 @@ Public history and activity endpoints remain shape-identical. Implementations mu
 - The contextual byte limit does not apply when `context` is omitted.
 - Contextual validation errors return `400` and insert nothing.
 - Missing contextual schema capability returns `500` with `{ error, code: 'SCORE_CONTEXT_UNAVAILABLE' }`.
+- `saveGameScore()` and `saveGameScoreWithAchievements()` preserve the discriminated failure code instead of collapsing it to `false`.
 - The success response shape remains unchanged.
 - Both submission forms use the single write path and identical aggregate-stat, favorite-game, achievement, and challenge sequencing.
+- `submitScore()` reads a JSON error body for non-2xx responses, propagates recognized public `code` values through `ScoreSubmissionResult.code`, and distinguishes them from transport/network failures.
 
 ### 11.2 `GET /api/leaderboard`
 
@@ -477,7 +509,7 @@ The legacy query may retain its defensive empty-array behavior for compatibility
 
 - Invalid context or oversized contextual data fails before database mutation.
 - Legacy game-data objects are not subject to the new contextual byte cap.
-- Contextual migration failure is logged and surfaced; no unscoped substitute is written.
+- Contextual migration failure is logged and surfaced through the discriminated save result; no unscoped substitute is written.
 - A partial schema never causes a query to reference a missing column.
 - Malformed persisted JSON becomes missing tie-break data rather than a query failure.
 - Public error codes identify an unavailable capability without exposing serialized game data, raw user IDs, SQL details, or secrets.
@@ -495,6 +527,7 @@ Use mocked query tests for call boundaries and real in-memory LibSQL tests for s
 - A legacy object larger than 16 KiB remains accepted by the score schema.
 - Contextual payload with and without game data is valid.
 - Mode, competition-key, and ruleset-version boundaries are covered.
+- The fully anchored mode and competition-key regexes reject valid substrings with invalid prefixes/suffixes (for example `Ice Slide!daily`).
 - The canonical Ice Slide key passes the competition-key regex; `/` and `#` are rejected.
 - Unknown context fields are rejected.
 - Arrays and primitives remain rejected as game data.
@@ -506,13 +539,14 @@ Use mocked query tests for call boundaries and real in-memory LibSQL tests for s
 
 - Fresh initialization through each non-test schema surface contains all four columns and the index.
 - A legacy four-column table gains all columns without rewriting existing rows.
-- Unscoped fallback covers the four meaningful scope-column states.
+- Confirmed complete schema uses both unscoped predicates; confirmed legacy/incomplete schema uses the legacy no-predicate query.
 - Representative states missing `ruleset_version` or `game_data_json` fail contextual operations and complete on retry.
 - Repeated calls are idempotent.
 - Concurrent calls share one migration execution.
 - Failed column addition retries.
-- Failed index creation leaves columns usable and retries later.
-- Legacy operations continue during incomplete migration.
+- Failed index creation leaves columns usable and retries only after the configured backoff; repeated hot-path requests inside the delay do not reattempt DDL.
+- A failed capability probe with no cached state returns existing defensive read results rather than executing an unfiltered query.
+- Legacy operations continue during confirmed incomplete migration.
 - Contextual operations fail rather than downgrade.
 
 ### 13.3 Real LibSQL query and side-effect tests
@@ -526,13 +560,14 @@ Use mocked query tests for call boundaries and real in-memory LibSQL tests for s
 - Every personal-best function and alias excludes scoped rows.
 - History, activity, aggregate statistics, favorite-game updates, and daily-challenge sources include scoped rows.
 - Mode and competition-key isolation are exact.
-- Mode-only queries do not add `ruleset_version` predicates.
-- `ruleset_version` round-trips as metadata and is required on contextual rows.
+- Mode-only queries do not add `ruleset_version` equality predicates.
+- `ruleset_version` round-trips as non-null metadata on every scoped result; malformed scoped rows with a null version are excluded.
 - Each user appears at most once in scoped output.
 - Better retries replace worse retries in output while all attempts remain stored.
 - Every tie-break level is independently covered.
 - Index presence is not treated as proof of complete ranking order.
 - Valid allowlisted values sort before null/invalid values.
+- Fractional contextual `elapsedSeconds` and `totalMoves` are rejected at submission; fractional historical/external fixtures normalize to `NULL`.
 - Unknown JSON metrics remain unprojected.
 - Malformed JSON does not abort the query.
 - `limit` is applied after partitioning, including a fixture with at least 100 users and multiple attempts per user.
@@ -548,7 +583,8 @@ Use mocked query tests for call boundaries and real in-memory LibSQL tests for s
 - Scoped entries retain `created_at` and omit `userId`.
 - Scoped null tie-break fields remain nullable and are not assigned game-independent labels by the backend.
 - Contextual validation failures return `400`.
-- Missing score-context capability returns `500` with `SCORE_CONTEXT_UNAVAILABLE`.
+- Missing score-context capability survives both server result layers and returns `500` with `SCORE_CONTEXT_UNAVAILABLE`.
+- The client parses and exposes `SCORE_CONTEXT_UNAVAILABLE`; a network failure has no server error code.
 - Scoped leaderboard failure returns `500` with `SCOPED_LEADERBOARD_UNAVAILABLE`, never empty `200`.
 - Existing side-effect calls still occur after successful legacy and contextual submissions.
 - Public history endpoints do not leak context columns after `GameScore` widens.
@@ -575,7 +611,7 @@ focused unit, API, migration, legacy-schema, and LibSQL integration tests
 
 Implementation constraints:
 
-- Extend the existing `saveGameScore()` database write contract with one optional structured context argument.
+- Extend the existing `saveGameScore()` database write contract with one optional structured context argument and a discriminated result; do not retain `Promise<boolean>`.
 - Keep `saveGameScoreWithAchievements()` as the single achievement pipeline.
 - Extend `ScoreData` and the existing client options bag; do not add a seventh positional argument to client `saveGameScore()`.
 - Public queries and endpoints use explicit DTO mapping; no internal `GameScore` pass-through.
@@ -586,7 +622,7 @@ Implementation constraints:
 
 1. Update both schema creation surfaces, Kysely types, the capability guard, and focused migration/bootstrap tests.
 2. Add strict omit-only request context and contextual game-data storage bounds without tightening legacy validation.
-3. Extend the single score-write function and client options bag while preserving all existing side effects.
+3. Extend the single score-write function with a discriminated result, preserve the code through `saveGameScoreWithAchievements()`, and propagate recognized server codes through the client options/object path.
 4. Isolate default leaderboard and personal-best queries to unscoped rows.
 5. Add the scoped best-per-user query, v1 metric allowlist, internal/public DTO boundary, and deterministic tie-break tests.
 6. Replace leaderboard manual parsing with one schema and stable scoped error categories.
@@ -603,7 +639,7 @@ Implementation constraints:
 - `context: null` is rejected.
 - A contextual submission round-trips mode, optional key, required ruleset version, and optional game data.
 - Invalid context or oversized contextual data returns `400` and inserts nothing.
-- Contextual schema failure returns explicit `500` without downgrade.
+- Contextual schema failure remains distinguishable through the database result, achievement wrapper, route response, and client `ScoreSubmissionResult.code`; it returns explicit `500` without downgrade.
 - One score-write function serves legacy and contextual inserts and preserves all existing side effects.
 - Scoped submissions still award existing score-threshold and in-game achievements; only best-score-derived progress is unscoped.
 - Default leaderboards and personal bests exclude scoped rows.
@@ -611,12 +647,15 @@ Implementation constraints:
 - History, activity, aggregate statistics, favorite-game updates, and current daily challenges include scoped rows.
 - Public history/activity DTOs remain shape-identical and never expose context columns or stored JSON.
 - Scoped public output preserves `created_at` and never exposes raw `user_id`.
-- `ruleset_version` is required metadata and never an implicit mode-only predicate or tie-break.
+- `ruleset_version` is non-null required metadata in scoped output and never an equality predicate for mode-only ranking or a tie-break.
+- HPA-487 emits integer whole-second `elapsedSeconds` and integer `totalMoves`; fractional submitted values are rejected, while malformed historical values normalize to null.
 - Only allowlisted v1 tie-break metrics are projected; unknown metrics remain stored-only.
 - The index is used for filtering where possible, while window SQL defines complete ranking.
 - All documented tie-breaks are deterministic and covered against real LibSQL.
 - Missing or malformed tie-break JSON cannot crash the query.
-- Scoped unavailable errors are distinguishable from legitimate empty results.
+- Scoped unavailable errors are distinguishable from legitimate empty results and recognized server codes are propagated by the client.
+- Index retry uses bounded backoff and cannot execute performance-only DDL on every contextual request.
+- Unknown capability state never fails open into an unfiltered legacy read.
 - The leaderboard route enforces all parameter combinations through one schema.
 - HPA-487 and HPA-488 can consume these primitives without adding Ice Slide rules to the shared database layer.
 
@@ -627,19 +666,22 @@ Implementation constraints:
 - Scoped rows count as platform plays, aggregate-stat/favorite-game updates, and daily-challenge activity.
 - Context is explicit, omit-only, and separate from game data.
 - Legacy transient game data does not receive the contextual 16 KiB storage bound.
-- One score-write function handles legacy and contextual persistence.
+- One score-write function handles legacy and contextual persistence and returns a discriminated failure result; booleans are insufficient for the public capability contract.
 - Contextual data is never silently discarded or downgraded.
 - Unscoped ranking remains raw-attempt; scoped ranking is best-per-user.
-- Mode-only ranking intentionally spans keys and ruleset eras and must not add a ruleset predicate.
-- `ruleset_version` is required audit/display metadata so rows are inspectable without parsing keys.
+- Mode-only ranking remains an approved reusable diagnostic/aggregate primitive, intentionally spans keys and ruleset eras, is not an official competition, and must not add a ruleset equality predicate.
+- `ruleset_version` is required non-null audit/display metadata so rows are inspectable without parsing keys.
 - The exact-key index assists filtering but does not define the complete ranking order.
+- `elapsedSeconds` is a non-negative integer count of floored whole seconds and `totalMoves` is a non-negative integer count; HPA-487 must produce those units.
 - `elapsedSeconds` and `totalMoves` are an Ice-Slide-first v1 projection allowlist; unknown metrics stay in JSON.
 - Null tie-break values mean unavailable/not-applicable to the shared projection, not a universal gameplay statement.
 - JSON tie-breaks are staged, guarded, nullable, and sorted after valid values.
 - Public scoped output preserves `created_at` and strips raw user IDs.
 - Public history/activity DTOs never pass through internal context or JSON fields.
 - Client context extends `ScoreData` and `SaveScoreOptions`, not the positional helper signature.
-- Scoped capability failures return stable public unavailable codes with HTTP 500.
+- Scoped capability failures return stable public unavailable codes with HTTP 500, preserve the code through server result unions, and propagate recognized codes to the client.
+- Performance-only index creation retries with bounded exponential backoff.
+- Confirmed legacy/incomplete schema may use the legacy query; unknown capability without cache fails closed to existing defensive results.
 - The leaderboard route uses one schema for all-games, single-game, and scoped forms.
 - The canonical parent key format fits the approved competition-key charset.
 - The two non-test schema creation surfaces are updated together.
@@ -649,12 +691,12 @@ Implementation constraints:
 
 - **Placeholder scan:** no TBD, TODO, unresolved field bound, or invented volume target remains.
 - **Achievement semantics:** awarding and best-score-derived progress are explicitly separated.
-- **Write-path consistency:** one insert function and one side-effect pipeline serve both submission forms.
+- **Write-path consistency:** one insert function and one side-effect pipeline serve both submission forms, and discriminated failures survive every server/client layer.
 - **Legacy compatibility:** contextual persistence limits do not change legacy transient input.
-- **Migration safety:** contextual operations require complete capability; legacy behavior never references unavailable columns; index failure remains retryable.
+- **Migration safety:** contextual operations require complete capability; confirmed legacy schemas use the legacy query; unknown capability fails closed; performance-only index retry is backoff-bounded.
 - **Determinism:** per-user selection and final ordering use the same complete sequence, including row ID.
 - **API surface:** raw-attempt and best-per-user contracts are explicit; public DTOs retain casing and exclude raw IDs/JSON.
 - **Version semantics:** exact keys isolate versions; `ruleset_version` is required metadata rather than a hidden predicate.
-- **Metric extensibility:** the v1 allowlist is explicit and null semantics are documented.
+- **Metric extensibility:** the v1 allowlist and producer units are explicit; submitted fractions are rejected and malformed historical values have documented null semantics.
 - **Bootstrap coverage:** both non-test creation paths and public history mappings are named.
 - **Scope:** Ice Slide gameplay, semantic admission, highlighting, and UI remain in HPA-487/HPA-488.

--- a/scripts/init-db.sql
+++ b/scripts/init-db.sql
@@ -11,9 +11,12 @@ CREATE TABLE IF NOT EXISTS game_scores (
     user_id TEXT NOT NULL,
     game_id TEXT NOT NULL,
     score INTEGER NOT NULL,
+    mode TEXT,
+    competition_key TEXT,
+    ruleset_version INTEGER,
+    game_data_json TEXT,
     created_at DATETIME DEFAULT CURRENT_TIMESTAMP,
-    FOREIGN KEY (user_id) REFERENCES user(id) ON DELETE CASCADE,
-    -- game_id references game definitions in code
+    FOREIGN KEY (user_id) REFERENCES user(id) ON DELETE CASCADE
 );
 
 -- User statistics table - aggregated user gaming data
@@ -49,6 +52,14 @@ CREATE INDEX IF NOT EXISTS idx_game_scores_user_id ON game_scores(user_id);
 CREATE INDEX IF NOT EXISTS idx_game_scores_game_id ON game_scores(game_id);
 CREATE INDEX IF NOT EXISTS idx_game_scores_created_at ON game_scores(created_at);
 CREATE INDEX IF NOT EXISTS idx_game_scores_score ON game_scores(score);
+CREATE INDEX IF NOT EXISTS idx_game_scores_scoped_ranking
+    ON game_scores(
+        game_id,
+        mode,
+        competition_key,
+        score DESC,
+        created_at ASC
+    );
 CREATE INDEX IF NOT EXISTS idx_user_stats_user_id ON user_stats(user_id);
 CREATE INDEX IF NOT EXISTS idx_user_achievements_user_id ON user_achievements(user_id);
 CREATE INDEX IF NOT EXISTS idx_user_achievements_achievement_id ON user_achievements(achievement_id);

--- a/src/lib/server/api-utils.ts
+++ b/src/lib/server/api-utils.ts
@@ -20,6 +20,17 @@ export function errorResponse(message: string, status: number = 500): Response {
 }
 
 /**
+ * Create an error response with a machine-readable code
+ */
+export function codedErrorResponse<C extends string>(
+    message: string,
+    code: C,
+    status: number = 500
+): Response {
+    return jsonResponse({ error: message, code }, status)
+}
+
+/**
  * Create an unauthorized response
  */
 export function unauthorizedResponse(

--- a/src/lib/server/db/game-score-context.concurrent-migrator.test.ts
+++ b/src/lib/server/db/game-score-context.concurrent-migrator.test.ts
@@ -1,5 +1,4 @@
-import { beforeAll, describe, expect, it, vi } from 'vitest'
-import { sql } from 'kysely'
+import { beforeEach, describe, expect, it, vi } from 'vitest'
 
 vi.mock('@/lib/server/db/client', async () => {
     const { Kysely } = await import('kysely')
@@ -9,83 +8,126 @@ vi.mock('@/lib/server/db/client', async () => {
     return { db: new Kysely({ dialect }), dialect }
 })
 
-import { db } from '@/lib/server/db/client'
-import { ensureGameScoresContextSchema } from './game-score-context'
+// Each case targets one column whose capability name differs from (or matches)
+// its SQL column name. The concurrent-migrator recovery path must re-inspect
+// the schema after a "duplicate column name" failure and match the actual SQL
+// column name, not the camelCase capability key.
+const CASES = [
+    {
+        capability: 'mode' as const,
+        column: 'mode',
+        alterSql: 'ALTER TABLE game_scores ADD COLUMN mode TEXT',
+        alterRegex: /add\s+column\s+"?mode"?/i,
+    },
+    {
+        capability: 'competitionKey' as const,
+        column: 'competition_key',
+        alterSql: 'ALTER TABLE game_scores ADD COLUMN competition_key TEXT',
+        alterRegex: /add\s+column\s+"?competition_key"?/i,
+    },
+    {
+        capability: 'rulesetVersion' as const,
+        column: 'ruleset_version',
+        alterSql: 'ALTER TABLE game_scores ADD COLUMN ruleset_version INTEGER',
+        alterRegex: /add\s+column\s+"?ruleset_version"?/i,
+    },
+    {
+        capability: 'gameDataJson' as const,
+        column: 'game_data_json',
+        alterSql: 'ALTER TABLE game_scores ADD COLUMN game_data_json TEXT',
+        alterRegex: /add\s+column\s+"?game_data_json"?/i,
+    },
+]
 
-beforeAll(async () => {
-    await sql`
-        CREATE TABLE game_scores (
-            id INTEGER PRIMARY KEY AUTOINCREMENT,
-            user_id TEXT NOT NULL,
-            game_id TEXT NOT NULL,
-            score INTEGER NOT NULL,
-            created_at TEXT DEFAULT CURRENT_TIMESTAMP
-        )
-    `.execute(db)
-
-    await sql`
-        INSERT INTO game_scores (user_id, game_id, score)
-        VALUES ('u1', 'tetris', 123)
-    `.execute(db)
+beforeEach(async () => {
+    // Reset the module registry so each case gets a fresh in-memory DB and a
+    // fresh game-score-context module (whose module-level cachedState would
+    // otherwise short-circuit migration after the first case completes).
+    vi.resetModules()
 })
 
-describe('ensureGameScoresContextSchema - concurrent migrator', () => {
-    it('tolerates another process adding a column between inspection and ALTER', async () => {
-        const executor = db.getExecutor()
-        const originalExecute = executor.executeQuery.bind(executor)
+describe.each(CASES)(
+    'ensureGameScoresContextSchema - concurrent migrator ($capability)',
+    ({ capability, column, alterSql, alterRegex }) => {
+        it(`tolerates another process adding ${column} between inspection and ALTER`, async () => {
+            const { sql } = await import('kysely')
+            const { db } = await import('@/lib/server/db/client')
+            const { ensureGameScoresContextSchema } = await import(
+                './game-score-context'
+            )
 
-        let injectedConcurrentAdd = false
-        executor.executeQuery = vi.fn(async (query: any) => {
-            const sqlText: string = query.sql ?? ''
-
-            // Intercept the first ALTER for `mode` and simulate a second
-            // Vercel instance adding the column just before our ALTER runs.
-            // Our ALTER will then fail with "duplicate column name"; the
-            // migrator must re-inspect, see the column exists, and continue.
-            if (
-                !injectedConcurrentAdd &&
-                /add\s+column\s+"?mode"?/i.test(sqlText)
-            ) {
-                injectedConcurrentAdd = true
-                await sql`ALTER TABLE game_scores ADD COLUMN mode TEXT`.execute(
-                    db
+            await sql`DROP TABLE IF EXISTS game_scores`.execute(db)
+            await sql`
+                CREATE TABLE game_scores (
+                    id INTEGER PRIMARY KEY AUTOINCREMENT,
+                    user_id TEXT NOT NULL,
+                    game_id TEXT NOT NULL,
+                    score INTEGER NOT NULL,
+                    created_at TEXT DEFAULT CURRENT_TIMESTAMP
                 )
+            `.execute(db)
+
+            await sql`
+                INSERT INTO game_scores (user_id, game_id, score)
+                VALUES ('u1', 'tetris', 123)
+            `.execute(db)
+
+            const executor = db.getExecutor()
+            const originalExecute = executor.executeQuery.bind(executor)
+
+            let injectedConcurrentAdd = false
+            executor.executeQuery = vi.fn(async (query: any) => {
+                const sqlText: string = query.sql ?? ''
+
+                // Intercept the first ALTER for the target column and
+                // simulate a second Vercel instance adding it just before
+                // our ALTER runs. Our ALTER will then fail with "duplicate
+                // column name"; the migrator must re-inspect, see the
+                // column exists, and continue.
+                if (!injectedConcurrentAdd && alterRegex.test(sqlText)) {
+                    injectedConcurrentAdd = true
+                    await sql.raw(alterSql).execute(db)
+                }
+
+                return originalExecute(query)
+            }) as typeof executor.executeQuery
+
+            const state = await ensureGameScoresContextSchema()
+
+            expect(state.known).toBe(true)
+            if (!state.known) {
+                throw new Error('expected known state')
             }
+            expect(state.capabilities.mode).toBe(true)
+            expect(state.capabilities.competitionKey).toBe(true)
+            expect(state.capabilities.rulesetVersion).toBe(true)
+            expect(state.capabilities.gameDataJson).toBe(true)
 
-            return originalExecute(query)
-        }) as typeof executor.executeQuery
+            const columns = await sql<{
+                name: string
+            }>`PRAGMA table_info(game_scores)`.execute(db)
+            expect(columns.rows.map(row => row.name)).toEqual(
+                expect.arrayContaining([
+                    'mode',
+                    'competition_key',
+                    'ruleset_version',
+                    'game_data_json',
+                ])
+            )
 
-        const state = await ensureGameScoresContextSchema()
+            // The row written before migration must be preserved, with the
+            // concurrently-added column defaulting to null.
+            const rows = await sql<{
+                score: number
+            }>`SELECT score, ${sql.raw(column)} AS col FROM game_scores`.execute(
+                db
+            )
+            expect(rows.rows).toHaveLength(1)
+            expect(rows.rows[0].score).toBe(123)
+            expect((rows.rows[0] as Record<string, unknown>).col).toBeNull()
 
-        expect(state.known).toBe(true)
-        if (!state.known) {
-            throw new Error('expected known state')
-        }
-        expect(state.capabilities.mode).toBe(true)
-        expect(state.capabilities.competitionKey).toBe(true)
-        expect(state.capabilities.rulesetVersion).toBe(true)
-        expect(state.capabilities.gameDataJson).toBe(true)
-
-        const columns = await sql<{
-            name: string
-        }>`PRAGMA table_info(game_scores)`.execute(db)
-        expect(columns.rows.map(row => row.name)).toEqual(
-            expect.arrayContaining([
-                'mode',
-                'competition_key',
-                'ruleset_version',
-                'game_data_json',
-            ])
-        )
-
-        // The row written before migration must be preserved, with the
-        // concurrently-added column defaulting to null.
-        const rows = await sql<{
-            score: number
-            mode: string | null
-        }>`SELECT score, mode FROM game_scores`.execute(db)
-        expect(rows.rows).toEqual([{ score: 123, mode: null }])
-
-        expect(injectedConcurrentAdd).toBe(true)
-    })
-})
+            expect(injectedConcurrentAdd).toBe(true)
+            expect(state.capabilities[capability]).toBe(true)
+        })
+    }
+)

--- a/src/lib/server/db/game-score-context.concurrent-migrator.test.ts
+++ b/src/lib/server/db/game-score-context.concurrent-migrator.test.ts
@@ -1,0 +1,91 @@
+import { beforeAll, describe, expect, it, vi } from 'vitest'
+import { sql } from 'kysely'
+
+vi.mock('@/lib/server/db/client', async () => {
+    const { Kysely } = await import('kysely')
+    const { LibsqlDialect, libsql } = await import('@libsql/kysely-libsql')
+    const client = libsql.createClient({ url: ':memory:' })
+    const dialect = new LibsqlDialect({ client })
+    return { db: new Kysely({ dialect }), dialect }
+})
+
+import { db } from '@/lib/server/db/client'
+import { ensureGameScoresContextSchema } from './game-score-context'
+
+beforeAll(async () => {
+    await sql`
+        CREATE TABLE game_scores (
+            id INTEGER PRIMARY KEY AUTOINCREMENT,
+            user_id TEXT NOT NULL,
+            game_id TEXT NOT NULL,
+            score INTEGER NOT NULL,
+            created_at TEXT DEFAULT CURRENT_TIMESTAMP
+        )
+    `.execute(db)
+
+    await sql`
+        INSERT INTO game_scores (user_id, game_id, score)
+        VALUES ('u1', 'tetris', 123)
+    `.execute(db)
+})
+
+describe('ensureGameScoresContextSchema - concurrent migrator', () => {
+    it('tolerates another process adding a column between inspection and ALTER', async () => {
+        const executor = db.getExecutor()
+        const originalExecute = executor.executeQuery.bind(executor)
+
+        let injectedConcurrentAdd = false
+        executor.executeQuery = vi.fn(async (query: any) => {
+            const sqlText: string = query.sql ?? ''
+
+            // Intercept the first ALTER for `mode` and simulate a second
+            // Vercel instance adding the column just before our ALTER runs.
+            // Our ALTER will then fail with "duplicate column name"; the
+            // migrator must re-inspect, see the column exists, and continue.
+            if (
+                !injectedConcurrentAdd &&
+                /add\s+column\s+"?mode"?/i.test(sqlText)
+            ) {
+                injectedConcurrentAdd = true
+                await sql`ALTER TABLE game_scores ADD COLUMN mode TEXT`.execute(
+                    db
+                )
+            }
+
+            return originalExecute(query)
+        }) as typeof executor.executeQuery
+
+        const state = await ensureGameScoresContextSchema()
+
+        expect(state.known).toBe(true)
+        if (!state.known) {
+            throw new Error('expected known state')
+        }
+        expect(state.capabilities.mode).toBe(true)
+        expect(state.capabilities.competitionKey).toBe(true)
+        expect(state.capabilities.rulesetVersion).toBe(true)
+        expect(state.capabilities.gameDataJson).toBe(true)
+
+        const columns = await sql<{
+            name: string
+        }>`PRAGMA table_info(game_scores)`.execute(db)
+        expect(columns.rows.map(row => row.name)).toEqual(
+            expect.arrayContaining([
+                'mode',
+                'competition_key',
+                'ruleset_version',
+                'game_data_json',
+            ])
+        )
+
+        // The row written before migration must be preserved, with the
+        // concurrently-added column defaulting to null.
+        const rows = await sql<{
+            score: number
+            mode: string | null
+        }>`SELECT score, mode FROM game_scores`.execute(db)
+        expect(rows.rows).toEqual([{ score: 123, mode: null }])
+
+        expect(injectedConcurrentAdd).toBe(true)
+    })
+})

--- a/src/lib/server/db/game-score-context.index-retry.test.ts
+++ b/src/lib/server/db/game-score-context.index-retry.test.ts
@@ -1,0 +1,63 @@
+import { beforeAll, describe, expect, it, vi } from 'vitest'
+import { sql } from 'kysely'
+
+vi.mock('@/lib/server/db/client', async () => {
+    const { Kysely } = await import('kysely')
+    const { LibsqlDialect, libsql } = await import('@libsql/kysely-libsql')
+    const client = libsql.createClient({ url: ':memory:' })
+    const dialect = new LibsqlDialect({ client })
+    return { db: new Kysely({ dialect }), dialect }
+})
+
+import { db } from '@/lib/server/db/client'
+import { ensureGameScoresContextSchema } from './game-score-context'
+
+beforeAll(async () => {
+    vi.useFakeTimers()
+    vi.setSystemTime(new Date('2026-08-01T00:00:00Z'))
+
+    await sql`
+        CREATE TABLE game_scores (
+            id INTEGER PRIMARY KEY AUTOINCREMENT,
+            user_id TEXT NOT NULL,
+            game_id TEXT NOT NULL,
+            score INTEGER NOT NULL,
+            mode TEXT,
+            competition_key TEXT,
+            ruleset_version INTEGER,
+            game_data_json TEXT,
+            created_at TEXT DEFAULT CURRENT_TIMESTAMP
+        )
+    `.execute(db)
+
+    await sql`
+        CREATE TABLE idx_game_scores_scoped_ranking (id INTEGER)
+    `.execute(db)
+})
+
+describe('score-context index retry backoff', () => {
+    it('skips hot-path retries inside the delay and succeeds after one minute', async () => {
+        const executeSpy = vi.spyOn(db.getExecutor(), 'executeQuery')
+
+        const first = await ensureGameScoresContextSchema()
+        expect(first.known && first.capabilities.scopedIndex).toBe(false)
+
+        executeSpy.mockClear()
+        await ensureGameScoresContextSchema()
+        expect(
+            executeSpy.mock.calls.some(([query]) =>
+                query.sql.includes('CREATE INDEX')
+            )
+        ).toBe(false)
+
+        await sql`DROP TABLE idx_game_scores_scoped_ranking`.execute(db)
+        vi.advanceTimersByTime(60_000)
+
+        const recovered = await ensureGameScoresContextSchema()
+        expect(recovered.known).toBe(true)
+        if (!recovered.known) {
+            throw new Error('expected known state')
+        }
+        expect(recovered.capabilities.scopedIndex).toBe(true)
+    })
+})

--- a/src/lib/server/db/game-score-context.migrations.test.ts
+++ b/src/lib/server/db/game-score-context.migrations.test.ts
@@ -1,0 +1,81 @@
+import { beforeAll, describe, expect, it, vi } from 'vitest'
+import { sql } from 'kysely'
+
+vi.mock('@/lib/server/db/client', async () => {
+    const { Kysely } = await import('kysely')
+    const { LibsqlDialect, libsql } = await import('@libsql/kysely-libsql')
+    const client = libsql.createClient({ url: ':memory:' })
+    const dialect = new LibsqlDialect({ client })
+    return { db: new Kysely({ dialect }), dialect }
+})
+
+import { db } from '@/lib/server/db/client'
+import {
+    ensureGameScoresContextSchema,
+    getCachedGameScoresContextState,
+    hasCompleteGameScoresContextColumns,
+} from './game-score-context'
+
+beforeAll(async () => {
+    await sql`
+        CREATE TABLE game_scores (
+            id INTEGER PRIMARY KEY AUTOINCREMENT,
+            user_id TEXT NOT NULL,
+            game_id TEXT NOT NULL,
+            score INTEGER NOT NULL,
+            created_at TEXT DEFAULT CURRENT_TIMESTAMP
+        )
+    `.execute(db)
+
+    await sql`
+        INSERT INTO game_scores (user_id, game_id, score)
+        VALUES ('u1', 'tetris', 123)
+    `.execute(db)
+})
+
+describe('ensureGameScoresContextSchema', () => {
+    it('single-flights migration, preserves rows, and caches complete capability', async () => {
+        const executeSpy = vi.spyOn(db.getExecutor(), 'executeQuery')
+
+        const states = await Promise.all([
+            ensureGameScoresContextSchema(),
+            ensureGameScoresContextSchema(),
+            ensureGameScoresContextSchema(),
+        ])
+
+        expect(states.every(state => state.known)).toBe(true)
+        const state = states[0]
+        if (!state.known) {
+            throw new Error('expected known state')
+        }
+
+        expect(hasCompleteGameScoresContextColumns(state.capabilities)).toBe(
+            true
+        )
+        expect(state.capabilities.scopedIndex).toBe(true)
+        expect(getCachedGameScoresContextState()).toEqual(state)
+
+        const tableInfoCalls = executeSpy.mock.calls.filter(([query]) =>
+            query.sql.includes('PRAGMA table_info(game_scores)')
+        )
+        expect(tableInfoCalls).toHaveLength(2)
+
+        const columns = await sql<{
+            name: string
+        }>`PRAGMA table_info(game_scores)`.execute(db)
+        expect(columns.rows.map(row => row.name)).toEqual(
+            expect.arrayContaining([
+                'mode',
+                'competition_key',
+                'ruleset_version',
+                'game_data_json',
+            ])
+        )
+
+        const rows = await sql<{
+            score: number
+            mode: string | null
+        }>`SELECT score, mode FROM game_scores`.execute(db)
+        expect(rows.rows).toEqual([{ score: 123, mode: null }])
+    })
+})

--- a/src/lib/server/db/game-score-context.stale-incomplete-fallback.test.ts
+++ b/src/lib/server/db/game-score-context.stale-incomplete-fallback.test.ts
@@ -1,0 +1,132 @@
+import { describe, expect, it, vi } from 'vitest'
+
+// In-memory libSQL instance shared across the single test below. The mock
+// factory is hoisted; vi.resetModules() in the test re-runs it to give a fresh
+// DB and a fresh game-score-context module (whose module-level cachedState
+// must start empty for the stale-snapshot scenario).
+vi.mock('@/lib/server/db/client', async () => {
+    const { Kysely } = await import('kysely')
+    const { LibsqlDialect, libsql } = await import('@libsql/kysely-libsql')
+    const client = libsql.createClient({ url: ':memory:' })
+    const dialect = new LibsqlDialect({ client })
+    return { db: new Kysely({ dialect }), dialect }
+})
+
+describe('inspectAndMigrate - stale incomplete cached state', () => {
+    it('fails closed when a refresh probe fails after caching an incomplete schema', async () => {
+        vi.resetModules()
+
+        const { sql } = await import('kysely')
+        const { db } = await import('@/lib/server/db/client')
+        const { ensureGameScoresContextSchema } = await import(
+            './game-score-context'
+        )
+        const { getGameLeaderboard, isGameLeaderboardAvailable } = await import(
+            './queries'
+        )
+
+        // Start with a legacy schema (no score-context columns).
+        await sql`DROP TABLE IF EXISTS game_scores`.execute(db)
+        await sql`DROP TABLE IF EXISTS user`.execute(db)
+        await sql`
+            CREATE TABLE game_scores (
+                id INTEGER PRIMARY KEY AUTOINCREMENT,
+                user_id TEXT NOT NULL,
+                game_id TEXT NOT NULL,
+                score INTEGER NOT NULL,
+                created_at TEXT DEFAULT CURRENT_TIMESTAMP
+            )
+        `.execute(db)
+        await sql`
+            CREATE TABLE user (
+                id TEXT PRIMARY KEY,
+                name TEXT NOT NULL,
+                email TEXT NOT NULL,
+                emailVerified INTEGER NOT NULL DEFAULT 0,
+                image TEXT,
+                username TEXT,
+                displayName TEXT,
+                createdAt TEXT DEFAULT CURRENT_TIMESTAMP,
+                updatedAt TEXT DEFAULT CURRENT_TIMESTAMP
+            )
+        `.execute(db)
+
+        const executor = db.getExecutor()
+        const originalExecute = executor.executeQuery.bind(executor)
+
+        // Phase 1: let the initial inspection succeed (incomplete) but fail the
+        // first ALTER so migration throws and the catch path runs with an
+        // incomplete cachedState.
+        let phase: 1 | 3 = 1
+        executor.executeQuery = vi.fn(async (query: any) => {
+            const sqlText: string = query.sql ?? ''
+            if (phase === 1 && /ALTER\s+TABLE/i.test(sqlText)) {
+                throw new Error('injected migration failure')
+            }
+            return originalExecute(query)
+        }) as typeof executor.executeQuery
+
+        const firstState = await ensureGameScoresContextSchema()
+        // An incomplete cached state must not be reported as known; otherwise
+        // callers treat the context as available and skip the unscoped-row
+        // isolation filter.
+        expect(firstState.known).toBe(false)
+
+        // Phase 2 (external): another Vercel instance finishes the migration
+        // and starts accepting scoped rows. Restore the real executor so the
+        // external ALTERs and inserts run unmodified.
+        executor.executeQuery = originalExecute
+        await sql`ALTER TABLE game_scores ADD COLUMN mode TEXT`.execute(db)
+        await sql`ALTER TABLE game_scores ADD COLUMN competition_key TEXT`.execute(
+            db
+        )
+        await sql`ALTER TABLE game_scores ADD COLUMN ruleset_version INTEGER`.execute(
+            db
+        )
+        await sql`ALTER TABLE game_scores ADD COLUMN game_data_json TEXT`.execute(
+            db
+        )
+
+        await sql`
+            INSERT INTO user (id, name, email, emailVerified)
+            VALUES ('u1', 'Alice', 'a@t.co', 0)
+        `.execute(db)
+        // A scoped (campaign) row that must never appear in the unscoped
+        // leaderboard, and an unscoped row that legitimately belongs there.
+        await sql`
+            INSERT INTO game_scores (user_id, game_id, score, mode, competition_key)
+            VALUES ('u1', 'tetris', 999, 'campaign', 'season-1')
+        `.execute(db)
+        await sql`
+            INSERT INTO game_scores (user_id, game_id, score)
+            VALUES ('u1', 'tetris', 100)
+        `.execute(db)
+
+        // Phase 3: the next capability probe fails transiently. Only the
+        // PRAGMA inspection is forced to throw; the leaderboard SELECT (if it
+        // were to run) is allowed.
+        phase = 3
+        executor.executeQuery = vi.fn(async (query: any) => {
+            const sqlText: string = query.sql ?? ''
+            if (/PRAGMA\s+table_info/i.test(sqlText)) {
+                throw new Error('injected probe failure')
+            }
+            return originalExecute(query)
+        }) as typeof executor.executeQuery
+
+        const result = await getGameLeaderboard('tetris', 10)
+
+        // Must fail closed: the scoped campaign row (score 999) must not leak
+        // into the unscoped leaderboard, and the caller must see the coded
+        // 503-style unavailable result rather than a silently wrong list.
+        expect(isGameLeaderboardAvailable(result)).toBe(false)
+        if (!isGameLeaderboardAvailable(result)) {
+            expect(result).toEqual({
+                status: 'unavailable',
+                code: 'SCORE_CONTEXT_UNAVAILABLE',
+            })
+        }
+
+        executor.executeQuery = originalExecute
+    })
+})

--- a/src/lib/server/db/game-score-context.stale-incomplete-fallback.test.ts
+++ b/src/lib/server/db/game-score-context.stale-incomplete-fallback.test.ts
@@ -58,13 +58,15 @@ describe('inspectAndMigrate - stale incomplete cached state', () => {
         // first ALTER so migration throws and the catch path runs with an
         // incomplete cachedState.
         let phase: 1 | 3 = 1
-        executor.executeQuery = vi.fn(async (query: any) => {
-            const sqlText: string = query.sql ?? ''
-            if (phase === 1 && /ALTER\s+TABLE/i.test(sqlText)) {
-                throw new Error('injected migration failure')
+        executor.executeQuery = vi.fn(
+            async (query: Parameters<typeof executor.executeQuery>[0]) => {
+                const sqlText: string = query.sql ?? ''
+                if (phase === 1 && /ALTER\s+TABLE/i.test(sqlText)) {
+                    throw new Error('injected migration failure')
+                }
+                return originalExecute(query)
             }
-            return originalExecute(query)
-        }) as typeof executor.executeQuery
+        ) as typeof executor.executeQuery
 
         const firstState = await ensureGameScoresContextSchema()
         // An incomplete cached state must not be reported as known; otherwise
@@ -106,13 +108,15 @@ describe('inspectAndMigrate - stale incomplete cached state', () => {
         // PRAGMA inspection is forced to throw; the leaderboard SELECT (if it
         // were to run) is allowed.
         phase = 3
-        executor.executeQuery = vi.fn(async (query: any) => {
-            const sqlText: string = query.sql ?? ''
-            if (/PRAGMA\s+table_info/i.test(sqlText)) {
-                throw new Error('injected probe failure')
+        executor.executeQuery = vi.fn(
+            async (query: Parameters<typeof executor.executeQuery>[0]) => {
+                const sqlText: string = query.sql ?? ''
+                if (/PRAGMA\s+table_info/i.test(sqlText)) {
+                    throw new Error('injected probe failure')
+                }
+                return originalExecute(query)
             }
-            return originalExecute(query)
-        }) as typeof executor.executeQuery
+        ) as typeof executor.executeQuery
 
         const result = await getGameLeaderboard('tetris', 10)
 

--- a/src/lib/server/db/game-score-context.ts
+++ b/src/lib/server/db/game-score-context.ts
@@ -1,0 +1,183 @@
+import { sql } from 'kysely'
+import { db } from './client'
+
+export interface PersistedScoreContext {
+    mode: string
+    competitionKey: string | null
+    rulesetVersion: number
+    gameDataJson: string | null
+}
+
+export type SaveGameScoreFailureCode =
+    | 'SCORE_CONTEXT_UNAVAILABLE'
+    | 'SCORE_WRITE_FAILED'
+
+export type SaveGameScoreResult =
+    | { success: true }
+    | { success: false; code: SaveGameScoreFailureCode }
+
+export type SaveGameScoreWithAchievementsResult =
+    | { success: true; newAchievements: string[] }
+    | {
+          success: false
+          newAchievements: []
+          code: SaveGameScoreFailureCode
+      }
+
+export interface GameScoresContextCapabilities {
+    mode: boolean
+    competitionKey: boolean
+    rulesetVersion: boolean
+    gameDataJson: boolean
+    scopedIndex: boolean
+}
+
+export type GameScoresContextState =
+    | {
+          known: true
+          capabilities: GameScoresContextCapabilities
+      }
+    | { known: false }
+
+const INDEX_NAME = 'idx_game_scores_scoped_ranking'
+const INDEX_RETRY_MIN_MS = 60_000
+const INDEX_RETRY_MAX_MS = 3_600_000
+
+let cachedState: GameScoresContextState | null = null
+let schemaPromise: Promise<GameScoresContextState> | null = null
+let indexRetryDelayMs = INDEX_RETRY_MIN_MS
+let nextIndexRetryAt = 0
+
+export function hasCompleteGameScoresContextColumns(
+    capabilities: GameScoresContextCapabilities
+): boolean {
+    return (
+        capabilities.mode &&
+        capabilities.competitionKey &&
+        capabilities.rulesetVersion &&
+        capabilities.gameDataJson
+    )
+}
+
+export function getCachedGameScoresContextState(): GameScoresContextState | null {
+    return cachedState
+}
+
+async function inspectCapabilities(): Promise<GameScoresContextCapabilities> {
+    const columns = await sql<{
+        name: string
+    }>`PRAGMA table_info(game_scores)`.execute(db)
+    const names = new Set(columns.rows.map(row => row.name))
+
+    const indexes = await sql<{ name: string }>`
+        SELECT name
+        FROM sqlite_master
+        WHERE type = 'index' AND tbl_name = 'game_scores'
+    `.execute(db)
+
+    return {
+        mode: names.has('mode'),
+        competitionKey: names.has('competition_key'),
+        rulesetVersion: names.has('ruleset_version'),
+        gameDataJson: names.has('game_data_json'),
+        scopedIndex: indexes.rows.some(row => row.name === INDEX_NAME),
+    }
+}
+
+async function addMissingColumns(
+    capabilities: GameScoresContextCapabilities
+): Promise<void> {
+    if (!capabilities.mode) {
+        await sql`ALTER TABLE game_scores ADD COLUMN mode TEXT`.execute(db)
+    }
+    if (!capabilities.competitionKey) {
+        await sql`
+            ALTER TABLE game_scores ADD COLUMN competition_key TEXT
+        `.execute(db)
+    }
+    if (!capabilities.rulesetVersion) {
+        await sql`
+            ALTER TABLE game_scores ADD COLUMN ruleset_version INTEGER
+        `.execute(db)
+    }
+    if (!capabilities.gameDataJson) {
+        await sql`
+            ALTER TABLE game_scores ADD COLUMN game_data_json TEXT
+        `.execute(db)
+    }
+}
+
+async function createScopedIndexIfDue(
+    capabilities: GameScoresContextCapabilities
+): Promise<GameScoresContextCapabilities> {
+    if (
+        !hasCompleteGameScoresContextColumns(capabilities) ||
+        capabilities.scopedIndex ||
+        Date.now() < nextIndexRetryAt
+    ) {
+        return capabilities
+    }
+
+    try {
+        await sql`
+            CREATE INDEX IF NOT EXISTS idx_game_scores_scoped_ranking
+            ON game_scores (
+                game_id,
+                mode,
+                competition_key,
+                score DESC,
+                created_at ASC
+            )
+        `.execute(db)
+
+        indexRetryDelayMs = INDEX_RETRY_MIN_MS
+        nextIndexRetryAt = 0
+        return { ...capabilities, scopedIndex: true }
+    } catch (error) {
+        console.warn('[game-score-context] index creation failed:', error)
+        nextIndexRetryAt = Date.now() + indexRetryDelayMs
+        indexRetryDelayMs = Math.min(indexRetryDelayMs * 2, INDEX_RETRY_MAX_MS)
+        return capabilities
+    }
+}
+
+async function inspectAndMigrate(): Promise<GameScoresContextState> {
+    try {
+        let capabilities = await inspectCapabilities()
+        cachedState = { known: true, capabilities }
+
+        if (!hasCompleteGameScoresContextColumns(capabilities)) {
+            await addMissingColumns(capabilities)
+            capabilities = await inspectCapabilities()
+            cachedState = { known: true, capabilities }
+        }
+
+        capabilities = await createScopedIndexIfDue(capabilities)
+        cachedState = { known: true, capabilities }
+        return cachedState
+    } catch (error) {
+        console.warn('[game-score-context] capability probe failed:', error)
+        return cachedState ?? { known: false }
+    }
+}
+
+export function ensureGameScoresContextSchema(): Promise<GameScoresContextState> {
+    const cachedCapabilities =
+        cachedState?.known === true ? cachedState.capabilities : null
+
+    if (
+        cachedCapabilities &&
+        hasCompleteGameScoresContextColumns(cachedCapabilities) &&
+        (cachedCapabilities.scopedIndex || Date.now() < nextIndexRetryAt)
+    ) {
+        return Promise.resolve(cachedState as GameScoresContextState)
+    }
+
+    if (!schemaPromise) {
+        schemaPromise = inspectAndMigrate().finally(() => {
+            schemaPromise = null
+        })
+    }
+
+    return schemaPromise
+}

--- a/src/lib/server/db/game-score-context.ts
+++ b/src/lib/server/db/game-score-context.ts
@@ -84,26 +84,72 @@ async function inspectCapabilities(): Promise<GameScoresContextCapabilities> {
     }
 }
 
+const MISSING_COLUMN_DEFINITIONS = [
+    {
+        capability: 'mode' as const,
+        add: () =>
+            sql`ALTER TABLE game_scores ADD COLUMN mode TEXT`.execute(db),
+    },
+    {
+        capability: 'competitionKey' as const,
+        add: () =>
+            sql`
+                ALTER TABLE game_scores ADD COLUMN competition_key TEXT
+            `.execute(db),
+    },
+    {
+        capability: 'rulesetVersion' as const,
+        add: () =>
+            sql`
+                ALTER TABLE game_scores ADD COLUMN ruleset_version INTEGER
+            `.execute(db),
+    },
+    {
+        capability: 'gameDataJson' as const,
+        add: () =>
+            sql`
+                ALTER TABLE game_scores ADD COLUMN game_data_json TEXT
+            `.execute(db),
+    },
+]
+
+/**
+ * Add a column, tolerating a concurrent migrator that already added it.
+ *
+ * A second Vercel instance can run the same migration between our initial
+ * schema inspection and this ALTER TABLE; SQLite then fails with
+ * "duplicate column name". Re-inspect the schema after such a failure and
+ * continue when the target column now exists, otherwise rethrow so the outer
+ * handler reports a genuine failure instead of a stale capability snapshot.
+ */
+async function addColumnToleratingConcurrentMigrator(
+    add: () => Promise<unknown>,
+    columnName: string
+): Promise<void> {
+    try {
+        await add()
+    } catch (error) {
+        const columns = await sql<{
+            name: string
+        }>`PRAGMA table_info(game_scores)`.execute(db)
+        const nowPresent = columns.rows.some(row => row.name === columnName)
+        if (nowPresent) {
+            return
+        }
+        throw error
+    }
+}
+
 async function addMissingColumns(
     capabilities: GameScoresContextCapabilities
 ): Promise<void> {
-    if (!capabilities.mode) {
-        await sql`ALTER TABLE game_scores ADD COLUMN mode TEXT`.execute(db)
-    }
-    if (!capabilities.competitionKey) {
-        await sql`
-            ALTER TABLE game_scores ADD COLUMN competition_key TEXT
-        `.execute(db)
-    }
-    if (!capabilities.rulesetVersion) {
-        await sql`
-            ALTER TABLE game_scores ADD COLUMN ruleset_version INTEGER
-        `.execute(db)
-    }
-    if (!capabilities.gameDataJson) {
-        await sql`
-            ALTER TABLE game_scores ADD COLUMN game_data_json TEXT
-        `.execute(db)
+    for (const definition of MISSING_COLUMN_DEFINITIONS) {
+        if (!capabilities[definition.capability]) {
+            await addColumnToleratingConcurrentMigrator(
+                definition.add,
+                definition.capability
+            )
+        }
     }
 }
 

--- a/src/lib/server/db/game-score-context.ts
+++ b/src/lib/server/db/game-score-context.ts
@@ -87,11 +87,13 @@ async function inspectCapabilities(): Promise<GameScoresContextCapabilities> {
 const MISSING_COLUMN_DEFINITIONS = [
     {
         capability: 'mode' as const,
+        columnName: 'mode',
         add: () =>
             sql`ALTER TABLE game_scores ADD COLUMN mode TEXT`.execute(db),
     },
     {
         capability: 'competitionKey' as const,
+        columnName: 'competition_key',
         add: () =>
             sql`
                 ALTER TABLE game_scores ADD COLUMN competition_key TEXT
@@ -99,6 +101,7 @@ const MISSING_COLUMN_DEFINITIONS = [
     },
     {
         capability: 'rulesetVersion' as const,
+        columnName: 'ruleset_version',
         add: () =>
             sql`
                 ALTER TABLE game_scores ADD COLUMN ruleset_version INTEGER
@@ -106,6 +109,7 @@ const MISSING_COLUMN_DEFINITIONS = [
     },
     {
         capability: 'gameDataJson' as const,
+        columnName: 'game_data_json',
         add: () =>
             sql`
                 ALTER TABLE game_scores ADD COLUMN game_data_json TEXT
@@ -147,7 +151,7 @@ async function addMissingColumns(
         if (!capabilities[definition.capability]) {
             await addColumnToleratingConcurrentMigrator(
                 definition.add,
-                definition.capability
+                definition.columnName
             )
         }
     }

--- a/src/lib/server/db/game-score-context.ts
+++ b/src/lib/server/db/game-score-context.ts
@@ -207,7 +207,20 @@ async function inspectAndMigrate(): Promise<GameScoresContextState> {
         return cachedState
     } catch (error) {
         console.warn('[game-score-context] capability probe failed:', error)
-        return cachedState ?? { known: false }
+        // Reuse the cached state only when its context columns are confirmed
+        // complete. Returning an incomplete snapshot after a failed refresh is
+        // unsafe across Vercel instances: another instance may have finished
+        // the migration and started accepting scoped rows, and an incomplete
+        // capability set causes applyUnscopedContextIsolation to leave the
+        // query unfiltered, leaking scoped rows into unscoped leaderboards and
+        // bypassing the SCORE_CONTEXT_UNAVAILABLE 503 path. Fail closed.
+        if (
+            cachedState?.known === true &&
+            hasCompleteGameScoresContextColumns(cachedState.capabilities)
+        ) {
+            return cachedState
+        }
+        return { known: false }
     }
 }
 

--- a/src/lib/server/db/game-score-schema-files.test.ts
+++ b/src/lib/server/db/game-score-schema-files.test.ts
@@ -1,0 +1,64 @@
+import { readFile } from 'node:fs/promises'
+import { resolve } from 'node:path'
+import { createClient } from '@libsql/client'
+import { describe, expect, it } from 'vitest'
+
+const schemaFiles = [
+    'scripts/init-db.sql',
+    'better-auth_migrations/2025-07-06-schema-consolidation.sql',
+] as const
+
+function extractGameScoresDdl(source: string): string {
+    const table = source.match(
+        /CREATE TABLE IF NOT EXISTS\s+"?game_scores"?\s*\([\s\S]*?\n\);/i
+    )?.[0]
+    const index = source.match(
+        /CREATE INDEX IF NOT EXISTS\s+"?idx_game_scores_scoped_ranking"?[\s\S]*?;/i
+    )?.[0]
+
+    if (!table || !index) {
+        throw new Error('game_scores table or scoped index DDL is missing')
+    }
+
+    return `${table}\n${index}`
+}
+
+describe.each(schemaFiles)('%s', schemaPath => {
+    it('creates the complete contextual score schema', async () => {
+        const source = await readFile(
+            resolve(process.cwd(), schemaPath),
+            'utf8'
+        )
+        const client = createClient({ url: ':memory:' })
+
+        await client.executeMultiple(extractGameScoresDdl(source))
+
+        const columns = await client.execute('PRAGMA table_info(game_scores)')
+        expect(columns.rows.map(row => String(row.name))).toEqual(
+            expect.arrayContaining([
+                'id',
+                'user_id',
+                'game_id',
+                'score',
+                'mode',
+                'competition_key',
+                'ruleset_version',
+                'game_data_json',
+                'created_at',
+            ])
+        )
+
+        const index = await client.execute(
+            'PRAGMA index_info(idx_game_scores_scoped_ranking)'
+        )
+        expect(index.rows.map(row => String(row.name))).toEqual([
+            'game_id',
+            'mode',
+            'competition_key',
+            'score',
+            'created_at',
+        ])
+
+        client.close()
+    })
+})

--- a/src/lib/server/db/game-score-schema-files.test.ts
+++ b/src/lib/server/db/game-score-schema-files.test.ts
@@ -59,6 +59,32 @@ describe.each(schemaFiles)('%s', schemaPath => {
             'created_at',
         ])
 
+        // PRAGMA index_info returns column names but not sort directions.
+        // index_xinfo adds a `desc` column (1 = DESC, 0 = ASC) so we can
+        // verify the ranking-critical ordering: score DESC, created_at ASC.
+        const indexXinfo = await client.execute(
+            'PRAGMA index_xinfo(idx_game_scores_scoped_ranking)'
+        )
+        // index_xinfo appends a trailing rowid auxiliary row (name = null,
+        // cid = -1); filter it out so only the declared index columns remain.
+        const xinfoRows = indexXinfo.rows
+            .filter(row => row.name !== null)
+            .map(row => ({
+                name: String(row.name),
+                desc: Number(row.desc),
+            }))
+        expect(xinfoRows.map(row => row.name)).toEqual([
+            'game_id',
+            'mode',
+            'competition_key',
+            'score',
+            'created_at',
+        ])
+        const scoreColumn = xinfoRows.find(row => row.name === 'score')
+        const createdAtColumn = xinfoRows.find(row => row.name === 'created_at')
+        expect(scoreColumn?.desc).toBe(1)
+        expect(createdAtColumn?.desc).toBe(0)
+
         client.close()
     })
 })

--- a/src/lib/server/db/queries.extended.test.ts
+++ b/src/lib/server/db/queries.extended.test.ts
@@ -7,6 +7,7 @@ import {
     getUserBestScore,
     getUserBestScoreForGame,
     getGameLeaderboard,
+    isGameLeaderboardAvailable,
     saveGameScoreWithAchievements,
     updateUser,
     getUserAchievements,
@@ -91,6 +92,20 @@ const COMPLETE_CAPABILITIES = {
         scopedIndex: true,
     },
 } as const
+
+// Narrow a GameLeaderboardResult to its success (array) branch. These tests
+// mock ensureGameScoresContextSchema to confirmed-complete capabilities, so
+// the probe always succeeds and the result is always an array; this helper
+// makes that invariant explicit for TypeScript while failing the test if it
+// ever does not hold.
+function asEntries(result: Awaited<ReturnType<typeof getGameLeaderboard>>) {
+    if (!isGameLeaderboardAvailable(result)) {
+        throw new Error(
+            'expected leaderboard entries but got unavailable result'
+        )
+    }
+    return result
+}
 
 describe('Extended Database Queries', () => {
     beforeEach(() => {
@@ -453,7 +468,7 @@ describe('Extended Database Queries', () => {
             }
             vi.mocked(db.selectFrom).mockReturnValue(mockQuery as any)
 
-            const result = await getGameLeaderboard('tetris', 10)
+            const result = asEntries(await getGameLeaderboard('tetris', 10))
 
             expect(result).toHaveLength(1)
             expect(result[0].name).toBe('Player One')
@@ -480,7 +495,7 @@ describe('Extended Database Queries', () => {
             }
             vi.mocked(db.selectFrom).mockReturnValue(mockQuery as any)
 
-            const result = await getGameLeaderboard('tetris')
+            const result = asEntries(await getGameLeaderboard('tetris'))
 
             expect(result[0].name).toBe('Anonymous')
             expect(result[0].username).toBeNull()

--- a/src/lib/server/db/queries.extended.test.ts
+++ b/src/lib/server/db/queries.extended.test.ts
@@ -371,10 +371,10 @@ describe('Extended Database Queries', () => {
 
             const result = await getUserBestScore('user-123', 'tetris')
 
-            expect(result).toBe(9500)
+            expect(result).toEqual({ status: 'ok', bestScore: 9500 })
         })
 
-        it('should return null when no scores exist', async () => {
+        it('should return ok/null when no scores exist', async () => {
             const mockQuery = {
                 select: vi.fn().mockReturnThis(),
                 where: vi.fn().mockReturnThis(),
@@ -386,17 +386,17 @@ describe('Extended Database Queries', () => {
 
             const result = await getUserBestScore('user-123', 'tetris')
 
-            expect(result).toBeNull()
+            expect(result).toEqual({ status: 'ok', bestScore: null })
         })
 
-        it('should return null on database error', async () => {
+        it('should return ok/null on database error', async () => {
             vi.mocked(db.selectFrom).mockImplementation(() => {
                 throw new Error('DB error')
             })
 
             const result = await getUserBestScore('user-123', 'tetris')
 
-            expect(result).toBeNull()
+            expect(result).toEqual({ status: 'ok', bestScore: null })
         })
     })
 

--- a/src/lib/server/db/queries.extended.test.ts
+++ b/src/lib/server/db/queries.extended.test.ts
@@ -68,9 +68,36 @@ vi.mock('@/lib/achievements', () => ({
     ]),
 }))
 
+vi.mock('@/lib/server/db/game-score-context', async importOriginal => {
+    const actual =
+        await importOriginal<
+            typeof import('@/lib/server/db/game-score-context')
+        >()
+    return {
+        ...actual,
+        ensureGameScoresContextSchema: vi.fn(),
+    }
+})
+
+import { ensureGameScoresContextSchema } from '@/lib/server/db/game-score-context'
+
+const COMPLETE_CAPABILITIES = {
+    known: true,
+    capabilities: {
+        mode: true,
+        competitionKey: true,
+        rulesetVersion: true,
+        gameDataJson: true,
+        scopedIndex: true,
+    },
+} as const
+
 describe('Extended Database Queries', () => {
     beforeEach(() => {
         vi.clearAllMocks()
+        vi.mocked(ensureGameScoresContextSchema).mockResolvedValue(
+            COMPLETE_CAPABILITIES
+        )
     })
 
     describe('getUserStats', () => {

--- a/src/lib/server/db/queries.integration.test.ts
+++ b/src/lib/server/db/queries.integration.test.ts
@@ -32,6 +32,12 @@ import {
     getAllUserIds,
     getActiveUserIdsBetween,
     getGameLeaderboard,
+    saveGameScore,
+    getUserGameHistory,
+    getUserDailyActivity,
+    getGamesPlayedCountToday,
+    getUniqueGamesPlayedToday,
+    getTotalScoreToday,
 } from '@/lib/server/db/queries'
 
 // ─── Schema setup ────────────────────────────────────────────────────────────
@@ -594,5 +600,103 @@ describe('Score context isolation (integration)', () => {
         const result = await getGameLeaderboard('tetris', 10)
 
         expect(result.map(entry => entry.score)).toEqual([200, 100])
+    })
+})
+
+// ─── Contextual write side effects (integration) ─────────────────────────────
+
+describe('Contextual write side effects (integration)', () => {
+    it('persists scoped context while retaining platform activity side effects', async () => {
+        await seedUser('scoped-user', 'Scoped Player')
+        await seedUserStats('scoped-user')
+
+        const result = await saveGameScore('scoped-user', 'tetris', 500, {
+            mode: 'daily',
+            competitionKey: 'daily:activity',
+            rulesetVersion: 1,
+            gameDataJson: JSON.stringify({
+                elapsedSeconds: 12,
+                totalMoves: 34,
+            }),
+        })
+        expect(result).toEqual({ success: true })
+
+        const scoreRows = await sql<{
+            mode: string | null
+            competition_key: string | null
+            ruleset_version: number | null
+            game_data_json: string | null
+        }>`
+            SELECT
+                mode,
+                competition_key,
+                ruleset_version,
+                game_data_json
+            FROM game_scores
+            WHERE user_id = 'scoped-user'
+        `.execute(db)
+        expect(scoreRows.rows).toEqual([
+            {
+                mode: 'daily',
+                competition_key: 'daily:activity',
+                ruleset_version: 1,
+                game_data_json: '{"elapsedSeconds":12,"totalMoves":34}',
+            },
+        ])
+
+        const stats = await sql<{
+            total_games_played: number
+            total_score: number
+            favorite_game: string | null
+        }>`
+            SELECT total_games_played, total_score, favorite_game
+            FROM user_stats
+            WHERE user_id = 'scoped-user'
+        `.execute(db)
+        // saveGameScore calls getUserStats (distinct game count = 1) then upserts
+        // total_games_played = 1 + 1 = 2. total_score = 0 + 500 = 500.
+        expect(stats.rows[0]).toEqual({
+            total_games_played: 2,
+            total_score: 500,
+            favorite_game: 'tetris',
+        })
+
+        const history = await getUserGameHistory('scoped-user', 10)
+        expect(history).toHaveLength(1)
+        expect(Object.keys(history[0]).sort()).toEqual([
+            'created_at',
+            'game_id',
+            'game_name',
+            'score',
+        ])
+
+        expect(await getGamesPlayedCountToday('scoped-user')).toBe(1)
+        expect(await getUniqueGamesPlayedToday('scoped-user')).toHaveLength(1)
+        expect(await getTotalScoreToday('scoped-user')).toBe(500)
+
+        const activity = await getUserDailyActivity(
+            'scoped-user',
+            new Date().getUTCFullYear()
+        )
+        expect(activity.reduce((sum, day) => sum + day.count, 0)).toBe(1)
+    })
+
+    it('omits context columns from the real getUserGameHistory query', async () => {
+        await seedScore('scoped-user', 'tetris', 500, {
+            mode: 'daily',
+            competitionKey: 'daily:leak',
+            rulesetVersion: 1,
+            gameDataJson: '{"elapsedSeconds":12}',
+        })
+
+        const history = await getUserGameHistory('scoped-user', 10)
+
+        expect(history).toHaveLength(1)
+        expect(Object.keys(history[0]).sort()).toEqual([
+            'created_at',
+            'game_id',
+            'game_name',
+            'score',
+        ])
     })
 })

--- a/src/lib/server/db/queries.integration.test.ts
+++ b/src/lib/server/db/queries.integration.test.ts
@@ -32,6 +32,7 @@ import {
     getAllUserIds,
     getActiveUserIdsBetween,
     getGameLeaderboard,
+    isGameLeaderboardAvailable,
     saveGameScore,
     getUserGameHistory,
     getUserDailyActivity,
@@ -39,6 +40,20 @@ import {
     getUniqueGamesPlayedToday,
     getTotalScoreToday,
 } from '@/lib/server/db/queries'
+
+// Narrow a GameLeaderboardResult to its success (array) branch. These
+// integration tests run against a confirmed score-context schema, so the
+// probe always succeeds and the result is always an array; this helper makes
+// that invariant explicit for TypeScript while failing the test if it ever
+// does not hold.
+function asEntries(result: Awaited<ReturnType<typeof getGameLeaderboard>>) {
+    if (!isGameLeaderboardAvailable(result)) {
+        throw new Error(
+            'expected leaderboard entries but got unavailable result'
+        )
+    }
+    return result
+}
 
 // ─── Schema setup ────────────────────────────────────────────────────────────
 
@@ -488,7 +503,7 @@ describe('getGameLeaderboard (integration)', () => {
         await seedScore('u1', 'tetris', 3000)
         await seedScore('u2', 'tetris', 8000)
 
-        const result = await getGameLeaderboard('tetris')
+        const result = asEntries(await getGameLeaderboard('tetris'))
 
         expect(result[0].score).toBe(8000)
         expect(result[1].score).toBe(3000)
@@ -501,7 +516,7 @@ describe('getGameLeaderboard (integration)', () => {
             VALUES ('ghost-user', 'tetris', 5000)
         `.execute(db)
 
-        const result = await getGameLeaderboard('tetris')
+        const result = asEntries(await getGameLeaderboard('tetris'))
 
         expect(result).toHaveLength(1)
         expect(result[0].name).toBe('Anonymous')
@@ -516,7 +531,7 @@ describe('getGameLeaderboard (integration)', () => {
         })
         await seedScore('u1', 'tetris', 1000)
 
-        const result = await getGameLeaderboard('tetris')
+        const result = asEntries(await getGameLeaderboard('tetris'))
 
         expect(result[0].name).toBe('DisplayPref')
     })
@@ -525,7 +540,7 @@ describe('getGameLeaderboard (integration)', () => {
         await seedUser('u1', 'RealName', { username: 'handle' })
         await seedScore('u1', 'tetris', 1000)
 
-        const result = await getGameLeaderboard('tetris')
+        const result = asEntries(await getGameLeaderboard('tetris'))
 
         expect(result[0].name).toBe('handle')
     })
@@ -534,7 +549,7 @@ describe('getGameLeaderboard (integration)', () => {
         await seedUser('u1', 'RealName')
         await seedScore('u1', 'tetris', 1000)
 
-        const result = await getGameLeaderboard('tetris')
+        const result = asEntries(await getGameLeaderboard('tetris'))
 
         expect(result[0].name).toBe('RealName')
     })
@@ -556,7 +571,7 @@ describe('getGameLeaderboard (integration)', () => {
         await seedScore('u1', 'snake', 9999) // different game
         await seedScore('u1', 'tetris', 500)
 
-        const result = await getGameLeaderboard('tetris')
+        const result = asEntries(await getGameLeaderboard('tetris'))
 
         expect(result).toHaveLength(1)
         expect(result[0].score).toBe(500)
@@ -575,7 +590,7 @@ describe('Score context isolation (integration)', () => {
             rulesetVersion: 1,
         })
 
-        const result = await getGameLeaderboard('tetris', 10)
+        const result = asEntries(await getGameLeaderboard('tetris', 10))
 
         expect(result.map(entry => entry.score)).toEqual([100])
     })
@@ -600,7 +615,7 @@ describe('Score context isolation (integration)', () => {
         await seedScore('u1', 'tetris', 100)
         await seedScore('u1', 'tetris', 200)
 
-        const result = await getGameLeaderboard('tetris', 10)
+        const result = asEntries(await getGameLeaderboard('tetris', 10))
 
         expect(result.map(entry => entry.score)).toEqual([200, 100])
     })

--- a/src/lib/server/db/queries.integration.test.ts
+++ b/src/lib/server/db/queries.integration.test.ts
@@ -278,9 +278,9 @@ describe('getUserRecentScores (integration)', () => {
 // ─── getUserBestScore ─────────────────────────────────────────────────────────
 
 describe('getUserBestScore (integration)', () => {
-    it('returns null when user has no scores for the game', async () => {
+    it('returns ok/null when user has no scores for the game', async () => {
         const result = await getUserBestScore('u1', 'tetris')
-        expect(result).toBeNull()
+        expect(result).toEqual({ status: 'ok', bestScore: null })
     })
 
     it('returns the highest score for the user/game pair', async () => {
@@ -289,7 +289,7 @@ describe('getUserBestScore (integration)', () => {
         await seedScore('u1', 'tetris', 2000)
 
         const result = await getUserBestScore('u1', 'tetris')
-        expect(result).toBe(5000)
+        expect(result).toEqual({ status: 'ok', bestScore: 5000 })
     })
 
     it('only considers scores for the specified game', async () => {
@@ -297,7 +297,7 @@ describe('getUserBestScore (integration)', () => {
         await seedScore('u1', 'tetris', 500)
 
         const result = await getUserBestScore('u1', 'tetris')
-        expect(result).toBe(500)
+        expect(result).toEqual({ status: 'ok', bestScore: 500 })
     })
 
     it('only considers scores for the specified user', async () => {
@@ -305,7 +305,7 @@ describe('getUserBestScore (integration)', () => {
         await seedScore('u1', 'tetris', 100)
 
         const result = await getUserBestScore('u1', 'tetris')
-        expect(result).toBe(100)
+        expect(result).toEqual({ status: 'ok', bestScore: 100 })
     })
 })
 
@@ -587,7 +587,10 @@ describe('Score context isolation (integration)', () => {
             rulesetVersion: 1,
         })
 
-        await expect(getUserBestScore('u1', 'tetris')).resolves.toBe(100)
+        await expect(getUserBestScore('u1', 'tetris')).resolves.toEqual({
+            status: 'ok',
+            bestScore: 100,
+        })
         await expect(getUserBestScoreForGame('u1', 'tetris')).resolves.toBe(100)
         await expect(getUserBestScoreByGame('u1', 'tetris')).resolves.toBe(100)
     })

--- a/src/lib/server/db/queries.integration.test.ts
+++ b/src/lib/server/db/queries.integration.test.ts
@@ -24,6 +24,7 @@ import {
     getUserStats,
     getUserRecentScores,
     getUserBestScore,
+    getUserBestScoreByGame,
     getUserBestScoreForGame,
     hasUserEarnedAchievement,
     awardAchievement,
@@ -56,6 +57,10 @@ beforeAll(async () => {
             user_id TEXT NOT NULL,
             game_id TEXT NOT NULL,
             score INTEGER NOT NULL,
+            mode TEXT,
+            competition_key TEXT,
+            ruleset_version INTEGER,
+            game_data_json TEXT,
             created_at TEXT DEFAULT CURRENT_TIMESTAMP
         )
     `.execute(db)
@@ -118,19 +123,36 @@ async function seedScore(
     userId: string,
     gameId: string,
     score: number,
-    createdAt?: string
+    options: {
+        createdAt?: string
+        mode?: string
+        competitionKey?: string
+        rulesetVersion?: number
+        gameDataJson?: string
+    } = {}
 ) {
-    if (createdAt) {
-        await sql`
-            INSERT INTO game_scores (user_id, game_id, score, created_at)
-            VALUES (${userId}, ${gameId}, ${score}, ${createdAt})
-        `.execute(db)
-    } else {
-        await sql`
-            INSERT INTO game_scores (user_id, game_id, score)
-            VALUES (${userId}, ${gameId}, ${score})
-        `.execute(db)
-    }
+    await sql`
+        INSERT INTO game_scores (
+            user_id,
+            game_id,
+            score,
+            mode,
+            competition_key,
+            ruleset_version,
+            game_data_json,
+            created_at
+        )
+        VALUES (
+            ${userId},
+            ${gameId},
+            ${score},
+            ${options.mode ?? null},
+            ${options.competitionKey ?? null},
+            ${options.rulesetVersion ?? null},
+            ${options.gameDataJson ?? null},
+            ${options.createdAt ?? new Date().toISOString()}
+        )
+    `.execute(db)
 }
 
 async function seedUserStats(
@@ -420,12 +442,20 @@ describe('getActiveUserIdsBetween (integration)', () => {
 
     it('includes only in-range users, deduplicates same-user scores, and excludes out-of-range users', async () => {
         // u_before: score timestamped before the window – must be excluded
-        await seedScore('u_before', 'tetris', 100, '2024-06-01 00:00:00')
+        await seedScore('u_before', 'tetris', 100, {
+            createdAt: '2024-06-01 00:00:00',
+        })
         // u_inside: two scores within the window – must appear exactly once (distinct)
-        await seedScore('u_inside', 'tetris', 200, '4000-01-01 00:00:00')
-        await seedScore('u_inside', 'snake', 300, '4500-06-01 00:00:00')
+        await seedScore('u_inside', 'tetris', 200, {
+            createdAt: '4000-01-01 00:00:00',
+        })
+        await seedScore('u_inside', 'snake', 300, {
+            createdAt: '4500-06-01 00:00:00',
+        })
         // u_after: score timestamped after the window – must be excluded
-        await seedScore('u_after', 'tetris', 400, '9999-01-01 00:00:00')
+        await seedScore('u_after', 'tetris', 400, {
+            createdAt: '9999-01-01 00:00:00',
+        })
 
         const start = new Date(3e12)
         const end = new Date(5e12)
@@ -524,5 +554,45 @@ describe('getGameLeaderboard (integration)', () => {
 
         expect(result).toHaveLength(1)
         expect(result[0].score).toBe(500)
+    })
+})
+
+// ─── Score context isolation (integration) ────────────────────────────────────
+
+describe('Score context isolation (integration)', () => {
+    it('keeps scoped rows out of the default raw-attempt leaderboard', async () => {
+        await seedUser('u1', 'Player')
+        await seedScore('u1', 'tetris', 100)
+        await seedScore('u1', 'tetris', 999, {
+            mode: 'daily',
+            competitionKey: 'daily:1',
+            rulesetVersion: 1,
+        })
+
+        const result = await getGameLeaderboard('tetris', 10)
+
+        expect(result.map(entry => entry.score)).toEqual([100])
+    })
+
+    it('keeps scoped rows out of every personal-best alias', async () => {
+        await seedScore('u1', 'tetris', 100)
+        await seedScore('u1', 'tetris', 999, {
+            mode: 'daily',
+            rulesetVersion: 1,
+        })
+
+        await expect(getUserBestScore('u1', 'tetris')).resolves.toBe(100)
+        await expect(getUserBestScoreForGame('u1', 'tetris')).resolves.toBe(100)
+        await expect(getUserBestScoreByGame('u1', 'tetris')).resolves.toBe(100)
+    })
+
+    it('retains raw-attempt semantics for unscoped rows', async () => {
+        await seedUser('u1', 'Player')
+        await seedScore('u1', 'tetris', 100)
+        await seedScore('u1', 'tetris', 200)
+
+        const result = await getGameLeaderboard('tetris', 10)
+
+        expect(result.map(entry => entry.score)).toEqual([200, 100])
     })
 })

--- a/src/lib/server/db/queries.score-context-read-failure.test.ts
+++ b/src/lib/server/db/queries.score-context-read-failure.test.ts
@@ -38,10 +38,13 @@ describe('Score context read failure (unknown capability)', () => {
         expect(mockSelectFrom).not.toHaveBeenCalled()
     })
 
-    it('returns null from getUserBestScore without querying', async () => {
+    it('returns an unavailable result from getUserBestScore without querying', async () => {
         const result = await getUserBestScore('u1', 'tetris')
 
-        expect(result).toBeNull()
+        expect(result).toEqual({
+            status: 'unavailable',
+            code: 'SCORE_CONTEXT_UNAVAILABLE',
+        })
         expect(mockEnsure).toHaveBeenCalled()
         expect(mockSelectFrom).not.toHaveBeenCalled()
     })

--- a/src/lib/server/db/queries.score-context-read-failure.test.ts
+++ b/src/lib/server/db/queries.score-context-read-failure.test.ts
@@ -30,10 +30,13 @@ describe('Score context read failure (unknown capability)', () => {
         mockEnsure.mockResolvedValue({ known: false })
     })
 
-    it('returns [] from getGameLeaderboard without querying', async () => {
+    it('returns an unavailable result from getGameLeaderboard without querying', async () => {
         const result = await getGameLeaderboard('tetris', 10)
 
-        expect(result).toEqual([])
+        expect(result).toEqual({
+            status: 'unavailable',
+            code: 'SCORE_CONTEXT_UNAVAILABLE',
+        })
         expect(mockEnsure).toHaveBeenCalled()
         expect(mockSelectFrom).not.toHaveBeenCalled()
     })

--- a/src/lib/server/db/queries.score-context-read-failure.test.ts
+++ b/src/lib/server/db/queries.score-context-read-failure.test.ts
@@ -1,0 +1,48 @@
+import { describe, it, expect, vi, beforeEach } from 'vitest'
+
+vi.mock('@/lib/server/db/client', () => ({
+    db: {
+        selectFrom: vi.fn(),
+    },
+}))
+
+vi.mock('@/lib/server/db/game-score-context', async importOriginal => {
+    const actual =
+        await importOriginal<
+            typeof import('@/lib/server/db/game-score-context')
+        >()
+    return {
+        ...actual,
+        ensureGameScoresContextSchema: vi.fn(),
+    }
+})
+
+import { db } from '@/lib/server/db/client'
+import { getGameLeaderboard, getUserBestScore } from '@/lib/server/db/queries'
+import { ensureGameScoresContextSchema } from '@/lib/server/db/game-score-context'
+
+const mockSelectFrom = vi.mocked(db.selectFrom)
+const mockEnsure = vi.mocked(ensureGameScoresContextSchema)
+
+describe('Score context read failure (unknown capability)', () => {
+    beforeEach(() => {
+        vi.clearAllMocks()
+        mockEnsure.mockResolvedValue({ known: false })
+    })
+
+    it('returns [] from getGameLeaderboard without querying', async () => {
+        const result = await getGameLeaderboard('tetris', 10)
+
+        expect(result).toEqual([])
+        expect(mockEnsure).toHaveBeenCalled()
+        expect(mockSelectFrom).not.toHaveBeenCalled()
+    })
+
+    it('returns null from getUserBestScore without querying', async () => {
+        const result = await getUserBestScore('u1', 'tetris')
+
+        expect(result).toBeNull()
+        expect(mockEnsure).toHaveBeenCalled()
+        expect(mockSelectFrom).not.toHaveBeenCalled()
+    })
+})

--- a/src/lib/server/db/queries.test.ts
+++ b/src/lib/server/db/queries.test.ts
@@ -1,6 +1,7 @@
 import { describe, it, expect, vi, beforeEach } from 'vitest'
 import {
     saveGameScore,
+    saveGameScoreWithAchievements,
     getUserGameHistory,
     getUserGameHistoryPaginated,
     getUserBestScoreByGame,
@@ -9,6 +10,7 @@ import {
     updateAllUserStreaksForUTC,
 } from '@/lib/server/db/queries'
 import { db } from '@/lib/server/db/client'
+import { ensureGameScoresContextSchema } from '@/lib/server/db/game-score-context'
 
 // Mock the database client
 vi.mock('@/lib/server/db/client', () => ({
@@ -23,6 +25,17 @@ vi.mock('@/lib/server/db/client', () => ({
         },
     },
 }))
+
+vi.mock('@/lib/server/db/game-score-context', async importOriginal => {
+    const actual =
+        await importOriginal<
+            typeof import('@/lib/server/db/game-score-context')
+        >()
+    return {
+        ...actual,
+        ensureGameScoresContextSchema: vi.fn(),
+    }
+})
 
 describe('Database Queries', () => {
     beforeEach(() => {
@@ -64,7 +77,7 @@ describe('Database Queries', () => {
             const result = await saveGameScore('user-123', 'tetris', 5000)
 
             // Assert
-            expect(result).toBe(true)
+            expect(result).toEqual({ success: true })
             expect(db.insertInto).toHaveBeenCalledWith('game_scores')
             expect(mockInsertQuery.values).toHaveBeenCalledWith({
                 user_id: 'user-123',
@@ -86,7 +99,10 @@ describe('Database Queries', () => {
             const result = await saveGameScore('user-123', 'tetris', 5000)
 
             // Assert
-            expect(result).toBe(false)
+            expect(result).toEqual({
+                success: false,
+                code: 'SCORE_WRITE_FAILED',
+            })
         })
 
         it('should use currentStats values when getUserStats returns non-null (lines 525-526 left-truthy branch)', async () => {
@@ -152,10 +168,157 @@ describe('Database Queries', () => {
 
             const result = await saveGameScore('user-123', 'tetris', 5000)
 
-            expect(result).toBe(true)
+            expect(result).toEqual({ success: true })
             expect(mockUpdateSet).toHaveBeenCalledWith(
                 expect.objectContaining({ total_score: 15000 })
             )
+        })
+
+        it('returns SCORE_CONTEXT_UNAVAILABLE and does not insert when columns are unavailable', async () => {
+            vi.mocked(ensureGameScoresContextSchema).mockResolvedValue({
+                known: true,
+                capabilities: {
+                    mode: true,
+                    competitionKey: true,
+                    rulesetVersion: false,
+                    gameDataJson: true,
+                    scopedIndex: false,
+                },
+            })
+
+            const result = await saveGameScore('u1', 'tetris', 100, {
+                mode: 'daily',
+                competitionKey: 'ice-slide:daily:2026-08-01:g1:r1',
+                rulesetVersion: 1,
+                gameDataJson: '{"elapsedSeconds":12,"totalMoves":34}',
+            })
+
+            expect(result).toEqual({
+                success: false,
+                code: 'SCORE_CONTEXT_UNAVAILABLE',
+            })
+            expect(db.insertInto).not.toHaveBeenCalled()
+        })
+
+        it('inserts context and uses the existing stats update chain', async () => {
+            vi.mocked(ensureGameScoresContextSchema).mockResolvedValue({
+                known: true,
+                capabilities: {
+                    mode: true,
+                    competitionKey: true,
+                    rulesetVersion: true,
+                    gameDataJson: true,
+                    scopedIndex: true,
+                },
+            })
+
+            const insert = {
+                values: vi.fn().mockReturnThis(),
+                execute: vi.fn().mockResolvedValue({}),
+            }
+            vi.mocked(db.insertInto).mockReturnValue(insert as never)
+
+            const updateSet = vi.fn().mockReturnThis()
+            vi.mocked(db.updateTable).mockReturnValue({
+                set: updateSet,
+                where: vi.fn().mockReturnThis(),
+                execute: vi.fn().mockResolvedValue({}),
+            } as never)
+
+            const existingStats = {
+                id: 1,
+                user_id: 'u1',
+                total_games_played: 2,
+                total_score: 500,
+                favorite_game: 'snake',
+                streak_days: 0,
+                xp: 0,
+                level: 1,
+                challenge_streak: 0,
+                last_challenge_date: null,
+                login_streak: 0,
+                last_login_reward_date: null,
+                total_login_cycles: 0,
+                email_notifications: 1,
+                push_notifications: 0,
+                challenge_reminders: 1,
+                created_at: new Date(),
+                updated_at: new Date(),
+            }
+
+            vi.mocked(db.selectFrom)
+                .mockReturnValueOnce({
+                    selectAll: vi.fn().mockReturnThis(),
+                    where: vi.fn().mockReturnThis(),
+                    executeTakeFirst: vi.fn().mockResolvedValue(existingStats),
+                } as never)
+                .mockReturnValueOnce({
+                    select: vi.fn().mockReturnThis(),
+                    distinct: vi.fn().mockReturnThis(),
+                    where: vi.fn().mockReturnThis(),
+                    execute: vi.fn().mockResolvedValue([{ game_id: 'tetris' }]),
+                } as never)
+                .mockReturnValueOnce({
+                    selectAll: vi.fn().mockReturnThis(),
+                    where: vi.fn().mockReturnThis(),
+                    executeTakeFirst: vi.fn().mockResolvedValue(existingStats),
+                } as never)
+                .mockReturnValueOnce({
+                    select: vi.fn().mockReturnThis(),
+                    distinct: vi.fn().mockReturnThis(),
+                    where: vi.fn().mockReturnThis(),
+                    execute: vi.fn().mockResolvedValue([{ game_id: 'tetris' }]),
+                } as never)
+
+            const result = await saveGameScore('u1', 'tetris', 100, {
+                mode: 'daily',
+                competitionKey: null,
+                rulesetVersion: 1,
+                gameDataJson: null,
+            })
+
+            expect(result).toEqual({ success: true })
+            expect(insert.values).toHaveBeenCalledWith({
+                user_id: 'u1',
+                game_id: 'tetris',
+                score: 100,
+                mode: 'daily',
+                competition_key: null,
+                ruleset_version: 1,
+                game_data_json: null,
+            })
+            expect(updateSet).toHaveBeenCalledWith(
+                expect.objectContaining({
+                    total_score: 600,
+                    favorite_game: 'tetris',
+                })
+            )
+        })
+
+        it('preserves capability failure through the achievement wrapper', async () => {
+            vi.mocked(ensureGameScoresContextSchema).mockResolvedValue({
+                known: false,
+            })
+
+            const result = await saveGameScoreWithAchievements(
+                'u1',
+                'tetris',
+                100,
+                { elapsedSeconds: 12 },
+                {
+                    mode: 'daily',
+                    competitionKey: null,
+                    rulesetVersion: 1,
+                    gameDataJson: '{"elapsedSeconds":12}',
+                }
+            )
+
+            expect(result).toEqual({
+                success: false,
+                newAchievements: [],
+                code: 'SCORE_CONTEXT_UNAVAILABLE',
+            })
+            expect(db.insertInto).not.toHaveBeenCalled()
         })
     })
 

--- a/src/lib/server/db/queries.test.ts
+++ b/src/lib/server/db/queries.test.ts
@@ -40,6 +40,16 @@ vi.mock('@/lib/server/db/game-score-context', async importOriginal => {
 describe('Database Queries', () => {
     beforeEach(() => {
         vi.clearAllMocks()
+        vi.mocked(ensureGameScoresContextSchema).mockResolvedValue({
+            known: true,
+            capabilities: {
+                mode: true,
+                competitionKey: true,
+                rulesetVersion: true,
+                gameDataJson: true,
+                scopedIndex: true,
+            },
+        })
     })
 
     describe('saveGameScore', () => {

--- a/src/lib/server/db/queries.ts
+++ b/src/lib/server/db/queries.ts
@@ -19,6 +19,7 @@ import {
     type PersistedScoreContext,
     type SaveGameScoreResult,
     type SaveGameScoreWithAchievementsResult,
+    type GameScoresContextCapabilities,
 } from './game-score-context'
 
 function sanitizeError(error: unknown): string {
@@ -222,6 +223,16 @@ export async function updateUserLevel(
     }
 }
 
+async function getConfirmedScoreContextCapabilities(): Promise<
+    GameScoresContextCapabilities | undefined
+> {
+    const state = await ensureGameScoresContextSchema()
+    if (!state.known) {
+        return undefined
+    }
+    return state.capabilities
+}
+
 /**
  * Get game leaderboard (includes anonymous players)
  */
@@ -238,7 +249,12 @@ export async function getGameLeaderboard(
     }>
 > {
     try {
-        const results = await db
+        const capabilities = await getConfirmedScoreContextCapabilities()
+        if (capabilities === undefined) {
+            return []
+        }
+
+        let query = db
             .selectFrom('game_scores')
             .leftJoin('user', 'user.id', 'game_scores.user_id')
             .select(eb => [
@@ -257,7 +273,14 @@ export async function getGameLeaderboard(
             .where('game_scores.game_id', '=', gameId)
             .orderBy('game_scores.score', 'desc')
             .limit(limit)
-            .execute()
+
+        if (hasCompleteGameScoresContextColumns(capabilities)) {
+            query = query
+                .where('game_scores.mode', 'is', null)
+                .where('game_scores.competition_key', 'is', null)
+        }
+
+        const results = await query.execute()
 
         type Row = {
             name: string | null
@@ -525,14 +548,26 @@ export async function getUserBestScore(
     gameId: string
 ): Promise<number | null> {
     try {
-        const result = await db
+        const capabilities = await getConfirmedScoreContextCapabilities()
+        if (capabilities === undefined) {
+            return null
+        }
+
+        let query = db
             .selectFrom('game_scores')
             .select('score')
             .where('user_id', '=', userId)
             .where('game_id', '=', gameId)
             .orderBy('score', 'desc')
             .limit(1)
-            .executeTakeFirst()
+
+        if (hasCompleteGameScoresContextColumns(capabilities)) {
+            query = query
+                .where('mode', 'is', null)
+                .where('competition_key', 'is', null)
+        }
+
+        const result = await query.executeTakeFirst()
 
         return result?.score ?? null
     } catch (error) {

--- a/src/lib/server/db/queries.ts
+++ b/src/lib/server/db/queries.ts
@@ -261,24 +261,57 @@ function applyUnscopedContextIsolation<QB extends UnscopedContextFilterable>(
 }
 
 /**
+ * A single entry in the unscoped game leaderboard.
+ */
+export type GameLeaderboardEntry = {
+    name: string
+    username: string | null
+    score: number
+    created_at: string
+    image: string | null
+}
+
+/**
+ * Result of reading the unscoped game leaderboard.
+ *
+ * - `GameLeaderboardEntry[]`: the score-context schema probe succeeded. An
+ *   empty array means the game genuinely has no unscoped rows. Query-execution
+ *   errors are still swallowed to `[]` to preserve the existing
+ *   graceful-degradation behavior for transient read failures.
+ * - `{ status: 'unavailable' }`: the `ensureGameScoresContextSchema` probe
+ *   failed (the schema/capabilities could not be confirmed). This is a
+ *   retryable state distinct from "no rows" so callers (notably
+ *   `/api/leaderboard`) can surface a coded 503 instead of silently reporting
+ *   an empty leaderboard — mirroring `getUserBestScore` and
+ *   `getScopedGameLeaderboard`.
+ */
+export type GameLeaderboardResult =
+    | GameLeaderboardEntry[]
+    | { status: 'unavailable'; code: 'SCORE_CONTEXT_UNAVAILABLE' }
+
+/**
+ * Type guard narrowing a `GameLeaderboardResult` to its success (array) branch.
+ */
+export function isGameLeaderboardAvailable(
+    result: GameLeaderboardResult
+): result is GameLeaderboardEntry[] {
+    return Array.isArray(result)
+}
+
+/**
  * Get game leaderboard (includes anonymous players)
  */
 export async function getGameLeaderboard(
     gameId: string,
     limit: number = 10
-): Promise<
-    Array<{
-        name: string
-        username: string | null
-        score: number
-        created_at: string
-        image: string | null
-    }>
-> {
+): Promise<GameLeaderboardResult> {
     try {
         const capabilities = await getConfirmedScoreContextCapabilities()
         if (capabilities === undefined) {
-            return []
+            return {
+                status: 'unavailable',
+                code: 'SCORE_CONTEXT_UNAVAILABLE',
+            }
         }
 
         const query = applyUnscopedContextIsolation(

--- a/src/lib/server/db/queries.ts
+++ b/src/lib/server/db/queries.ts
@@ -2189,3 +2189,15 @@ export async function updateUserPreferences(
         return false
     }
 }
+
+export {
+    getScopedGameLeaderboard,
+    toPublicScopedLeaderboardEntry,
+} from './scoped-leaderboard'
+
+export type {
+    ScopedLeaderboardEntry,
+    ScopedLeaderboardQuery,
+    ScopedLeaderboardResult,
+    ScopedLeaderboardRow,
+} from './scoped-leaderboard'

--- a/src/lib/server/db/queries.ts
+++ b/src/lib/server/db/queries.ts
@@ -234,6 +234,33 @@ async function getConfirmedScoreContextCapabilities(): Promise<
 }
 
 /**
+ * Apply the unscoped-score isolation predicate (`mode IS NULL AND
+ * competition_key IS NULL`) to a game_scores query when the contextual
+ * columns are present, so scoped/daily attempts never leak into legacy
+ * unscoped leaderboards or best-score reads. The column-reference arguments
+ * let the single-table (`getUserBestScore`) and joined (`getGameLeaderboard`)
+ * query shapes share one helper without duplicating the leakage-prevention
+ * logic at either call site.
+ */
+type UnscopedContextFilterable = {
+    where: (col: string, op: 'is', val: null) => UnscopedContextFilterable
+}
+
+function applyUnscopedContextIsolation<QB extends UnscopedContextFilterable>(
+    query: QB,
+    capabilities: GameScoresContextCapabilities | undefined,
+    modeColumn: 'mode' | 'game_scores.mode',
+    competitionKeyColumn: 'competition_key' | 'game_scores.competition_key'
+): QB {
+    if (!capabilities || !hasCompleteGameScoresContextColumns(capabilities)) {
+        return query
+    }
+    return query
+        .where(modeColumn, 'is', null)
+        .where(competitionKeyColumn, 'is', null) as QB
+}
+
+/**
  * Get game leaderboard (includes anonymous players)
  */
 export async function getGameLeaderboard(
@@ -254,31 +281,30 @@ export async function getGameLeaderboard(
             return []
         }
 
-        let query = db
-            .selectFrom('game_scores')
-            .leftJoin('user', 'user.id', 'game_scores.user_id')
-            .select(eb => [
-                eb
-                    .fn<string>('coalesce', [
-                        'user.displayName',
-                        'user.username',
-                        'user.name',
-                    ])
-                    .as('name'),
-                'user.username',
-                'game_scores.score',
-                'game_scores.created_at',
-                'user.image',
-            ])
-            .where('game_scores.game_id', '=', gameId)
-            .orderBy('game_scores.score', 'desc')
-            .limit(limit)
-
-        if (hasCompleteGameScoresContextColumns(capabilities)) {
-            query = query
-                .where('game_scores.mode', 'is', null)
-                .where('game_scores.competition_key', 'is', null)
-        }
+        const query = applyUnscopedContextIsolation(
+            db
+                .selectFrom('game_scores')
+                .leftJoin('user', 'user.id', 'game_scores.user_id')
+                .select(eb => [
+                    eb
+                        .fn<string>('coalesce', [
+                            'user.displayName',
+                            'user.username',
+                            'user.name',
+                        ])
+                        .as('name'),
+                    'user.username',
+                    'game_scores.score',
+                    'game_scores.created_at',
+                    'user.image',
+                ])
+                .where('game_scores.game_id', '=', gameId)
+                .orderBy('game_scores.score', 'desc')
+                .limit(limit),
+            capabilities,
+            'game_scores.mode',
+            'game_scores.competition_key'
+        )
 
         const results = await query.execute()
 
@@ -483,17 +509,15 @@ export async function getUserDailyActivity(
         // Filter by year directly using SQLite strftime to avoid type/format issues
         const yearStr = String(y)
 
-        // Use UTC for grouping to match UTC calendar logic in the UI
-        const dayExpr = sql<string>`strftime('%Y-%m-%d', "created_at", 'utc')`
+        // Treat stored created_at as UTC and bucket by its calendar date.
+        const dayExpr = sql<string>`strftime('%Y-%m-%d', "created_at")`
 
         const rows = (await db
             .selectFrom('game_scores')
             .select([dayExpr.as('day'), db.fn.count('id').as('count')])
             .where('user_id', '=', userId)
             // Filter by matching year in UTC
-            .where(
-                sql<boolean>`strftime('%Y', "created_at", 'utc') = ${yearStr}`
-            )
+            .where(sql<boolean>`strftime('%Y', "created_at") = ${yearStr}`)
             .groupBy(dayExpr)
             .orderBy('day', 'asc')
             .execute()) as unknown as Array<{
@@ -541,41 +565,64 @@ export async function getUserRecentScores(
 }
 
 /**
- * Get user's best score for a specific game
+ * Result of reading a user's best score for a game.
+ *
+ * - `ok`: the score-context schema probe succeeded. `bestScore` is `null` when
+ *   the user genuinely has no unscoped rows for the game, and a number when a
+ *   best score exists.
+ * - `unavailable`: the `ensureGameScoresContextSchema` probe failed (the
+ *   schema/capabilities could not be confirmed). This is a retryable state
+ *   distinct from "no rows" so callers (notably `/api/scores/best`) can
+ *   surface a coded 503 instead of silently reporting `null`/`0`.
+ */
+export type UserBestScoreResult =
+    | { status: 'ok'; bestScore: number | null }
+    | { status: 'unavailable'; code: 'SCORE_CONTEXT_UNAVAILABLE' }
+
+/**
+ * Get user's best score for a specific game.
+ *
+ * Returns a discriminated `UserBestScoreResult` so callers can distinguish a
+ * failed score-context probe (`unavailable`) from a genuine absence of score
+ * rows (`ok` with `bestScore: null`). Query-execution errors are still
+ * swallowed to `ok`/`null` to preserve the existing graceful-degradation
+ * behavior for transient read failures.
  */
 export async function getUserBestScore(
     userId: string,
     gameId: string
-): Promise<number | null> {
+): Promise<UserBestScoreResult> {
     try {
         const capabilities = await getConfirmedScoreContextCapabilities()
         if (capabilities === undefined) {
-            return null
+            return {
+                status: 'unavailable',
+                code: 'SCORE_CONTEXT_UNAVAILABLE',
+            }
         }
 
-        let query = db
-            .selectFrom('game_scores')
-            .select('score')
-            .where('user_id', '=', userId)
-            .where('game_id', '=', gameId)
-            .orderBy('score', 'desc')
-            .limit(1)
-
-        if (hasCompleteGameScoresContextColumns(capabilities)) {
-            query = query
-                .where('mode', 'is', null)
-                .where('competition_key', 'is', null)
-        }
+        const query = applyUnscopedContextIsolation(
+            db
+                .selectFrom('game_scores')
+                .select('score')
+                .where('user_id', '=', userId)
+                .where('game_id', '=', gameId)
+                .orderBy('score', 'desc')
+                .limit(1),
+            capabilities,
+            'mode',
+            'competition_key'
+        )
 
         const result = await query.executeTakeFirst()
 
-        return result?.score ?? null
+        return { status: 'ok', bestScore: result?.score ?? null }
     } catch (error) {
         console.error(
             '[getUserBestScore] Database error:',
             sanitizeError(error)
         )
-        return null
+        return { status: 'ok', bestScore: null }
     }
 }
 
@@ -824,9 +871,17 @@ export async function getUserGameHistoryPaginated(
 
 /**
  * Get user's best score for a specific game
- * @deprecated Use getUserBestScore instead - this is an alias for backward compatibility
+ * @deprecated Use getUserBestScore instead - this is an alias for backward compatibility.
+ * Preserves the legacy `Promise<number | null>` contract by collapsing the
+ * `unavailable` probe-failure state to `null`.
  */
-export const getUserBestScoreByGame = getUserBestScore
+export async function getUserBestScoreByGame(
+    userId: string,
+    gameId: string
+): Promise<number | null> {
+    const result = await getUserBestScore(userId, gameId)
+    return result.status === 'ok' ? result.bestScore : null
+}
 
 /**
  * Update user profile information
@@ -1002,13 +1057,16 @@ export async function awardAchievement(
 /**
  * Get user's best score for a specific game (for achievement checking)
  * Returns 0 instead of null when no score is found.
- * @deprecated Use getUserBestScore with ?? 0 instead
+ * @deprecated Use getUserBestScore instead. Preserves the legacy
+ * `Promise<number>` contract by collapsing both `null` and the `unavailable`
+ * probe-failure state to `0`.
  */
 export async function getUserBestScoreForGame(
     userId: string,
     gameId: string
 ): Promise<number> {
-    return (await getUserBestScore(userId, gameId)) ?? 0
+    const result = await getUserBestScore(userId, gameId)
+    return result.status === 'ok' ? (result.bestScore ?? 0) : 0
 }
 
 /**
@@ -1728,9 +1786,7 @@ export async function getUniqueGamesPlayedToday(
             .select('game_id')
             .distinct()
             .where('user_id', '=', userId)
-            .where(
-                sql<boolean>`strftime('%Y-%m-%d', created_at, 'utc') = ${today}`
-            )
+            .where(sql<boolean>`strftime('%Y-%m-%d', created_at) = ${today}`)
             .execute()
         return rows.map(r => r.game_id)
     } catch (error) {
@@ -1752,9 +1808,7 @@ export async function getTotalScoreToday(userId: string): Promise<number> {
             .selectFrom('game_scores')
             .select(db.fn.sum('score').as('total'))
             .where('user_id', '=', userId)
-            .where(
-                sql<boolean>`strftime('%Y-%m-%d', created_at, 'utc') = ${today}`
-            )
+            .where(sql<boolean>`strftime('%Y-%m-%d', created_at) = ${today}`)
             .executeTakeFirst()
         return Number(result?.total) || 0
     } catch (error) {
@@ -1775,9 +1829,7 @@ export async function getGamesPlayedCountToday(
             .selectFrom('game_scores')
             .select(db.fn.count('id').as('count'))
             .where('user_id', '=', userId)
-            .where(
-                sql<boolean>`strftime('%Y-%m-%d', created_at, 'utc') = ${today}`
-            )
+            .where(sql<boolean>`strftime('%Y-%m-%d', created_at) = ${today}`)
             .executeTakeFirst()
         return Number(result?.count) || 0
     } catch (error) {

--- a/src/lib/server/db/queries.ts
+++ b/src/lib/server/db/queries.ts
@@ -13,6 +13,13 @@ import type {
     UserAchievementRecord,
     DailyChallengeProgress,
 } from './types'
+import {
+    ensureGameScoresContextSchema,
+    hasCompleteGameScoresContextColumns,
+    type PersistedScoreContext,
+    type SaveGameScoreResult,
+    type SaveGameScoreWithAchievementsResult,
+} from './game-score-context'
 
 function sanitizeError(error: unknown): string {
     return error instanceof Error ? error.message : String(error)
@@ -545,18 +552,38 @@ export async function getUserBestScore(
 export async function saveGameScore(
     userId: string,
     gameId: string,
-    score: number
-): Promise<boolean> {
+    score: number,
+    context?: PersistedScoreContext
+): Promise<SaveGameScoreResult> {
     try {
+        if (context) {
+            const state = await ensureGameScoresContextSchema()
+            if (
+                !state.known ||
+                !hasCompleteGameScoresContextColumns(state.capabilities)
+            ) {
+                return {
+                    success: false,
+                    code: 'SCORE_CONTEXT_UNAVAILABLE',
+                }
+            }
+        }
+
         const newScore: NewGameScore = {
             user_id: userId,
             game_id: gameId,
             score,
         }
 
+        if (context) {
+            newScore.mode = context.mode
+            newScore.competition_key = context.competitionKey
+            newScore.ruleset_version = context.rulesetVersion
+            newScore.game_data_json = context.gameDataJson
+        }
+
         await db.insertInto('game_scores').values(newScore).execute()
 
-        // Update user stats
         const currentStats = await getUserStats(userId)
         await upsertUserStats(userId, {
             total_games_played: (currentStats?.total_games_played || 0) + 1,
@@ -564,10 +591,10 @@ export async function saveGameScore(
             favorite_game: gameId,
         })
 
-        return true
+        return { success: true }
     } catch (error) {
         console.error('[saveGameScore] Database error:', sanitizeError(error))
-        return false
+        return { success: false, code: 'SCORE_WRITE_FAILED' }
     }
 }
 
@@ -585,27 +612,28 @@ export async function saveGameScoreWithAchievements(
     userId: string,
     gameId: string,
     score: number,
-    gameData?: unknown
-): Promise<{ success: boolean; newAchievements: string[] }> {
+    gameData?: unknown,
+    context?: PersistedScoreContext
+): Promise<SaveGameScoreWithAchievementsResult> {
     try {
-        // First save the score
-        const saveResult = await saveGameScore(userId, gameId, score)
-        if (!saveResult) {
-            return { success: false, newAchievements: [] }
+        const saveResult = await saveGameScore(userId, gameId, score, context)
+        if (!saveResult.success) {
+            return {
+                success: false,
+                newAchievements: [],
+                code: saveResult.code,
+            }
         }
 
-        // Use cached import to avoid circular dependency
         const { checkAndAwardAchievements, checkInGameAchievements } =
             await getAchievementService()
 
-        // Check and award score-based achievements
         const scoreAchievements = await checkAndAwardAchievements(
             userId,
             gameId as GameID,
             score
         )
 
-        // Check and award in-game achievements if game data is provided
         let inGameAchievements: string[] = []
         if (gameData !== undefined) {
             if (!isGameData(gameData)) {
@@ -628,7 +656,11 @@ export async function saveGameScoreWithAchievements(
             '[saveGameScoreWithAchievements] Database error:',
             sanitizeError(error)
         )
-        return { success: false, newAchievements: [] }
+        return {
+            success: false,
+            newAchievements: [],
+            code: 'SCORE_WRITE_FAILED',
+        }
     }
 }
 

--- a/src/lib/server/db/scoped-leaderboard.integration.test.ts
+++ b/src/lib/server/db/scoped-leaderboard.integration.test.ts
@@ -1,0 +1,434 @@
+import { afterEach, beforeAll, describe, expect, it, vi } from 'vitest'
+import { sql } from 'kysely'
+
+vi.mock('@/lib/server/db/client', async () => {
+    const { Kysely } = await import('kysely')
+    const { LibsqlDialect, libsql } = await import('@libsql/kysely-libsql')
+    const client = libsql.createClient({ url: ':memory:' })
+    const dialect = new LibsqlDialect({ client })
+    return { db: new Kysely({ dialect }), dialect }
+})
+
+import { db } from '@/lib/server/db/client'
+import {
+    getScopedGameLeaderboard,
+    toPublicScopedLeaderboardEntry,
+} from './scoped-leaderboard'
+
+interface SeedScoreOptions {
+    mode: string
+    competitionKey: string | null
+    rulesetVersion: number | null
+    createdAt?: string
+    gameData?: Record<string, unknown>
+    rawGameDataJson?: string
+}
+
+beforeAll(async () => {
+    await sql`
+        CREATE TABLE "user" (
+            id TEXT PRIMARY KEY,
+            name TEXT NOT NULL,
+            username TEXT,
+            displayName TEXT,
+            image TEXT
+        )
+    `.execute(db)
+
+    await sql`
+        CREATE TABLE game_scores (
+            id INTEGER PRIMARY KEY AUTOINCREMENT,
+            user_id TEXT NOT NULL,
+            game_id TEXT NOT NULL,
+            score INTEGER NOT NULL,
+            mode TEXT,
+            competition_key TEXT,
+            ruleset_version INTEGER,
+            game_data_json TEXT,
+            created_at TEXT DEFAULT CURRENT_TIMESTAMP
+        )
+    `.execute(db)
+
+    await sql`
+        CREATE INDEX idx_game_scores_scoped_ranking
+        ON game_scores (
+            game_id,
+            mode,
+            competition_key,
+            score DESC,
+            created_at ASC
+        )
+    `.execute(db)
+})
+
+afterEach(async () => {
+    await sql`DELETE FROM game_scores`.execute(db)
+    await sql`DELETE FROM "user"`.execute(db)
+})
+
+async function seedUser(
+    id: string,
+    name: string,
+    options: {
+        username?: string
+        displayName?: string
+        image?: string
+    } = {}
+): Promise<void> {
+    await sql`
+        INSERT INTO "user" (id, name, username, displayName, image)
+        VALUES (
+            ${id},
+            ${name},
+            ${options.username ?? null},
+            ${options.displayName ?? null},
+            ${options.image ?? null}
+        )
+    `.execute(db)
+}
+
+async function seedScopedScore(
+    userId: string,
+    score: number,
+    options: SeedScoreOptions
+): Promise<void> {
+    const gameDataJson =
+        options.rawGameDataJson ??
+        (options.gameData === undefined
+            ? null
+            : JSON.stringify(options.gameData))
+
+    await sql`
+        INSERT INTO game_scores (
+            user_id,
+            game_id,
+            score,
+            mode,
+            competition_key,
+            ruleset_version,
+            game_data_json,
+            created_at
+        )
+        VALUES (
+            ${userId},
+            'tetris',
+            ${score},
+            ${options.mode},
+            ${options.competitionKey},
+            ${options.rulesetVersion},
+            ${gameDataJson},
+            ${options.createdAt ?? '2026-08-01T00:00:00Z'}
+        )
+    `.execute(db)
+}
+
+describe('getScopedGameLeaderboard', () => {
+    it('returns one best row per user for an exact competition key', async () => {
+        await seedUser('u1', 'One')
+        await seedUser('u2', 'Two')
+        await seedScopedScore('u1', 100, {
+            mode: 'daily',
+            competitionKey: 'daily:1',
+            rulesetVersion: 1,
+            gameData: { elapsedSeconds: 20, totalMoves: 10 },
+        })
+        await seedScopedScore('u1', 200, {
+            mode: 'daily',
+            competitionKey: 'daily:1',
+            rulesetVersion: 1,
+            gameData: { elapsedSeconds: 30, totalMoves: 20 },
+        })
+        await seedScopedScore('u2', 150, {
+            mode: 'daily',
+            competitionKey: 'daily:1',
+            rulesetVersion: 1,
+            gameData: { elapsedSeconds: 25, totalMoves: 12 },
+        })
+
+        const result = await getScopedGameLeaderboard({
+            gameId: 'tetris',
+            mode: 'daily',
+            competitionKey: 'daily:1',
+            limit: 10,
+        })
+
+        expect(result.success).toBe(true)
+        if (!result.success) {
+            throw new Error('expected success')
+        }
+        expect(result.rows.map(row => [row.userId, row.score])).toEqual([
+            ['u1', 200],
+            ['u2', 150],
+        ])
+    })
+
+    it('mode-only ranking spans keys and ruleset versions', async () => {
+        await seedUser('u1', 'One')
+        await seedScopedScore('u1', 100, {
+            mode: 'daily',
+            competitionKey: 'daily:1',
+            rulesetVersion: 1,
+        })
+        await seedScopedScore('u1', 200, {
+            mode: 'daily',
+            competitionKey: 'daily:2',
+            rulesetVersion: 2,
+        })
+
+        const result = await getScopedGameLeaderboard({
+            gameId: 'tetris',
+            mode: 'daily',
+            limit: 10,
+        })
+
+        expect(result.success).toBe(true)
+        if (!result.success) {
+            throw new Error('expected success')
+        }
+        expect(result.rows[0].rulesetVersion).toBe(2)
+    })
+
+    it.each([
+        {
+            name: 'higher score',
+            first: {
+                score: 100,
+                rulesetVersion: 1,
+                elapsedSeconds: 10,
+                totalMoves: 10,
+                createdAt: '2026-08-01T00:00:00Z',
+            },
+            second: {
+                score: 200,
+                rulesetVersion: 2,
+                elapsedSeconds: 99,
+                totalMoves: 99,
+                createdAt: '2026-08-01T00:00:01Z',
+            },
+            expectedRuleset: 2,
+        },
+        {
+            name: 'lower valid elapsed time',
+            first: {
+                score: 100,
+                rulesetVersion: 1,
+                elapsedSeconds: 10,
+                totalMoves: 20,
+                createdAt: '2026-08-01T00:00:01Z',
+            },
+            second: {
+                score: 100,
+                rulesetVersion: 2,
+                elapsedSeconds: 20,
+                totalMoves: 1,
+                createdAt: '2026-08-01T00:00:00Z',
+            },
+            expectedRuleset: 1,
+        },
+        {
+            name: 'lower valid move count',
+            first: {
+                score: 100,
+                rulesetVersion: 1,
+                elapsedSeconds: 10,
+                totalMoves: 5,
+                createdAt: '2026-08-01T00:00:01Z',
+            },
+            second: {
+                score: 100,
+                rulesetVersion: 2,
+                elapsedSeconds: 10,
+                totalMoves: 9,
+                createdAt: '2026-08-01T00:00:00Z',
+            },
+            expectedRuleset: 1,
+        },
+        {
+            name: 'earlier created_at',
+            first: {
+                score: 100,
+                rulesetVersion: 1,
+                elapsedSeconds: 10,
+                totalMoves: 5,
+                createdAt: '2026-08-01T00:00:00Z',
+            },
+            second: {
+                score: 100,
+                rulesetVersion: 2,
+                elapsedSeconds: 10,
+                totalMoves: 5,
+                createdAt: '2026-08-01T00:00:01Z',
+            },
+            expectedRuleset: 1,
+        },
+        {
+            name: 'lower row id for equal second-resolution timestamps',
+            first: {
+                score: 100,
+                rulesetVersion: 1,
+                elapsedSeconds: 10,
+                totalMoves: 5,
+                createdAt: '2026-08-01T00:00:00Z',
+            },
+            second: {
+                score: 100,
+                rulesetVersion: 2,
+                elapsedSeconds: 10,
+                totalMoves: 5,
+                createdAt: '2026-08-01T00:00:00Z',
+            },
+            expectedRuleset: 1,
+        },
+    ])('selects by $name', async ({ first, second, expectedRuleset }) => {
+        await seedUser('u1', 'One')
+        await seedScopedScore('u1', first.score, {
+            mode: 'daily',
+            competitionKey: 'daily:tie',
+            rulesetVersion: first.rulesetVersion,
+            createdAt: first.createdAt,
+            gameData: {
+                elapsedSeconds: first.elapsedSeconds,
+                totalMoves: first.totalMoves,
+            },
+        })
+        await seedScopedScore('u1', second.score, {
+            mode: 'daily',
+            competitionKey: 'daily:tie',
+            rulesetVersion: second.rulesetVersion,
+            createdAt: second.createdAt,
+            gameData: {
+                elapsedSeconds: second.elapsedSeconds,
+                totalMoves: second.totalMoves,
+            },
+        })
+
+        const result = await getScopedGameLeaderboard({
+            gameId: 'tetris',
+            mode: 'daily',
+            competitionKey: 'daily:tie',
+            limit: 10,
+        })
+
+        expect(result.success).toBe(true)
+        if (!result.success) {
+            throw new Error('expected success')
+        }
+        expect(result.rows[0].rulesetVersion).toBe(expectedRuleset)
+    })
+
+    it('sorts valid metrics before missing, fractional, negative, and malformed values', async () => {
+        await seedUser('valid', 'Valid')
+        await seedUser('invalid', 'Invalid')
+        await seedUser('broken', 'Broken')
+
+        await seedScopedScore('valid', 100, {
+            mode: 'daily',
+            competitionKey: 'daily:invalid',
+            rulesetVersion: 1,
+            gameData: { elapsedSeconds: 12, totalMoves: 20 },
+        })
+        await seedScopedScore('invalid', 100, {
+            mode: 'daily',
+            competitionKey: 'daily:invalid',
+            rulesetVersion: 1,
+            rawGameDataJson: '{"elapsedSeconds":12.5,"totalMoves":-1}',
+        })
+        await seedScopedScore('broken', 100, {
+            mode: 'daily',
+            competitionKey: 'daily:invalid',
+            rulesetVersion: 1,
+            rawGameDataJson: '{not-json',
+        })
+
+        const result = await getScopedGameLeaderboard({
+            gameId: 'tetris',
+            mode: 'daily',
+            competitionKey: 'daily:invalid',
+            limit: 10,
+        })
+
+        expect(result.success).toBe(true)
+        if (!result.success) {
+            throw new Error('expected success')
+        }
+        expect(result.rows[0].userId).toBe('valid')
+        expect(result.rows.slice(1)).toEqual(
+            expect.arrayContaining([
+                expect.objectContaining({
+                    userId: 'invalid',
+                    elapsedSeconds: null,
+                    totalMoves: null,
+                }),
+                expect.objectContaining({
+                    userId: 'broken',
+                    elapsedSeconds: null,
+                    totalMoves: null,
+                }),
+            ])
+        )
+    })
+
+    it('excludes null-version rows and does not project unknown JSON keys', async () => {
+        await seedUser('u1', 'One')
+        await seedUser('u2', 'Two')
+        await seedScopedScore('u1', 100, {
+            mode: 'daily',
+            competitionKey: 'daily:version',
+            rulesetVersion: null,
+            gameData: { elapsedSeconds: 1, combo: 99 },
+        })
+        await seedScopedScore('u2', 90, {
+            mode: 'daily',
+            competitionKey: 'daily:version',
+            rulesetVersion: 1,
+            gameData: { elapsedSeconds: 2, combo: 100 },
+        })
+
+        const result = await getScopedGameLeaderboard({
+            gameId: 'tetris',
+            mode: 'daily',
+            competitionKey: 'daily:version',
+            limit: 10,
+        })
+
+        expect(result.success).toBe(true)
+        if (!result.success) {
+            throw new Error('expected success')
+        }
+        expect(result.rows.map(row => row.userId)).toEqual(['u2'])
+        expect(result.rows[0]).not.toHaveProperty('combo')
+    })
+
+    it('applies limit after best-per-user partitioning', async () => {
+        for (let user = 0; user < 100; user += 1) {
+            const userId = `u-${user}`
+            await seedUser(userId, `Player ${user}`)
+            for (let attempt = 0; attempt < 3; attempt += 1) {
+                await seedScopedScore(userId, user * 10 + attempt, {
+                    mode: 'daily',
+                    competitionKey: 'daily:bulk',
+                    rulesetVersion: 1,
+                    gameData: {
+                        elapsedSeconds: 100 - attempt,
+                        totalMoves: 50 - attempt,
+                    },
+                })
+            }
+        }
+
+        const result = await getScopedGameLeaderboard({
+            gameId: 'tetris',
+            mode: 'daily',
+            competitionKey: 'daily:bulk',
+            limit: 10,
+        })
+
+        expect(result.success).toBe(true)
+        if (!result.success) {
+            throw new Error('expected success')
+        }
+        expect(result.rows).toHaveLength(10)
+        expect(new Set(result.rows.map(row => row.userId)).size).toBe(10)
+        expect(result.rows[0].score).toBe(992)
+    })
+})

--- a/src/lib/server/db/scoped-leaderboard.integration.test.ts
+++ b/src/lib/server/db/scoped-leaderboard.integration.test.ts
@@ -352,6 +352,8 @@ describe('getScopedGameLeaderboard', () => {
             throw new Error('expected success')
         }
         expect(result.rows[0].userId).toBe('valid')
+        expect(result.rows[0].elapsedSeconds).toBe(12)
+        expect(result.rows[0].totalMoves).toBe(20)
         expect(result.rows.slice(1)).toEqual(
             expect.arrayContaining([
                 expect.objectContaining({
@@ -366,6 +368,68 @@ describe('getScopedGameLeaderboard', () => {
                 }),
             ])
         )
+    })
+
+    it('normalizes SQLite bare-timestamp created_at as UTC and preserves ISO inputs', async () => {
+        await seedUser('u1', 'One')
+        // SQLite CURRENT_TIMESTAMP stores 'YYYY-MM-DD HH:MM:SS' with no zone
+        // suffix; this must be interpreted as UTC, not local time.
+        await seedScopedScore('u1', 100, {
+            mode: 'daily',
+            competitionKey: 'daily:ts',
+            rulesetVersion: 1,
+            createdAt: '2026-08-01 00:00:00',
+            gameData: { elapsedSeconds: 1, totalMoves: 1 },
+        })
+
+        const result = await getScopedGameLeaderboard({
+            gameId: 'tetris',
+            mode: 'daily',
+            competitionKey: 'daily:ts',
+            limit: 10,
+        })
+
+        expect(result.success).toBe(true)
+        if (!result.success) {
+            throw new Error('expected success')
+        }
+        expect(result.rows[0].created_at).toBe('2026-08-01T00:00:00.000Z')
+    })
+
+    it('does not let one unparseable created_at poison the result set', async () => {
+        await seedUser('u1', 'One')
+        await seedUser('u2', 'Two')
+        await seedScopedScore('u1', 100, {
+            mode: 'daily',
+            competitionKey: 'daily:bad-ts',
+            rulesetVersion: 1,
+            createdAt: '2026-08-01T00:00:00Z',
+            gameData: { elapsedSeconds: 1, totalMoves: 1 },
+        })
+        await seedScopedScore('u2', 200, {
+            mode: 'daily',
+            competitionKey: 'daily:bad-ts',
+            rulesetVersion: 1,
+            createdAt: 'not-a-date',
+            gameData: { elapsedSeconds: 1, totalMoves: 1 },
+        })
+
+        const result = await getScopedGameLeaderboard({
+            gameId: 'tetris',
+            mode: 'daily',
+            competitionKey: 'daily:bad-ts',
+            limit: 10,
+        })
+
+        expect(result.success).toBe(true)
+        if (!result.success) {
+            throw new Error('expected success')
+        }
+        // Both rows return; the malformed timestamp falls back to its raw
+        // string instead of throwing and failing the whole query.
+        expect(result.rows).toHaveLength(2)
+        const badRow = result.rows.find(row => row.userId === 'u2')
+        expect(badRow?.created_at).toBe('not-a-date')
     })
 
     it('excludes null-version rows and does not project unknown JSON keys', async () => {
@@ -430,5 +494,39 @@ describe('getScopedGameLeaderboard', () => {
         expect(result.rows).toHaveLength(10)
         expect(new Set(result.rows.map(row => row.userId)).size).toBe(10)
         expect(result.rows[0].score).toBe(992)
+    })
+})
+
+describe('toPublicScopedLeaderboardEntry', () => {
+    it('excludes userId while preserving every public leaderboard field', () => {
+        const row = {
+            userId: 'secret-user-id',
+            name: 'Player',
+            username: 'player',
+            image: null,
+            score: 500,
+            created_at: '2026-08-01T00:00:00.000Z',
+            mode: 'daily',
+            competitionKey: 'daily:1',
+            rulesetVersion: 2,
+            elapsedSeconds: 12,
+            totalMoves: 34,
+        }
+
+        const entry = toPublicScopedLeaderboardEntry(row)
+
+        expect(entry).not.toHaveProperty('userId')
+        expect(entry).toEqual({
+            name: 'Player',
+            username: 'player',
+            image: null,
+            score: 500,
+            created_at: '2026-08-01T00:00:00.000Z',
+            mode: 'daily',
+            competitionKey: 'daily:1',
+            rulesetVersion: 2,
+            elapsedSeconds: 12,
+            totalMoves: 34,
+        })
     })
 })

--- a/src/lib/server/db/scoped-leaderboard.ts
+++ b/src/lib/server/db/scoped-leaderboard.ts
@@ -1,0 +1,237 @@
+import { sql } from 'kysely'
+import { db } from './client'
+import {
+    ensureGameScoresContextSchema,
+    hasCompleteGameScoresContextColumns,
+} from './game-score-context'
+
+export interface ScopedLeaderboardQuery {
+    gameId: string
+    mode: string
+    competitionKey?: string
+    limit?: number
+}
+
+export interface ScopedLeaderboardRow {
+    userId: string
+    name: string
+    username: string | null
+    image: string | null
+    score: number
+    created_at: string
+    mode: string
+    competitionKey: string | null
+    rulesetVersion: number
+    elapsedSeconds: number | null
+    totalMoves: number | null
+}
+
+export type ScopedLeaderboardEntry = Omit<ScopedLeaderboardRow, 'userId'>
+
+export type ScopedLeaderboardResult =
+    | { success: true; rows: ScopedLeaderboardRow[] }
+    | {
+          success: false
+          code: 'SCOPED_LEADERBOARD_UNAVAILABLE'
+      }
+
+export function toPublicScopedLeaderboardEntry(
+    row: ScopedLeaderboardRow
+): ScopedLeaderboardEntry {
+    const { userId: _userId, ...entry } = row
+    return entry
+}
+
+interface RawScopedLeaderboardRow {
+    user_id: string
+    name: string | null
+    username: string | null
+    image: string | null
+    score: number
+    created_at: string | Date
+    mode: string
+    competition_key: string | null
+    ruleset_version: number
+    elapsed_seconds: number | null
+    total_moves: number | null
+}
+
+export async function getScopedGameLeaderboard(
+    query: ScopedLeaderboardQuery
+): Promise<ScopedLeaderboardResult> {
+    const state = await ensureGameScoresContextSchema()
+    if (
+        !state.known ||
+        !hasCompleteGameScoresContextColumns(state.capabilities)
+    ) {
+        return {
+            success: false,
+            code: 'SCOPED_LEADERBOARD_UNAVAILABLE',
+        }
+    }
+
+    const competitionFilter =
+        query.competitionKey === undefined
+            ? sql``
+            : sql`AND gs.competition_key = ${query.competitionKey}`
+    const limit = query.limit ?? 10
+
+    try {
+        const result = await sql<RawScopedLeaderboardRow>`
+            WITH scoped AS (
+                SELECT
+                    gs.id,
+                    gs.user_id,
+                    gs.score,
+                    gs.created_at,
+                    gs.mode,
+                    gs.competition_key,
+                    gs.ruleset_version,
+                    CASE
+                        WHEN json_valid(gs.game_data_json) = 1
+                        THEN gs.game_data_json
+                        ELSE NULL
+                    END AS valid_json
+                FROM game_scores AS gs
+                WHERE gs.game_id = ${query.gameId}
+                  AND gs.mode = ${query.mode}
+                  AND gs.ruleset_version IS NOT NULL
+                  ${competitionFilter}
+            ),
+            metrics AS (
+                SELECT
+                    *,
+                    CASE
+                        WHEN json_type(
+                            valid_json,
+                            '$.elapsedSeconds'
+                        ) = 'integer'
+                         AND json_extract(
+                            valid_json,
+                            '$.elapsedSeconds'
+                         ) >= 0
+                        THEN CAST(
+                            json_extract(
+                                valid_json,
+                                '$.elapsedSeconds'
+                            ) AS INTEGER
+                        )
+                        ELSE NULL
+                    END AS elapsed_seconds,
+                    CASE
+                        WHEN json_type(
+                            valid_json,
+                            '$.totalMoves'
+                        ) = 'integer'
+                         AND json_extract(
+                            valid_json,
+                            '$.totalMoves'
+                         ) >= 0
+                        THEN CAST(
+                            json_extract(
+                                valid_json,
+                                '$.totalMoves'
+                            ) AS INTEGER
+                        )
+                        ELSE NULL
+                    END AS total_moves
+                FROM scoped
+            ),
+            ranked AS (
+                SELECT
+                    *,
+                    ROW_NUMBER() OVER (
+                        PARTITION BY user_id
+                        ORDER BY
+                            score DESC,
+                            CASE
+                                WHEN elapsed_seconds IS NULL
+                                THEN 1
+                                ELSE 0
+                            END ASC,
+                            elapsed_seconds ASC,
+                            CASE
+                                WHEN total_moves IS NULL
+                                THEN 1
+                                ELSE 0
+                            END ASC,
+                            total_moves ASC,
+                            created_at ASC,
+                            id ASC
+                    ) AS user_attempt_rank
+                FROM metrics
+            ),
+            best AS (
+                SELECT *
+                FROM ranked
+                WHERE user_attempt_rank = 1
+            )
+            SELECT
+                best.user_id AS user_id,
+                COALESCE(
+                    "user".displayName,
+                    "user".username,
+                    "user".name,
+                    'Anonymous'
+                ) AS name,
+                "user".username AS username,
+                "user".image AS image,
+                best.score AS score,
+                best.created_at AS created_at,
+                best.mode AS mode,
+                best.competition_key AS competition_key,
+                best.ruleset_version AS ruleset_version,
+                best.elapsed_seconds AS elapsed_seconds,
+                best.total_moves AS total_moves
+            FROM best
+            LEFT JOIN "user" ON "user".id = best.user_id
+            ORDER BY
+                best.score DESC,
+                CASE
+                    WHEN best.elapsed_seconds IS NULL
+                    THEN 1
+                    ELSE 0
+                END ASC,
+                best.elapsed_seconds ASC,
+                CASE
+                    WHEN best.total_moves IS NULL
+                    THEN 1
+                    ELSE 0
+                END ASC,
+                best.total_moves ASC,
+                best.created_at ASC,
+                best.id ASC
+            LIMIT ${limit}
+        `.execute(db)
+
+        return {
+            success: true,
+            rows: result.rows.map(row => ({
+                userId: row.user_id,
+                name: row.name ?? 'Anonymous',
+                username: row.username ?? null,
+                image: row.image ?? null,
+                score: Number(row.score),
+                created_at: new Date(row.created_at).toISOString(),
+                mode: row.mode,
+                competitionKey: row.competition_key ?? null,
+                rulesetVersion: Number(row.ruleset_version),
+                elapsedSeconds:
+                    row.elapsed_seconds === null
+                        ? null
+                        : Number(row.elapsed_seconds),
+                totalMoves:
+                    row.total_moves === null ? null : Number(row.total_moves),
+            })),
+        }
+    } catch (error) {
+        console.error(
+            '[getScopedGameLeaderboard] Database error:',
+            error instanceof Error ? error.message : String(error)
+        )
+        return {
+            success: false,
+            code: 'SCOPED_LEADERBOARD_UNAVAILABLE',
+        }
+    }
+}

--- a/src/lib/server/db/scoped-leaderboard.ts
+++ b/src/lib/server/db/scoped-leaderboard.ts
@@ -56,6 +56,30 @@ interface RawScopedLeaderboardRow {
     total_moves: number | null
 }
 
+/**
+ * Normalize a SQLite/libSQL `created_at` value to an ISO-8601 UTC string.
+ *
+ * SQLite `CURRENT_TIMESTAMP` stores `'YYYY-MM-DD HH:MM:SS'` with no timezone
+ * suffix. `new Date()` parses that form as LOCAL time, which would silently
+ * shift timestamps across zones. We therefore treat the bare form as UTC by
+ * appending a `Z` before parsing. Values that already carry a timezone offset
+ * (`Z`, `+HH:MM`, `-HH:MM`) are parsed as-is. Unparseable values fall back to
+ * `null` so a single malformed row cannot poison the whole result set.
+ */
+function normalizeCreatedAtToIso(value: string | Date): string | null {
+    if (value instanceof Date) {
+        return Number.isNaN(value.getTime()) ? null : value.toISOString()
+    }
+    const raw = value.trim()
+    if (raw === '') {
+        return null
+    }
+    // Already has a timezone designator (Z or numeric offset) → parse directly.
+    const hasTimezone = /Z$|[+-]\d{2}:?\d{2}$/.test(raw)
+    const parsed = hasTimezone ? new Date(raw) : new Date(`${raw}Z`)
+    return Number.isNaN(parsed.getTime()) ? null : parsed.toISOString()
+}
+
 export async function getScopedGameLeaderboard(
     query: ScopedLeaderboardQuery
 ): Promise<ScopedLeaderboardResult> {
@@ -75,10 +99,27 @@ export async function getScopedGameLeaderboard(
             ? sql``
             : sql`AND gs.competition_key = ${query.competitionKey}`
     const limit = query.limit ?? 10
+    // Performance note: when competitionKey is omitted (mode-only query) the
+    // scoped CTE matches every row for the game/mode, the ranked CTE numbers
+    // all of them, and LIMIT is applied only after best-per-user selection.
+    // Work therefore scales with the total matching row count for the game +
+    // mode, not with `limit`. If per-game/mode attempt volumes grow large,
+    // add a created_at retention window/filter to the scoped CTE, or back this
+    // view with a materialized best-per-user table that preserves the
+    // (score DESC, elapsedSeconds ASC, totalMoves ASC, created_at ASC, id ASC)
+    // ranking order.
 
     try {
+        // json_valid / json_type / json_extract are SQLite/libSQL JSON1
+        // functions. json_valid returns 1 for parseable JSON; json_type
+        // returns the declared type of a path element (here 'integer'), which
+        // also rejects fractional numbers and strings; json_extract returns
+        // the raw value, which we CAST to INTEGER for stable ordering.
         const result = await sql<RawScopedLeaderboardRow>`
             WITH scoped AS (
+                -- Filter to the requested game/mode/competition and project
+                -- game_data_json only when it is valid JSON; otherwise NULL so
+                -- malformed payloads are excluded from metric extraction.
                 SELECT
                     gs.id,
                     gs.user_id,
@@ -99,6 +140,10 @@ export async function getScopedGameLeaderboard(
                   ${competitionFilter}
             ),
             metrics AS (
+                -- Extract elapsedSeconds/totalMoves as non-negative integers.
+                -- Anything missing, fractional, negative, or wrong-typed
+                -- becomes NULL; the ranking CTEs order NULLs LAST via the
+                -- CASE guards so valid metrics always sort ahead of missing.
                 SELECT
                     *,
                     CASE
@@ -138,6 +183,11 @@ export async function getScopedGameLeaderboard(
                 FROM scoped
             ),
             ranked AS (
+                -- Number each user's attempts 1..N so the next CTE can keep
+                -- only their single best. Tie-break order mirrors the global
+                -- ranking: score DESC, then elapsed_seconds ASC (NULLs last),
+                -- then total_moves ASC (NULLs last), then created_at ASC,
+                -- then id ASC as the final deterministic tie-breaker.
                 SELECT
                     *,
                     ROW_NUMBER() OVER (
@@ -162,6 +212,7 @@ export async function getScopedGameLeaderboard(
                 FROM metrics
             ),
             best AS (
+                -- One row per user: their highest-ranked attempt.
                 SELECT *
                 FROM ranked
                 WHERE user_attempt_rank = 1
@@ -212,7 +263,9 @@ export async function getScopedGameLeaderboard(
                 username: row.username ?? null,
                 image: row.image ?? null,
                 score: Number(row.score),
-                created_at: new Date(row.created_at).toISOString(),
+                created_at:
+                    normalizeCreatedAtToIso(row.created_at) ??
+                    String(row.created_at),
                 mode: row.mode,
                 competitionKey: row.competition_key ?? null,
                 rulesetVersion: Number(row.ruleset_version),

--- a/src/lib/server/db/types.ts
+++ b/src/lib/server/db/types.ts
@@ -1,4 +1,4 @@
-import type { ColumnType, Selectable } from 'kysely'
+import type { ColumnType, Insertable, Selectable } from 'kysely'
 
 // Better Auth table types (based on the generated schema)
 export interface UserTable {
@@ -56,6 +56,22 @@ export interface GameScoresTable {
     user_id: string
     game_id: string
     score: number
+    mode: ColumnType<string | null, string | null | undefined, string | null>
+    competition_key: ColumnType<
+        string | null,
+        string | null | undefined,
+        string | null
+    >
+    ruleset_version: ColumnType<
+        number | null,
+        number | null | undefined,
+        number | null
+    >
+    game_data_json: ColumnType<
+        string | null,
+        string | null | undefined,
+        string | null
+    >
     created_at: ColumnType<Date, never, never> // DEFAULT CURRENT_TIMESTAMP
 }
 
@@ -142,7 +158,7 @@ export type UserUpdate = Partial<
     >
 >
 
-export type NewGameScore = Omit<GameScoresTable, 'id' | 'created_at'>
+export type NewGameScore = Insertable<GameScoresTable>
 export type GameScore = Selectable<GameScoresTable>
 
 export type NewUserStats = Omit<

--- a/src/lib/server/validations.test.ts
+++ b/src/lib/server/validations.test.ts
@@ -305,6 +305,18 @@ describe('server validations', () => {
             expect(tooLow.success).toBe(false)
             expect(tooHigh.success).toBe(false)
         })
+
+        it.each(['10junk', '1.9', '0x10', ' 25', '25 ', '+5', '-1', '1e2', ''])(
+            'rejects partially numeric or non-decimal limit: %j',
+            value => {
+                const result = leaderboardQuerySchema.safeParse({
+                    gameId: GameID.TETRIS,
+                    limit: value,
+                })
+
+                expect(result.success).toBe(false)
+            }
+        )
     })
 
     describe('paginationQuerySchema', () => {

--- a/src/lib/server/validations.test.ts
+++ b/src/lib/server/validations.test.ts
@@ -244,6 +244,35 @@ describe('server validations', () => {
     })
 
     describe('leaderboardQuerySchema', () => {
+        it('accepts the all-games form', () => {
+            expect(leaderboardQuerySchema.parse({})).toEqual({ limit: 10 })
+        })
+
+        it('accepts game-only, mode-only scoped, and exact-key forms', () => {
+            expect(
+                leaderboardQuerySchema.safeParse({
+                    gameId: GameID.TETRIS,
+                    mode: 'daily',
+                }).success
+            ).toBe(true)
+
+            expect(
+                leaderboardQuerySchema.safeParse({
+                    gameId: GameID.TETRIS,
+                    mode: 'daily',
+                    competitionKey: 'daily:1',
+                }).success
+            ).toBe(true)
+        })
+
+        it.each([
+            { mode: 'daily' },
+            { competitionKey: 'daily:1' },
+            { gameId: GameID.TETRIS, competitionKey: 'daily:1' },
+        ])('rejects invalid cross-field combinations: %o', params => {
+            expect(leaderboardQuerySchema.safeParse(params).success).toBe(false)
+        })
+
         it('applies default limit and parses numeric limit', () => {
             const withDefault = leaderboardQuerySchema.safeParse({
                 gameId: GameID.TETRIS,

--- a/src/lib/server/validations.test.ts
+++ b/src/lib/server/validations.test.ts
@@ -94,6 +94,100 @@ describe('server validations', () => {
         })
     })
 
+    describe('scoreSubmissionSchema context', () => {
+        const base = { gameId: GameID.TETRIS, score: 100 }
+
+        it('accepts omitted context and rejects null context', () => {
+            expect(scoreSubmissionSchema.safeParse(base).success).toBe(true)
+            expect(
+                scoreSubmissionSchema.safeParse({ ...base, context: null })
+                    .success
+            ).toBe(false)
+        })
+
+        it('uses fully anchored mode and competition-key patterns', () => {
+            const valid = {
+                ...base,
+                context: {
+                    mode: 'daily',
+                    competitionKey: 'ice-slide:daily:2026-08-01:g1:r1',
+                    rulesetVersion: 1,
+                },
+            }
+            expect(scoreSubmissionSchema.safeParse(valid).success).toBe(true)
+
+            expect(
+                scoreSubmissionSchema.safeParse({
+                    ...valid,
+                    context: { ...valid.context, mode: 'daily!' },
+                }).success
+            ).toBe(false)
+
+            expect(
+                scoreSubmissionSchema.safeParse({
+                    ...valid,
+                    context: {
+                        ...valid.context,
+                        competitionKey: 'ok#invalid',
+                    },
+                }).success
+            ).toBe(false)
+        })
+
+        it('accepts oversized legacy gameData but rejects oversized contextual data', () => {
+            const gameData = { payload: 'x'.repeat(17 * 1024) }
+
+            expect(
+                scoreSubmissionSchema.safeParse({ ...base, gameData }).success
+            ).toBe(true)
+
+            expect(
+                scoreSubmissionSchema.safeParse({
+                    ...base,
+                    gameData,
+                    context: { mode: 'daily', rulesetVersion: 1 },
+                }).success
+            ).toBe(false)
+        })
+
+        it('measures contextual data in UTF-8 bytes', () => {
+            const gameData = { payload: '界'.repeat(6_000) }
+
+            expect(
+                scoreSubmissionSchema.safeParse({
+                    ...base,
+                    gameData,
+                    context: { mode: 'daily', rulesetVersion: 1 },
+                }).success
+            ).toBe(false)
+        })
+
+        it.each([
+            { elapsedSeconds: 12.5 },
+            { elapsedSeconds: -1 },
+            { totalMoves: 4.5 },
+            { totalMoves: -1 },
+        ])('rejects invalid allowlisted metrics: %o', metric => {
+            expect(
+                scoreSubmissionSchema.safeParse({
+                    ...base,
+                    gameData: metric,
+                    context: { mode: 'daily', rulesetVersion: 1 },
+                }).success
+            ).toBe(false)
+        })
+
+        it('accepts whole-second elapsed time and integer moves', () => {
+            expect(
+                scoreSubmissionSchema.safeParse({
+                    ...base,
+                    gameData: { elapsedSeconds: 12, totalMoves: 34 },
+                    context: { mode: 'daily', rulesetVersion: 1 },
+                }).success
+            ).toBe(true)
+        })
+    })
+
     describe('profileUpdateSchema', () => {
         it('normalizes whitespace and case', () => {
             const result = profileUpdateSchema.safeParse({

--- a/src/lib/server/validations.ts
+++ b/src/lib/server/validations.ts
@@ -62,14 +62,14 @@ function addContextualGameDataIssues(
 export const scoreSubmissionSchema = z
     .object({
         gameId: z.enum(gameIdValues, {
-            message: 'Invalid game ID',
+            error: 'Invalid game ID',
         }),
         score: z
             .number()
             .int()
-            .min(0, { message: 'Score must be a non-negative integer' })
+            .min(0, { error: 'Score must be a non-negative integer' })
             .max(999_999_999, {
-                message: 'Score exceeds maximum allowed value',
+                error: 'Score exceeds maximum allowed value',
             }),
         gameData: z.record(z.string(), z.unknown()).optional(),
         context: scoreContextSchema.optional(),

--- a/src/lib/server/validations.ts
+++ b/src/lib/server/validations.ts
@@ -152,7 +152,8 @@ export const leaderboardQuerySchema = z
             .optional(),
         limit: z
             .string()
-            .transform(value => Number.parseInt(value, 10))
+            .regex(/^\d+$/, { message: 'limit must be a positive integer' })
+            .transform(Number)
             .pipe(z.number().int().min(1).max(100))
             .optional()
             .default(10),

--- a/src/lib/server/validations.ts
+++ b/src/lib/server/validations.ts
@@ -11,17 +11,74 @@ const gameIdValues = Object.values(GameID) as [string, ...string[]]
 /**
  * Score submission schema
  */
-export const scoreSubmissionSchema = z.object({
-    gameId: z.enum(gameIdValues, {
-        message: 'Invalid game ID',
-    }),
-    score: z
-        .number()
-        .int()
-        .min(0, { message: 'Score must be a non-negative integer' })
-        .max(999_999_999, { message: 'Score exceeds maximum allowed value' }),
-    gameData: z.record(z.string(), z.unknown()).optional(),
-})
+const SCORE_CONTEXT_MAX_GAME_DATA_BYTES = 16 * 1024
+const modePattern = /^[a-z][a-z0-9_-]*$/
+const competitionKeyPattern = /^[A-Za-z0-9:._-]+$/
+
+export const scoreContextSchema = z
+    .object({
+        mode: z.string().min(1).max(32).regex(modePattern),
+        competitionKey: z
+            .string()
+            .min(1)
+            .max(128)
+            .regex(competitionKeyPattern)
+            .optional(),
+        rulesetVersion: z.number().int().min(1).max(2_147_483_647),
+    })
+    .strict()
+
+export type ScoreSubmissionContext = z.infer<typeof scoreContextSchema>
+
+function addContextualGameDataIssues(
+    data: Record<string, unknown>,
+    ctx: z.RefinementCtx
+): void {
+    for (const key of ['elapsedSeconds', 'totalMoves'] as const) {
+        const value = data[key]
+        if (
+            value !== undefined &&
+            (typeof value !== 'number' || !Number.isInteger(value) || value < 0)
+        ) {
+            ctx.addIssue({
+                code: 'custom',
+                path: ['gameData', key],
+                message: `${key} must be a non-negative integer`,
+            })
+        }
+    }
+
+    const serialized = JSON.stringify(data)
+    const byteLength = new TextEncoder().encode(serialized).byteLength
+    if (byteLength > SCORE_CONTEXT_MAX_GAME_DATA_BYTES) {
+        ctx.addIssue({
+            code: 'custom',
+            path: ['gameData'],
+            message: 'Contextual gameData exceeds 16 KiB',
+        })
+    }
+}
+
+export const scoreSubmissionSchema = z
+    .object({
+        gameId: z.enum(gameIdValues, {
+            message: 'Invalid game ID',
+        }),
+        score: z
+            .number()
+            .int()
+            .min(0, { message: 'Score must be a non-negative integer' })
+            .max(999_999_999, {
+                message: 'Score exceeds maximum allowed value',
+            }),
+        gameData: z.record(z.string(), z.unknown()).optional(),
+        context: scoreContextSchema.optional(),
+    })
+    .superRefine((data, ctx) => {
+        if (data.context && data.gameData) {
+            addContextualGameDataIssues(data.gameData, ctx)
+        }
+    })
 
 export type ScoreSubmissionInput = z.infer<typeof scoreSubmissionSchema>
 

--- a/src/lib/server/validations.ts
+++ b/src/lib/server/validations.ts
@@ -143,17 +143,44 @@ export type ProfileUpdateInput = z.infer<typeof profileUpdateSchema>
 /**
  * Leaderboard query schema
  */
-export const leaderboardQuerySchema = z.object({
-    gameId: z.enum(gameIdValues, {
-        message: 'Invalid game ID',
-    }),
-    limit: z
-        .string()
-        .transform(s => parseInt(s, 10))
-        .pipe(z.number().int().min(1).max(100))
-        .optional()
-        .default(10),
-})
+export const leaderboardQuerySchema = z
+    .object({
+        gameId: z
+            .enum(gameIdValues, {
+                message: 'Invalid game ID',
+            })
+            .optional(),
+        limit: z
+            .string()
+            .transform(value => Number.parseInt(value, 10))
+            .pipe(z.number().int().min(1).max(100))
+            .optional()
+            .default(10),
+        mode: z.string().min(1).max(32).regex(modePattern).optional(),
+        competitionKey: z
+            .string()
+            .min(1)
+            .max(128)
+            .regex(competitionKeyPattern)
+            .optional(),
+    })
+    .superRefine((data, ctx) => {
+        if (data.mode && !data.gameId) {
+            ctx.addIssue({
+                code: 'custom',
+                path: ['mode'],
+                message: 'mode requires gameId',
+            })
+        }
+
+        if (data.competitionKey && (!data.gameId || !data.mode)) {
+            ctx.addIssue({
+                code: 'custom',
+                path: ['competitionKey'],
+                message: 'competitionKey requires gameId and mode',
+            })
+        }
+    })
 
 export type LeaderboardQueryInput = z.infer<typeof leaderboardQuerySchema>
 

--- a/src/lib/services/achievementService.test.ts
+++ b/src/lib/services/achievementService.test.ts
@@ -377,6 +377,34 @@ describe('Achievement Service', () => {
 
             expect(result).toEqual([])
         })
+
+        it('derives progress from the unscoped best score regardless of earned state', async () => {
+            mockGetAchievementsByGame.mockReturnValue([
+                {
+                    id: 'tetris_master',
+                    name: 'Tetris Master',
+                    description: 'Score 1000 points in Tetris',
+                    logo: '👑',
+                    gameId: GameID.TETRIS,
+                    condition: { type: 'score_threshold', threshold: 1000 },
+                    rarity: AchievementRarity.EPIC,
+                },
+            ])
+            mockGetUserBestScore.mockResolvedValue(250)
+            mockHasUserEarnedAchievement.mockResolvedValue(true)
+
+            const result = await getUserGameAchievementProgress(
+                'user123',
+                GameID.TETRIS
+            )
+
+            expect(mockGetUserBestScore).toHaveBeenCalledWith(
+                'user123',
+                GameID.TETRIS
+            )
+            expect(result[0].progress).toBe(25)
+            expect(result[0].earned).toBe(true)
+        })
     })
 
     describe('getAchievementNotifications', () => {

--- a/src/lib/services/achievementService.test.ts
+++ b/src/lib/services/achievementService.test.ts
@@ -405,6 +405,45 @@ describe('Achievement Service', () => {
             expect(result[0].progress).toBe(25)
             expect(result[0].earned).toBe(true)
         })
+
+        it('treats earned as authoritative when scoped awarding exceeds unscoped progress', async () => {
+            const achievement: Achievement = {
+                id: 'tetris_master',
+                name: 'Tetris Master',
+                description: 'Score 1000 points in Tetris',
+                logo: '👑',
+                gameId: GameID.TETRIS,
+                condition: {
+                    type: 'score_threshold',
+                    threshold: 1000,
+                },
+                rarity: AchievementRarity.EPIC,
+            }
+
+            mockGetAchievementsByGame.mockReturnValue([achievement])
+            mockHasUserEarnedAchievement
+                .mockResolvedValueOnce(false)
+                .mockResolvedValueOnce(true)
+            mockAwardAchievement.mockResolvedValue(true)
+            mockGetUserBestScore.mockResolvedValue(250)
+
+            await expect(
+                checkAndAwardAchievements('user123', GameID.TETRIS, 1200)
+            ).resolves.toEqual(['tetris_master'])
+
+            const progress = await getUserGameAchievementProgress(
+                'user123',
+                GameID.TETRIS
+            )
+
+            expect(progress).toEqual([
+                {
+                    achievement,
+                    earned: true,
+                    progress: 25,
+                },
+            ])
+        })
     })
 
     describe('getAchievementNotifications', () => {

--- a/src/lib/services/achievementService.test.ts
+++ b/src/lib/services/achievementService.test.ts
@@ -303,7 +303,10 @@ describe('Achievement Service', () => {
                     rarity: AchievementRarity.COMMON,
                 },
             ])
-            mockGetUserBestScore.mockResolvedValue(50) // 50% progress
+            mockGetUserBestScore.mockResolvedValue({
+                status: 'ok',
+                bestScore: 50,
+            }) // 50% progress
             mockHasUserEarnedAchievement.mockResolvedValue(false)
 
             const result = await getUserGameAchievementProgress(
@@ -328,7 +331,10 @@ describe('Achievement Service', () => {
                     rarity: AchievementRarity.COMMON,
                 },
             ])
-            mockGetUserBestScore.mockResolvedValue(200) // 200% but should cap at 100%
+            mockGetUserBestScore.mockResolvedValue({
+                status: 'ok',
+                bestScore: 200,
+            }) // 200% but should cap at 100%
             mockHasUserEarnedAchievement.mockResolvedValue(true)
 
             const result = await getUserGameAchievementProgress(
@@ -352,7 +358,10 @@ describe('Achievement Service', () => {
                     rarity: AchievementRarity.RARE,
                 } satisfies Achievement,
             ])
-            mockGetUserBestScore.mockResolvedValue(999)
+            mockGetUserBestScore.mockResolvedValue({
+                status: 'ok',
+                bestScore: 999,
+            })
             mockHasUserEarnedAchievement.mockResolvedValue(false)
 
             const result = await getUserGameAchievementProgress(
@@ -378,6 +387,35 @@ describe('Achievement Service', () => {
             expect(result).toEqual([])
         })
 
+        it('returns an empty progress set when the score context is unavailable', async () => {
+            // A failed score-context probe is a retryable unavailable state,
+            // distinct from the user having no scores (which yields progress
+            // entries with 0%). Unavailable → no progress can be computed.
+            mockGetAchievementsByGame.mockReturnValue([
+                {
+                    id: 'tetris_novice',
+                    name: 'Tetris Novice',
+                    description: 'Score 100 points in Tetris',
+                    logo: '🔰',
+                    gameId: GameID.TETRIS,
+                    condition: { type: 'score_threshold', threshold: 100 },
+                    rarity: AchievementRarity.COMMON,
+                },
+            ])
+            mockGetUserBestScore.mockResolvedValue({
+                status: 'unavailable',
+                code: 'SCORE_CONTEXT_UNAVAILABLE',
+            })
+            mockHasUserEarnedAchievement.mockResolvedValue(false)
+
+            const result = await getUserGameAchievementProgress(
+                'user123',
+                GameID.TETRIS
+            )
+
+            expect(result).toEqual([])
+        })
+
         it('derives progress from the unscoped best score regardless of earned state', async () => {
             mockGetAchievementsByGame.mockReturnValue([
                 {
@@ -390,7 +428,10 @@ describe('Achievement Service', () => {
                     rarity: AchievementRarity.EPIC,
                 },
             ])
-            mockGetUserBestScore.mockResolvedValue(250)
+            mockGetUserBestScore.mockResolvedValue({
+                status: 'ok',
+                bestScore: 250,
+            })
             mockHasUserEarnedAchievement.mockResolvedValue(true)
 
             const result = await getUserGameAchievementProgress(
@@ -425,7 +466,10 @@ describe('Achievement Service', () => {
                 .mockResolvedValueOnce(false)
                 .mockResolvedValueOnce(true)
             mockAwardAchievement.mockResolvedValue(true)
-            mockGetUserBestScore.mockResolvedValue(250)
+            mockGetUserBestScore.mockResolvedValue({
+                status: 'ok',
+                bestScore: 250,
+            })
 
             await expect(
                 checkAndAwardAchievements('user123', GameID.TETRIS, 1200)

--- a/src/lib/services/achievementService.ts
+++ b/src/lib/services/achievementService.ts
@@ -102,7 +102,18 @@ export async function getUserGameAchievementProgress(
 > {
     try {
         const gameAchievements = getAchievementsByGame(gameId)
-        const userBestScore = (await getUserBestScore(userId, gameId)) ?? 0
+        const bestResult = await getUserBestScore(userId, gameId)
+
+        // A failed score-context probe is a retryable unavailable state. We
+        // cannot compute score-threshold progress without confirming the
+        // schema, so return an empty progress set rather than silently
+        // treating it as 0 (which would be indistinguishable from "no
+        // scores"). The no-scores case still falls through to progress
+        // entries with 0%.
+        if (bestResult.status === 'unavailable') {
+            return []
+        }
+        const userBestScore = bestResult.bestScore ?? 0
 
         const progress = []
 

--- a/src/lib/services/scoreService.test.ts
+++ b/src/lib/services/scoreService.test.ts
@@ -494,6 +494,59 @@ describe('Score Service', () => {
         })
     })
 
+    describe('saveGameScore context forwarding', () => {
+        it('forwards context through SaveScoreOptions without a new positional argument', async () => {
+            global.fetch = vi.fn().mockResolvedValue({
+                ok: true,
+                json: () => Promise.resolve({ success: true }),
+            })
+
+            await saveGameScore(
+                GameID.TETRIS,
+                100,
+                undefined,
+                undefined,
+                { elapsedSeconds: 12, totalMoves: 34 },
+                {
+                    context: {
+                        mode: 'daily',
+                        competitionKey: 'ice-slide:daily:2026-08-01:g1:r1',
+                        rulesetVersion: 1,
+                    },
+                }
+            )
+
+            const request = vi.mocked(global.fetch).mock
+                .calls[0][1] as RequestInit
+            expect(JSON.parse(String(request.body))).toEqual({
+                gameId: GameID.TETRIS,
+                score: 100,
+                gameData: { elapsedSeconds: 12, totalMoves: 34 },
+                context: {
+                    mode: 'daily',
+                    competitionKey: 'ice-slide:daily:2026-08-01:g1:r1',
+                    rulesetVersion: 1,
+                },
+            })
+        })
+
+        it('keeps the legacy request body free of a context property', async () => {
+            global.fetch = vi.fn().mockResolvedValue({
+                ok: true,
+                json: () => Promise.resolve({ success: true }),
+            })
+
+            await saveGameScore(GameID.TETRIS, 100)
+
+            const request = vi.mocked(global.fetch).mock
+                .calls[0][1] as RequestInit
+            expect(JSON.parse(String(request.body))).toEqual({
+                gameId: GameID.TETRIS,
+                score: 100,
+            })
+        })
+    })
+
     describe('saveGameScore stale-run guard', () => {
         it('suppresses all callbacks when isStale returns true on success', async () => {
             global.fetch = vi.fn().mockResolvedValue({

--- a/src/lib/services/scoreService.test.ts
+++ b/src/lib/services/scoreService.test.ts
@@ -131,6 +131,41 @@ describe('Score Service', () => {
             expect(result.success).toBe(true)
             expect(result.newAchievements).toEqual([])
         })
+
+        it('propagates recognized server error codes', async () => {
+            global.fetch = vi.fn().mockResolvedValue({
+                ok: false,
+                status: 500,
+                json: () =>
+                    Promise.resolve({
+                        error: 'Score context is unavailable',
+                        code: 'SCORE_CONTEXT_UNAVAILABLE',
+                    }),
+            })
+
+            const result = await submitScore({
+                gameId: GameID.TETRIS,
+                score: 100,
+                context: { mode: 'daily', rulesetVersion: 1 },
+            })
+
+            expect(result).toMatchObject({
+                success: false,
+                code: 'SCORE_CONTEXT_UNAVAILABLE',
+            })
+        })
+
+        it('does not invent a server code for network failures', async () => {
+            global.fetch = vi.fn().mockRejectedValue(new Error('offline'))
+
+            const result = await submitScore({
+                gameId: GameID.TETRIS,
+                score: 100,
+            })
+
+            expect(result.success).toBe(false)
+            expect(result.code).toBeUndefined()
+        })
     })
 
     describe('saveGameScore', () => {

--- a/src/lib/services/scoreService.ts
+++ b/src/lib/services/scoreService.ts
@@ -184,7 +184,18 @@ export async function getUserGameHistory(
 }
 
 /**
- * Get user's best score for a specific game
+ * Get user's best score for a specific game.
+ *
+ * Returns the best score as a number, or null when the user has no score.
+ *
+ * Note: this helper intentionally collapses every non-success path — network
+ * errors, non-2xx responses, and the server's retryable 503
+ * `SCORE_CONTEXT_UNAVAILABLE` state (see `src/pages/api/scores/best.ts`) — to
+ * the same null result used for "no score yet". This is the documented client
+ * contract: callers cannot distinguish a transient score-context outage from
+ * a genuine empty best score, and should treat null as "no score to show".
+ * If a future caller needs to retry on the unavailable state, switch this to
+ * a discriminated result that propagates `SCORE_CONTEXT_UNAVAILABLE`.
  */
 export async function getUserBestScore(
     gameId: GameType

--- a/src/lib/services/scoreService.ts
+++ b/src/lib/services/scoreService.ts
@@ -8,6 +8,8 @@ import { getGameById, type GameID } from '@/lib/games'
 import type { GameData } from '@/lib/games/shared/types'
 import type { ScoreSubmissionContext } from '@/lib/server/validations'
 
+export type ScoreSubmissionPublicErrorCode = 'SCORE_CONTEXT_UNAVAILABLE'
+
 export interface ScoreSubmissionResult {
     success: boolean
     newAchievements?: AchievementNotification[]
@@ -24,6 +26,7 @@ export interface ScoreSubmissionResult {
         newLevel?: number
     }
     error?: string
+    code?: ScoreSubmissionPublicErrorCode
 }
 
 export interface ScoreData {
@@ -61,16 +64,28 @@ export async function submitScore(
         })
 
         if (!response.ok) {
-            // Handle specific error cases
+            let body: { code?: unknown } | null = null
+            try {
+                body = (await response.json()) as { code?: unknown }
+            } catch {
+                body = null
+            }
+
+            const code =
+                body?.code === 'SCORE_CONTEXT_UNAVAILABLE'
+                    ? body.code
+                    : undefined
+
             if (response.status === 401) {
                 return {
                     success: false,
                     error: 'You must be logged in to save scores',
+                    code,
                 }
             } else if (response.status === 400) {
-                return { success: false, error: 'Invalid score data' }
+                return { success: false, error: 'Invalid score data', code }
             } else {
-                return { success: false, error: 'Failed to save score' }
+                return { success: false, error: 'Failed to save score', code }
             }
         }
 

--- a/src/lib/services/scoreService.ts
+++ b/src/lib/services/scoreService.ts
@@ -6,6 +6,7 @@ import type { GameType } from '@/lib/server/db/types'
 import { type AchievementNotification } from '@/lib/achievements'
 import { getGameById, type GameID } from '@/lib/games'
 import type { GameData } from '@/lib/games/shared/types'
+import type { ScoreSubmissionContext } from '@/lib/server/validations'
 
 export interface ScoreSubmissionResult {
     success: boolean
@@ -29,10 +30,12 @@ export interface ScoreData {
     gameId: GameType
     score: number
     gameData?: GameData | Record<string, unknown>
+    context?: ScoreSubmissionContext
 }
 
 export interface SaveScoreOptions {
     isStale?: () => boolean
+    context?: ScoreSubmissionContext
 }
 
 export interface GameHistoryEntry {
@@ -98,7 +101,14 @@ export async function saveGameScore(
     }
 
     try {
-        const result = await submitScore({ gameId, score, gameData })
+        const scoreData: ScoreData = { gameId, score }
+        if (gameData !== undefined) {
+            scoreData.gameData = gameData
+        }
+        if (options?.context !== undefined) {
+            scoreData.context = options.context
+        }
+        const result = await submitScore(scoreData)
 
         if (options?.isStale?.()) {
             return

--- a/src/pages/api/leaderboard.test.ts
+++ b/src/pages/api/leaderboard.test.ts
@@ -92,9 +92,9 @@ describe('GET /api/leaderboard', () => {
             const data = await response.json()
             expect(typeof data.error).toBe('string')
             expect(data.error.length).toBeGreaterThan(0)
-            // Non-numeric input fails the number-type check (NaN), distinct
+            // Non-decimal input fails the digit-only regex boundary, distinct
             // from the range checks below.
-            expect(data.error).toMatch(/NaN|expected number/i)
+            expect(data.error).toMatch(/positive integer|digit|number/i)
         })
 
         it('should return 400 for negative limit', async () => {
@@ -106,8 +106,9 @@ describe('GET /api/leaderboard', () => {
             const data = await response.json()
             expect(typeof data.error).toBe('string')
             expect(data.error.length).toBeGreaterThan(0)
-            // Negative value fails the minimum (>=1) check.
-            expect(data.error).toMatch(/>=|greater|at least|small/i)
+            // Negative values fail the digit-only regex boundary before the
+            // minimum (>=1) check runs.
+            expect(data.error).toMatch(/positive integer|digit|number/i)
         })
 
         it('should return 400 for limit exceeding maximum', async () => {

--- a/src/pages/api/leaderboard.test.ts
+++ b/src/pages/api/leaderboard.test.ts
@@ -414,7 +414,7 @@ describe('GET /api/leaderboard', () => {
                 ),
             } as never)
 
-            expect(response.status).toBe(500)
+            expect(response.status).toBe(503)
             expect(await response.json()).toEqual({
                 error: 'Scoped leaderboard is unavailable',
                 code: 'SCOPED_LEADERBOARD_UNAVAILABLE',

--- a/src/pages/api/leaderboard.test.ts
+++ b/src/pages/api/leaderboard.test.ts
@@ -1,11 +1,18 @@
 import { describe, it, expect, vi, beforeEach } from 'vitest'
 import { GET } from '@/pages/api/leaderboard'
-import { getGameLeaderboard } from '@/lib/server/db/queries'
+import {
+    getGameLeaderboard,
+    getScopedGameLeaderboard,
+} from '@/lib/server/db/queries'
 import { getAllGames, GameID } from '@/lib/games'
 
 // Mock dependencies
 vi.mock('@/lib/server/db/queries', () => ({
     getGameLeaderboard: vi.fn(),
+    getScopedGameLeaderboard: vi.fn(),
+    toPublicScopedLeaderboardEntry: vi.fn(
+        ({ userId: _userId, ...entry }) => entry
+    ),
 }))
 
 vi.mock('@/lib/games', () => ({
@@ -82,7 +89,7 @@ describe('GET /api/leaderboard', () => {
             expect(response.status).toBe(400)
 
             const data = await response.json()
-            expect(data).toHaveProperty('error', 'Invalid limit parameter')
+            expect(typeof data.error).toBe('string')
         })
 
         it('should return 400 for negative limit', async () => {
@@ -92,7 +99,7 @@ describe('GET /api/leaderboard', () => {
             expect(response.status).toBe(400)
 
             const data = await response.json()
-            expect(data).toHaveProperty('error', 'Invalid limit parameter')
+            expect(typeof data.error).toBe('string')
         })
 
         it('should return 400 for limit exceeding maximum', async () => {
@@ -102,7 +109,7 @@ describe('GET /api/leaderboard', () => {
             expect(response.status).toBe(400)
 
             const data = await response.json()
-            expect(data).toHaveProperty('error', 'Invalid limit parameter')
+            expect(typeof data.error).toBe('string')
         })
     })
 
@@ -256,6 +263,138 @@ describe('GET /api/leaderboard', () => {
             expect(typeof entry.name).toBe('string')
             expect(typeof entry.score).toBe('number')
             expect(typeof entry.created_at).toBe('string')
+        })
+    })
+
+    describe('scoped leaderboard', () => {
+        it('returns a mode-only scoped best-per-user leaderboard', async () => {
+            vi.mocked(getScopedGameLeaderboard).mockResolvedValue({
+                success: true,
+                rows: [
+                    {
+                        userId: 'u1',
+                        name: 'Player',
+                        username: 'player',
+                        image: null,
+                        score: 500,
+                        created_at: '2026-08-01T00:00:00.000Z',
+                        mode: 'daily',
+                        competitionKey: null,
+                        rulesetVersion: 2,
+                        elapsedSeconds: 12,
+                        totalMoves: 34,
+                    },
+                ],
+            })
+
+            const response = await GET({
+                url: new URL(
+                    'http://localhost/api/leaderboard?gameId=tetris&mode=daily'
+                ),
+            } as never)
+
+            expect(response.status).toBe(200)
+            expect(getScopedGameLeaderboard).toHaveBeenCalledWith({
+                gameId: 'tetris',
+                mode: 'daily',
+                competitionKey: undefined,
+                limit: 10,
+            })
+
+            const body = await response.json()
+            expect(body.leaderboard).toEqual([
+                {
+                    rank: 1,
+                    name: 'Player',
+                    username: 'player',
+                    image: null,
+                    score: 500,
+                    created_at: '2026-08-01T00:00:00.000Z',
+                    mode: 'daily',
+                    competitionKey: null,
+                    rulesetVersion: 2,
+                    elapsedSeconds: 12,
+                    totalMoves: 34,
+                },
+            ])
+            expect(body.leaderboard[0]).not.toHaveProperty('userId')
+        })
+
+        it('forwards an exact competition key', async () => {
+            vi.mocked(getScopedGameLeaderboard).mockResolvedValue({
+                success: true,
+                rows: [],
+            })
+
+            await GET({
+                url: new URL(
+                    'http://localhost/api/leaderboard' +
+                        '?gameId=tetris&mode=daily&competitionKey=daily%3A1'
+                ),
+            } as never)
+
+            expect(getScopedGameLeaderboard).toHaveBeenCalledWith({
+                gameId: 'tetris',
+                mode: 'daily',
+                competitionKey: 'daily:1',
+                limit: 10,
+            })
+        })
+
+        it.each([
+            'http://localhost/api/leaderboard?mode=daily',
+            'http://localhost/api/leaderboard?competitionKey=daily%3A1',
+            'http://localhost/api/leaderboard?gameId=tetris&competitionKey=daily%3A1',
+        ])('rejects invalid scoped parameter combinations: %s', async url => {
+            const response = await GET({ url: new URL(url) } as never)
+            expect(response.status).toBe(400)
+            expect(getScopedGameLeaderboard).not.toHaveBeenCalled()
+        })
+
+        it('returns a stable scoped-unavailable code', async () => {
+            vi.mocked(getScopedGameLeaderboard).mockResolvedValue({
+                success: false,
+                code: 'SCOPED_LEADERBOARD_UNAVAILABLE',
+            })
+
+            const response = await GET({
+                url: new URL(
+                    'http://localhost/api/leaderboard?gameId=tetris&mode=daily'
+                ),
+            } as never)
+
+            expect(response.status).toBe(500)
+            expect(await response.json()).toEqual({
+                error: 'Scoped leaderboard is unavailable',
+                code: 'SCOPED_LEADERBOARD_UNAVAILABLE',
+            })
+        })
+
+        it('keeps two unscoped rows from the same user as two response entries', async () => {
+            vi.mocked(getGameLeaderboard).mockResolvedValue([
+                {
+                    name: 'Same User',
+                    username: 'sameuser',
+                    score: 1000,
+                    created_at: '2023-01-01T00:00:00Z',
+                    image: null,
+                },
+                {
+                    name: 'Same User',
+                    username: 'sameuser',
+                    score: 900,
+                    created_at: '2023-01-02T00:00:00Z',
+                    image: null,
+                },
+            ])
+
+            const url = new URL(
+                'http://localhost/api/leaderboard?gameId=tetris'
+            )
+            const response = await GET({ url } as never)
+
+            const data = await response.json()
+            expect(data.leaderboard).toHaveLength(2)
         })
     })
 })

--- a/src/pages/api/leaderboard.test.ts
+++ b/src/pages/api/leaderboard.test.ts
@@ -14,6 +14,7 @@ vi.mock('@/lib/server/db/queries', () => ({
     toPublicScopedLeaderboardEntry: vi.fn(
         ({ userId: _userId, ...entry }: ScopedLeaderboardRow) => entry
     ),
+    isGameLeaderboardAvailable: (result: unknown) => Array.isArray(result),
 }))
 
 vi.mock('@/lib/games', () => ({
@@ -123,6 +124,24 @@ describe('GET /api/leaderboard', () => {
             // Over-maximum value fails the maximum (<=100) check.
             expect(data.error).toMatch(/<=|less|at most|big/i)
         })
+
+        it('should return a 503 coded error when any game leaderboard is unavailable', async () => {
+            vi.mocked(getGameLeaderboard).mockResolvedValue({
+                status: 'unavailable',
+                code: 'SCORE_CONTEXT_UNAVAILABLE',
+            })
+
+            const url = new URL('http://localhost/api/leaderboard')
+            const response = await GET({ url } as any)
+
+            expect(response.status).toBe(503)
+
+            const data = await response.json()
+            expect(data).toEqual({
+                error: 'Score context is unavailable',
+                code: 'SCORE_CONTEXT_UNAVAILABLE',
+            })
+        })
     })
 
     describe('with gameId parameter', () => {
@@ -211,6 +230,26 @@ describe('GET /api/leaderboard', () => {
 
             const data = await response.json()
             expect(data.leaderboard).toEqual([])
+        })
+
+        it('should return a 503 coded error when the score context is unavailable', async () => {
+            vi.mocked(getGameLeaderboard).mockResolvedValue({
+                status: 'unavailable',
+                code: 'SCORE_CONTEXT_UNAVAILABLE',
+            })
+
+            const url = new URL(
+                'http://localhost/api/leaderboard?gameId=tetris'
+            )
+            const response = await GET({ url } as any)
+
+            expect(response.status).toBe(503)
+
+            const data = await response.json()
+            expect(data).toEqual({
+                error: 'Score context is unavailable',
+                code: 'SCORE_CONTEXT_UNAVAILABLE',
+            })
         })
     })
 

--- a/src/pages/api/leaderboard.test.ts
+++ b/src/pages/api/leaderboard.test.ts
@@ -3,6 +3,7 @@ import { GET } from '@/pages/api/leaderboard'
 import {
     getGameLeaderboard,
     getScopedGameLeaderboard,
+    type ScopedLeaderboardRow,
 } from '@/lib/server/db/queries'
 import { getAllGames, GameID } from '@/lib/games'
 
@@ -11,7 +12,7 @@ vi.mock('@/lib/server/db/queries', () => ({
     getGameLeaderboard: vi.fn(),
     getScopedGameLeaderboard: vi.fn(),
     toPublicScopedLeaderboardEntry: vi.fn(
-        ({ userId: _userId, ...entry }) => entry
+        ({ userId: _userId, ...entry }: ScopedLeaderboardRow) => entry
     ),
 }))
 
@@ -90,6 +91,10 @@ describe('GET /api/leaderboard', () => {
 
             const data = await response.json()
             expect(typeof data.error).toBe('string')
+            expect(data.error.length).toBeGreaterThan(0)
+            // Non-numeric input fails the number-type check (NaN), distinct
+            // from the range checks below.
+            expect(data.error).toMatch(/NaN|expected number/i)
         })
 
         it('should return 400 for negative limit', async () => {
@@ -100,6 +105,9 @@ describe('GET /api/leaderboard', () => {
 
             const data = await response.json()
             expect(typeof data.error).toBe('string')
+            expect(data.error.length).toBeGreaterThan(0)
+            // Negative value fails the minimum (>=1) check.
+            expect(data.error).toMatch(/>=|greater|at least|small/i)
         })
 
         it('should return 400 for limit exceeding maximum', async () => {
@@ -110,6 +118,9 @@ describe('GET /api/leaderboard', () => {
 
             const data = await response.json()
             expect(typeof data.error).toBe('string')
+            expect(data.error.length).toBeGreaterThan(0)
+            // Over-maximum value fails the maximum (<=100) check.
+            expect(data.error).toMatch(/<=|less|at most|big/i)
         })
     })
 

--- a/src/pages/api/leaderboard.ts
+++ b/src/pages/api/leaderboard.ts
@@ -1,22 +1,26 @@
 import type { APIRoute } from 'astro'
-import { getGameLeaderboard } from '@/lib/server/db/queries'
+import {
+    getGameLeaderboard,
+    getScopedGameLeaderboard,
+    toPublicScopedLeaderboardEntry,
+} from '@/lib/server/db/queries'
 import { getAllGames } from '@/lib/games'
 import {
     jsonResponse,
     badRequestResponse,
+    codedErrorResponse,
     errorResponse,
 } from '@/lib/server/api-utils'
+import { leaderboardQuerySchema, validateQuery } from '@/lib/server/validations'
 
 export const GET: APIRoute = async ({ url }) => {
     try {
-        const gameId = url.searchParams.get('gameId')
-        const limitParam = url.searchParams.get('limit')
-        const limit = limitParam ? parseInt(limitParam, 10) : 10
-
-        // Validate limit parameter
-        if (isNaN(limit) || limit <= 0 || limit > 100) {
-            return badRequestResponse('Invalid limit parameter')
+        const parsed = validateQuery(url, leaderboardQuerySchema)
+        if (!parsed.success) {
+            return badRequestResponse(parsed.error)
         }
+
+        const { gameId, limit, mode, competitionKey } = parsed.data
 
         // If no gameId provided, return leaderboards for all games
         if (!gameId) {
@@ -51,6 +55,35 @@ export const GET: APIRoute = async ({ url }) => {
             return badRequestResponse('Invalid game ID')
         }
 
+        // Scoped branch: mode present → best-per-user via scoped query
+        if (mode) {
+            const scoped = await getScopedGameLeaderboard({
+                gameId,
+                mode,
+                competitionKey,
+                limit,
+            })
+
+            if (!scoped.success) {
+                return codedErrorResponse(
+                    'Scoped leaderboard is unavailable',
+                    'SCOPED_LEADERBOARD_UNAVAILABLE'
+                )
+            }
+
+            const leaderboard = scoped.rows.map((row, index) => ({
+                rank: index + 1,
+                ...toPublicScopedLeaderboardEntry(row),
+            }))
+
+            return jsonResponse({
+                gameId,
+                gameName: game.name,
+                leaderboard,
+            })
+        }
+
+        // Unscoped game-only branch
         const leaderboard = await getGameLeaderboard(gameId, limit)
         const leaderboardWithRanks = leaderboard.map((entry, index) => ({
             rank: index + 1,

--- a/src/pages/api/leaderboard.ts
+++ b/src/pages/api/leaderboard.ts
@@ -88,7 +88,8 @@ export const GET: APIRoute = async ({ url }) => {
             if (!scoped.success) {
                 return codedErrorResponse(
                     'Scoped leaderboard is unavailable',
-                    'SCOPED_LEADERBOARD_UNAVAILABLE'
+                    'SCOPED_LEADERBOARD_UNAVAILABLE',
+                    503
                 )
             }
 

--- a/src/pages/api/leaderboard.ts
+++ b/src/pages/api/leaderboard.ts
@@ -2,7 +2,9 @@ import type { APIRoute } from 'astro'
 import {
     getGameLeaderboard,
     getScopedGameLeaderboard,
+    isGameLeaderboardAvailable,
     toPublicScopedLeaderboardEntry,
+    type GameLeaderboardEntry,
 } from '@/lib/server/db/queries'
 import { getAllGames } from '@/lib/games'
 import {
@@ -38,11 +40,30 @@ export const GET: APIRoute = async ({ url }) => {
             const results = await Promise.all(
                 games.map(game => getGameLeaderboard(game.id, limit))
             )
+            // A failed score-context probe is a retryable unavailable state,
+            // distinct from a game genuinely having no scores (empty array).
+            // The probe is global, so any unavailable result means the whole
+            // batch is unavailable — surface a coded 503 instead of silently
+            // returning empty leaderboards for every game.
+            const unavailableResult = results.find(
+                r => !isGameLeaderboardAvailable(r)
+            )
+            if (unavailableResult) {
+                return codedErrorResponse(
+                    'Score context is unavailable',
+                    'SCORE_CONTEXT_UNAVAILABLE',
+                    503
+                )
+            }
+
+            const leaderboardResults = results as GameLeaderboardEntry[][]
             games.forEach((game, i) => {
-                leaderboards[game.id] = results[i].map((entry, index) => ({
-                    rank: index + 1,
-                    ...entry,
-                }))
+                leaderboards[game.id] = leaderboardResults[i].map(
+                    (entry, index) => ({
+                        rank: index + 1,
+                        ...entry,
+                    })
+                )
             })
 
             return jsonResponse({ leaderboards })
@@ -85,6 +106,18 @@ export const GET: APIRoute = async ({ url }) => {
 
         // Unscoped game-only branch
         const leaderboard = await getGameLeaderboard(gameId, limit)
+        // A failed score-context probe is a retryable unavailable state,
+        // distinct from the game genuinely having no scores (empty array).
+        // Surface it as a coded 503 instead of silently reporting an empty
+        // leaderboard, mirroring /api/scores/best and the scoped branch.
+        if (!isGameLeaderboardAvailable(leaderboard)) {
+            return codedErrorResponse(
+                'Score context is unavailable',
+                'SCORE_CONTEXT_UNAVAILABLE',
+                503
+            )
+        }
+
         const leaderboardWithRanks = leaderboard.map((entry, index) => ({
             rank: index + 1,
             ...entry,

--- a/src/pages/api/scores.test.ts
+++ b/src/pages/api/scores.test.ts
@@ -115,6 +115,7 @@ describe('POST /api/scores', () => {
             'user-123',
             'tetris',
             5000,
+            undefined,
             undefined
         )
     })
@@ -256,6 +257,7 @@ describe('POST /api/scores', () => {
         vi.mocked(saveGameScoreWithAchievements).mockResolvedValue({
             success: false,
             newAchievements: [],
+            code: 'SCORE_WRITE_FAILED',
         })
 
         const request = new Request('http://localhost:4321/api/scores', {
@@ -281,6 +283,7 @@ describe('POST /api/scores', () => {
             'user-123',
             'tetris',
             5000,
+            undefined,
             undefined
         )
     })
@@ -311,6 +314,34 @@ describe('POST /api/scores', () => {
         // Assert
         expect(response.status).toBe(500)
         expect(result).toEqual({ error: 'Internal server error' })
+    })
+
+    it('returns SCORE_CONTEXT_UNAVAILABLE when contextual storage is unavailable', async () => {
+        vi.mocked(auth.api.getSession).mockResolvedValue(mockSession as never)
+        const { getGameById } = await import('@/lib/games')
+        vi.mocked(getGameById).mockReturnValue(mockGame)
+        vi.mocked(saveGameScoreWithAchievements).mockResolvedValue({
+            success: false,
+            newAchievements: [],
+            code: 'SCORE_CONTEXT_UNAVAILABLE',
+        })
+
+        const request = new Request('http://localhost/api/scores', {
+            method: 'POST',
+            headers: { 'Content-Type': 'application/json' },
+            body: JSON.stringify({
+                gameId: 'tetris',
+                score: 100,
+                context: { mode: 'daily', rulesetVersion: 1 },
+            }),
+        })
+
+        const response = await POST({ request } as never)
+        expect(response.status).toBe(500)
+        expect(await response.json()).toEqual({
+            error: 'Score context is unavailable',
+            code: 'SCORE_CONTEXT_UNAVAILABLE',
+        })
     })
 
     it('should return 400 for malformed JSON', async () => {

--- a/src/pages/api/scores.test.ts
+++ b/src/pages/api/scores.test.ts
@@ -452,4 +452,93 @@ describe('POST /api/scores', () => {
         expect(response.status).toBe(200)
         expect(result.success).toBe(true)
     })
+
+    it('normalizes context and updates challenges after a successful contextual save', async () => {
+        vi.mocked(auth.api.getSession).mockResolvedValue(mockSession as never)
+        vi.mocked(getGameById).mockReturnValue(mockGame)
+        vi.mocked(saveGameScoreWithAchievements).mockResolvedValue({
+            success: true,
+            newAchievements: [],
+        })
+        vi.mocked(updateChallengeProgress).mockResolvedValue({
+            completedChallenges: [],
+            xpEarned: 0,
+            levelUp: false,
+        })
+
+        const request = new Request('http://localhost/api/scores', {
+            method: 'POST',
+            headers: { 'Content-Type': 'application/json' },
+            body: JSON.stringify({
+                gameId: 'tetris',
+                score: 500,
+                gameData: {
+                    elapsedSeconds: 12,
+                    totalMoves: 34,
+                },
+                context: {
+                    mode: 'daily',
+                    competitionKey: 'daily:route',
+                    rulesetVersion: 1,
+                },
+            }),
+        })
+
+        const response = await POST({ request } as never)
+        expect(response.status).toBe(200)
+
+        expect(saveGameScoreWithAchievements).toHaveBeenCalledWith(
+            'user-123',
+            'tetris',
+            500,
+            {
+                elapsedSeconds: 12,
+                totalMoves: 34,
+            },
+            {
+                mode: 'daily',
+                competitionKey: 'daily:route',
+                rulesetVersion: 1,
+                gameDataJson: '{"elapsedSeconds":12,"totalMoves":34}',
+            }
+        )
+        expect(updateChallengeProgress).toHaveBeenCalledWith(
+            'user-123',
+            'tetris',
+            500
+        )
+        expect(
+            vi.mocked(saveGameScoreWithAchievements).mock.invocationCallOrder[0]
+        ).toBeLessThan(
+            vi.mocked(updateChallengeProgress).mock.invocationCallOrder[0]
+        )
+    })
+
+    it('does not update challenges after contextual capability failure', async () => {
+        vi.mocked(auth.api.getSession).mockResolvedValue(mockSession as never)
+        vi.mocked(getGameById).mockReturnValue(mockGame)
+        vi.mocked(saveGameScoreWithAchievements).mockResolvedValue({
+            success: false,
+            newAchievements: [],
+            code: 'SCORE_CONTEXT_UNAVAILABLE',
+        })
+
+        const request = new Request('http://localhost/api/scores', {
+            method: 'POST',
+            headers: { 'Content-Type': 'application/json' },
+            body: JSON.stringify({
+                gameId: 'tetris',
+                score: 500,
+                context: {
+                    mode: 'daily',
+                    rulesetVersion: 1,
+                },
+            }),
+        })
+
+        const response = await POST({ request } as never)
+
+        expect(response.status).toBe(500)
+        expect(updateChallengeProgress).not.toHaveBeenCalled()
+    })
 })

--- a/src/pages/api/scores.ts
+++ b/src/pages/api/scores.ts
@@ -7,9 +7,11 @@ import { updateChallengeProgress } from '@/lib/services/challengeService'
 import {
     jsonResponse,
     errorResponse,
+    codedErrorResponse,
     unauthorizedResponse,
     badRequestResponse,
 } from '@/lib/server/api-utils'
+import type { PersistedScoreContext } from '@/lib/server/db/game-score-context'
 import { scoreSubmissionSchema, validateBody } from '@/lib/server/validations'
 
 const isGameId = (id: string): id is GameID =>
@@ -31,7 +33,7 @@ export const POST: APIRoute = async ({ request }) => {
             return badRequestResponse(validation.error)
         }
 
-        const { gameId, score, gameData } = validation.data
+        const { gameId, score, gameData, context } = validation.data
         if (!isGameId(gameId)) {
             return badRequestResponse('Invalid game ID')
         }
@@ -43,14 +45,31 @@ export const POST: APIRoute = async ({ request }) => {
             return badRequestResponse('Invalid game ID')
         }
 
+        const persistedContext: PersistedScoreContext | undefined = context
+            ? {
+                  mode: context.mode,
+                  competitionKey: context.competitionKey ?? null,
+                  rulesetVersion: context.rulesetVersion,
+                  gameDataJson:
+                      gameData === undefined ? null : JSON.stringify(gameData),
+              }
+            : undefined
+
         const result = await saveGameScoreWithAchievements(
             session.user.id,
             validatedGameId,
             score,
-            gameData
+            gameData,
+            persistedContext
         )
 
         if (!result.success) {
+            if (result.code === 'SCORE_CONTEXT_UNAVAILABLE') {
+                return codedErrorResponse(
+                    'Score context is unavailable',
+                    'SCORE_CONTEXT_UNAVAILABLE'
+                )
+            }
             return errorResponse('Failed to save score')
         }
 

--- a/src/pages/api/scores/best.test.ts
+++ b/src/pages/api/scores/best.test.ts
@@ -75,7 +75,10 @@ describe('GET /api/scores/best', () => {
         vi.mocked(auth.api.getSession).mockResolvedValue(mockSession as any)
         const { getGameById } = await import('@/lib/games')
         vi.mocked(getGameById).mockReturnValue(mockGame)
-        vi.mocked(getUserBestScore).mockResolvedValue(15000)
+        vi.mocked(getUserBestScore).mockResolvedValue({
+            status: 'ok',
+            bestScore: 15000,
+        })
 
         const url = new URL(
             'http://localhost:4321/api/scores/best?gameId=tetris'
@@ -98,7 +101,10 @@ describe('GET /api/scores/best', () => {
         vi.mocked(auth.api.getSession).mockResolvedValue(mockSession as any)
         const { getGameById } = await import('@/lib/games')
         vi.mocked(getGameById).mockReturnValue(mockGame)
-        vi.mocked(getUserBestScore).mockResolvedValue(null)
+        vi.mocked(getUserBestScore).mockResolvedValue({
+            status: 'ok',
+            bestScore: null,
+        })
 
         const url = new URL(
             'http://localhost:4321/api/scores/best?gameId=tetris'
@@ -113,6 +119,35 @@ describe('GET /api/scores/best', () => {
         expect(response.status).toBe(200)
         expect(result).toEqual({ bestScore: null })
         expect(getGameById).toHaveBeenCalledWith('tetris')
+        expect(getUserBestScore).toHaveBeenCalledWith('user-123', 'tetris')
+    })
+
+    it('should return a 503 coded error when the score context is unavailable', async () => {
+        // Arrange — a failed score-context probe is a retryable unavailable
+        // state, distinct from the user having no scores (ok/null).
+        vi.mocked(auth.api.getSession).mockResolvedValue(mockSession as any)
+        const { getGameById } = await import('@/lib/games')
+        vi.mocked(getGameById).mockReturnValue(mockGame)
+        vi.mocked(getUserBestScore).mockResolvedValue({
+            status: 'unavailable',
+            code: 'SCORE_CONTEXT_UNAVAILABLE',
+        })
+
+        const url = new URL(
+            'http://localhost:4321/api/scores/best?gameId=tetris'
+        )
+        const request = new Request(url)
+
+        // Act
+        const response = await GET({ request, url } as any)
+        const result = await response.json()
+
+        // Assert
+        expect(response.status).toBe(503)
+        expect(result).toEqual({
+            error: 'Score context is unavailable',
+            code: 'SCORE_CONTEXT_UNAVAILABLE',
+        })
         expect(getUserBestScore).toHaveBeenCalledWith('user-123', 'tetris')
     })
 
@@ -197,7 +232,10 @@ describe('GET /api/scores/best', () => {
         vi.mocked(auth.api.getSession).mockResolvedValue(mockSession as any)
         const { getGameById } = await import('@/lib/games')
         vi.mocked(getGameById).mockReturnValue(mockGame)
-        vi.mocked(getUserBestScore).mockResolvedValue(8000)
+        vi.mocked(getUserBestScore).mockResolvedValue({
+            status: 'ok',
+            bestScore: 8000,
+        })
 
         const url = new URL(
             'http://localhost:4321/api/scores/best?gameId=quick_math'
@@ -314,7 +352,10 @@ describe('GET /api/scores/best', () => {
                 ...mockGame,
                 id: gameIds[i] as GameID,
             })
-            vi.mocked(getUserBestScore).mockResolvedValue(expectedScores[i])
+            vi.mocked(getUserBestScore).mockResolvedValue({
+                status: 'ok',
+                bestScore: expectedScores[i],
+            })
 
             const url = new URL(
                 `http://localhost:4321/api/scores/best?gameId=${gameIds[i]}`
@@ -341,7 +382,10 @@ describe('GET /api/scores/best', () => {
         vi.mocked(auth.api.getSession).mockResolvedValue(mockSession as any)
         const { getGameById } = await import('@/lib/games')
         vi.mocked(getGameById).mockReturnValue(mockGame)
-        vi.mocked(getUserBestScore).mockResolvedValue(0)
+        vi.mocked(getUserBestScore).mockResolvedValue({
+            status: 'ok',
+            bestScore: 0,
+        })
 
         const url = new URL(
             'http://localhost:4321/api/scores/best?gameId=tetris'

--- a/src/pages/api/scores/best.ts
+++ b/src/pages/api/scores/best.ts
@@ -6,6 +6,7 @@ import {
     jsonResponse,
     unauthorizedResponse,
     badRequestResponse,
+    codedErrorResponse,
     errorResponse,
 } from '@/lib/server/api-utils'
 
@@ -38,9 +39,20 @@ export const GET: APIRoute = async ({ request, url }) => {
             return badRequestResponse('Invalid game ID')
         }
 
-        const bestScore = await getUserBestScore(session.user.id, gameId)
+        const result = await getUserBestScore(session.user.id, gameId)
 
-        return jsonResponse({ bestScore })
+        // A failed score-context probe is a retryable unavailable state,
+        // distinct from the user simply having no scores (ok/null). Surface it
+        // as a coded 503 instead of silently reporting null.
+        if (result.status === 'unavailable') {
+            return codedErrorResponse(
+                'Score context is unavailable',
+                'SCORE_CONTEXT_UNAVAILABLE',
+                503
+            )
+        }
+
+        return jsonResponse({ bestScore: result.bestScore })
     } catch (_error) {
         return errorResponse('Internal server error')
     }

--- a/src/pages/api/scores/history.test.ts
+++ b/src/pages/api/scores/history.test.ts
@@ -268,4 +268,31 @@ describe('GET /api/scores/history', () => {
             )
         }
     })
+
+    it('exposes only the four public history DTO keys even if context columns leaked from the DB layer', async () => {
+        vi.mocked(auth.api.getSession).mockResolvedValue(mockSession as any)
+        vi.mocked(getUserGameHistory).mockResolvedValue([
+            {
+                game_id: 'tetris',
+                game_name: 'Tetris Challenge',
+                score: 100,
+                created_at: '2026-08-01T00:00:00.000Z',
+            },
+        ])
+
+        const url = new URL('http://localhost:4321/api/scores/history')
+        const request = new Request(url)
+
+        const response = await GET({ request, url } as any)
+        const result = await response.json()
+
+        expect(response.status).toBe(200)
+        expect(result.history).toHaveLength(1)
+        expect(Object.keys(result.history[0]).sort()).toEqual([
+            'created_at',
+            'game_id',
+            'game_name',
+            'score',
+        ])
+    })
 })

--- a/src/pages/api/scores/history.test.ts
+++ b/src/pages/api/scores/history.test.ts
@@ -269,30 +269,11 @@ describe('GET /api/scores/history', () => {
         }
     })
 
-    it('exposes only the four public history DTO keys even if context columns leaked from the DB layer', async () => {
-        vi.mocked(auth.api.getSession).mockResolvedValue(mockSession as any)
-        vi.mocked(getUserGameHistory).mockResolvedValue([
-            {
-                game_id: 'tetris',
-                game_name: 'Tetris Challenge',
-                score: 100,
-                created_at: '2026-08-01T00:00:00.000Z',
-            },
-        ])
-
-        const url = new URL('http://localhost:4321/api/scores/history')
-        const request = new Request(url)
-
-        const response = await GET({ request, url } as any)
-        const result = await response.json()
-
-        expect(response.status).toBe(200)
-        expect(result.history).toHaveLength(1)
-        expect(Object.keys(result.history[0]).sort()).toEqual([
-            'created_at',
-            'game_id',
-            'game_name',
-            'score',
-        ])
-    })
+    // Note: regression coverage for "getUserGameHistory omits context columns"
+    // lives in src/lib/server/db/queries.integration.test.ts ("omits context
+    // columns from the real getUserGameHistory query"), which exercises the
+    // real allowlisted select against a row seeded with mode/competitionKey/
+    // rulesetVersion/gameDataJson. The GET /api/scores/history route is a
+    // pure pass-through of that query's result, so a route-level leak test
+    // would only re-mock the same allowlist without testing real behavior.
 })

--- a/src/pages/leaderboard/index.astro
+++ b/src/pages/leaderboard/index.astro
@@ -29,7 +29,13 @@ const gameLeaderboards: Record<string, LeaderboardEntry[]> = {}
 
 // Fetch leaderboard data for each game
 for (const game of games) {
-  gameLeaderboards[game.id] = await getGameLeaderboard(game.id, 10)
+  const result = await getGameLeaderboard(game.id, 10)
+  // A failed score-context probe returns a discriminated `unavailable` result
+  // (distinct from "no scores"). The server-rendered page degrades to the
+  // existing empty state rather than failing the whole render; the
+  // `/api/leaderboard` endpoint surfaces the coded 503 for programmatic
+  // callers.
+  gameLeaderboards[game.id] = Array.isArray(result) ? result : []
 }
 
 // Game icons mapping

--- a/src/pages/leaderboard/index.astro
+++ b/src/pages/leaderboard/index.astro
@@ -11,7 +11,10 @@ import Avatar from '@/components/ui/Avatar.astro'
 
 // Server-side data fetching
 import { getAllGames } from '@/lib/games'
-import { getGameLeaderboard } from '@/lib/server/db/queries'
+import {
+  getGameLeaderboard,
+  isGameLeaderboardAvailable,
+} from '@/lib/server/db/queries'
 
 // Define types
 type LeaderboardEntry = {
@@ -35,7 +38,7 @@ for (const game of games) {
   // existing empty state rather than failing the whole render; the
   // `/api/leaderboard` endpoint surfaces the coded 503 for programmatic
   // callers.
-  gameLeaderboards[game.id] = Array.isArray(result) ? result : []
+  gameLeaderboards[game.id] = isGameLeaderboardAvailable(result) ? result : []
 }
 
 // Game icons mapping


### PR DESCRIPTION
## Summary

Implements **HPA-484: Versioned Score Context and Scoped Leaderboards** — backward-compatible, versioned score persistence and deterministic scoped leaderboards, with no change to existing Campaign score, history, achievement-awarding, aggregate-stat, or daily-challenge behavior.

- Design: `docs/superpowers/specs/2026-07-31-versioned-score-context-design.md`
- Plan: `docs/superpowers/plans/2026-07-31-versioned-score-context-and-scoped-leaderboards.md`
- Tracking: Linear **HPA-484** (parent roadmap HPA-483)
- Design PR (closed unmerged, plan moved into implementation): #50

## What this adds

- **Persistent schema** — nullable `mode`, `competition_key`, `ruleset_version`, `game_data_json` columns on `game_scores` + scoped-ranking index `(game_id, mode, competition_key, score DESC, created_at ASC)` in both bootstrap SQL files.
- **Runtime capability guard** — cached, single-flight, additive `ALTER TABLE` migration with bounded exponential index-retry backoff (1 min → 1 hr). Unknown state always fails closed.
- **Strict contextual validation** — omit-only `context` (null rejected), anchored `mode`/`competitionKey` patterns, integer `rulesetVersion`, 16 KiB UTF-8 limit on contextual `gameData`, non-negative-integer `elapsedSeconds`/`totalMoves`.
- **Discriminated write-failure propagation** — one write path; `SCORE_CONTEXT_UNAVAILABLE` flows queries → route (HTTP 500) → client; generic failures stay `SCORE_WRITE_FAILED`.
- **Unscoped-read isolation** — existing Campaign leaderboard + personal-best + achievement-PROGRESS add `mode IS NULL AND competition_key IS NULL` when columns are confirmed, so scoped rows never pollute Campaign rankings.
- **Scoped best-per-user leaderboard** — staged-CTE query (filter → normalize JSON → partition by user → rank) with V1 tie-breaks (`elapsedSeconds`, `totalMoves`, `created_at`, `id`), malformed-value normalization to NULL, limit after partitioning, and a public DTO that strips internal `userId`.
- **Validated scoped API** — unified `leaderboardQuerySchema` (all-games / game-only / mode-only / exact-key); `GET /api/leaderboard?gameId=&mode=[&competitionKey=]` returns coded `SCOPED_LEADERBOARD_UNAVAILABLE` on failure.

Scoped writes still update total score, game-count/favorite-game, history/activity, current daily challenges, and run score-threshold + in-game achievement awarding against the submitted score — only Campaign leaderboards, personal bests, and best-score-derived progress stay unscoped.

## Task-by-task commits

| # | Commit | Task |
|---|--------|------|
| 1 | `1851287` | Add versioned score context schema |
| 2 | `5e63e7a` | Add score-context capability guard |
| 3 | `fb5e4ce` | Validate and forward score context |
| 4 | `fb33fc8` | Propagate contextual write failures |
| 5 | `53e8717` | Isolate unscoped leaderboard and best scores |
| 6 | `5b7a83c` | Add scoped best-per-user leaderboard query |
| 7 | `159fa0d` | Expose validated scoped leaderboards |
| 8 | `9600b82` | Lock scoped compatibility boundaries (tests) |

## Verification

All gates run on the final tree (`9600b82`):

| Command | Result |
|---------|--------|
| `bun run test:run` | ✅ exit 0 — **2564 passed / 131 files** |
| `bun run lint` | ✅ exit 0 |
| `bun run typecheck` | ⚠️ exit 1 — **3 pre-existing `ice-slide/*` errors only** (`game.crystal-farm.test.ts:3`, `init.test.ts:36`, `init.ts:178`); none in this branch's diff |
| `bun run format:check` | ✅ exit 0 |
| `bun run build` | ✅ exit 0 |

The typecheck errors are present on `main` and unrelated to this plan (the branch touches zero `ice-slide/*` files). Full verification commands are in the plan's Task 9.

## Out of scope

Per the plan and design, **HPA-487 / HPA-488** own the remaining Ice Slide work: daily-challenge generation, semantic admission of contextual scores, current-user highlighting, and any UI for scoped leaderboards. This PR adds the backend contracts and queries only — no Ice Slide runtime, no semantic admission policy, no UI, no anti-cheat, no second mode-only index.

## Notes for reviewers

- Each task was reviewed individually (spec compliance + code quality) before the final whole-branch review; the final review returned **Ready to merge: Yes** (no Critical/Important findings).
- Two deliberate, brief-mandated deviations from verbatim plan text were taken and documented in the per-task reports (e.g. the repo's `curly` ESLint rule forced braced `if`/`throw`; one brief-test expected value was corrected to match real `getUserStats`/`saveGameScore` semantics).
- One parked (deferred) minor: `getUserRecentScores` still uses `.selectAll()` on the widened table — no route calls it today, so no active leak; narrowing it changes the return type and is left for a follow-up if a route needs recent scores.

---

Draft while review is in progress. Linear HPA-484 will be updated with this PR link.


<!-- This is an auto-generated comment: release notes by coderabbit.ai -->
## Summary by CodeRabbit

* **New Features**
  * Added mode- and competition-specific leaderboards with best-per-player rankings and consistent tie-breaking.
  * Score submissions can include optional mode, competition, ruleset, and game-data context.
  * Added validation for score context and leaderboard filters.

* **Bug Fixes**
  * Prevented scoped scores from affecting default leaderboards and personal-best results.
  * Preserved legacy score, history, activity, and achievement behavior.

* **Reliability**
  * Added clear error responses when score storage or leaderboard data is temporarily unavailable.
<!-- end of auto-generated comment: release notes by coderabbit.ai -->