### PR TITLE
feat(ice-slide): deterministic run definitions, seeded RNG, and Campaign materialization (HPA-485)

### DIFF
--- a/docs/superpowers/plans/2026-08-02-deterministic-ice-slide-runs.md
+++ b/docs/superpowers/plans/2026-08-02-deterministic-ice-slide-runs.md
@@ -28,7 +28,7 @@
 - `shuffle()` uses descending Fisher–Yates with one `nextInt(index + 1)` draw per iteration.
 - Board transforms support rectangular inputs; quarter turns and diagonal reflections swap dimensions.
 - Canonical board equality uses the complete serialized rows, never a compact hash alone.
-- Stage signature format is `is1-<8 lowercase hex digits>` and uses the exact preimage from the design.
+- Stage signature format is `is2-<8 lowercase hex digits>` and uses the exact preimage from the design.
 - Structural run validation is not solver validation; HPA-486 owns solvability and quality checks.
 - HPA-485 initializes and preserves `starsEarned`, `falls`, and `resets` as zero; HPA-487 owns their runtime semantics.
 - Current Campaign game data remains transient because unscoped score submissions do not persist `gameDataJson`.
@@ -422,12 +422,14 @@ it('never calls Math.random', () => {
 
     const rng = createSeededRng('ice-slide:test')
     rng.nextUint32()
-    rng.nextFloat()
+    const float = rng.nextFloat()
     rng.nextInt(7)
     rng.pick(['A', 'B'])
     rng.shuffle(['A', 'B', 'C'])
     rng.fork('stage').nextUint32()
 
+    expect(float).toBeGreaterThanOrEqual(0)
+    expect(float).toBeLessThan(1)
     expect(randomSpy).not.toHaveBeenCalled()
 })
 ```
@@ -636,6 +638,8 @@ export function transformPosition(
     if (
         !Number.isInteger(inputRows) ||
         !Number.isInteger(inputCols) ||
+        !Number.isInteger(position.row) ||
+        !Number.isInteger(position.col) ||
         inputRows < 1 ||
         inputCols < 1 ||
         position.row < 0 ||
@@ -857,6 +861,26 @@ it('retains all variants for an asymmetric rectangle', () => {
         new Set(variants.map(variant => variant.canonicalKey)).size
     ).toBe(8)
 })
+
+it('deduplicates to exactly two variants for a 180-symmetric board', () => {
+    const variants = getUniqueBoardTransforms(['AB', 'BA'])
+    expect(variants).toHaveLength(2)
+    expect(variants.map(variant => variant.transform)).toEqual([
+        'identity',
+        'rotate_90',
+    ])
+})
+
+it('deduplicates to exactly four variants for a horizontally symmetric board', () => {
+    const variants = getUniqueBoardTransforms(['AABB', 'BBAA'])
+    expect(variants).toHaveLength(4)
+    expect(variants.map(variant => variant.transform)).toEqual([
+        'identity',
+        'rotate_90',
+        'reflect_horizontal',
+        'reflect_main_diagonal',
+    ])
+})
 ```
 
 - [ ] **Step 11: Implement unique transform generation**
@@ -902,7 +926,10 @@ bunx vitest run src/lib/games/ice-slide/transforms.test.ts
 bun run typecheck
 ```
 
-Expected: both commands succeed.
+Expected: the vitest command succeeds. `bun run typecheck` exits with the
+documented two-error baseline (`init.test.ts:36` ts 2556, `init.ts:178` ts 2358)
+and no errors in `transforms.ts`/`transforms.test.ts`; record the baseline
+diagnostics and confirm no new errors are introduced.
 
 - [ ] **Step 13: Commit transforms and additive types**
 
@@ -942,6 +969,9 @@ export const CAMPAIGN_RUN_KEY: string
 export function createIceSlideStageSignature(input: {
     rows: readonly string[]
     parMoves: number
+    transform: BoardTransform
+    mutationIds: readonly string[]
+    difficulty: IceSlideDifficulty
     objectiveIds: readonly IceSlideObjectiveId[]
     scoreMultiplierBps: number
 }): string
@@ -1035,10 +1065,13 @@ describe('Ice Slide run versions and signatures', () => {
             createIceSlideStageSignature({
                 rows: ICE_SLIDE_LEVELS[0].rows,
                 parMoves: 1,
+                transform: 'identity',
+                mutationIds: [],
+                difficulty: 'tutorial',
                 objectiveIds: [],
                 scoreMultiplierBps: 10000,
             })
-        ).toBe('is1-a387e186')
+        ).toBe('is2-68616e2d')
     })
 })
 ```
@@ -1075,19 +1108,26 @@ export const CAMPAIGN_RUN_KEY =
 export function createIceSlideStageSignature(input: {
     rows: readonly string[]
     parMoves: number
+    transform: BoardTransform
+    mutationIds: readonly string[]
+    difficulty: IceSlideDifficulty
     objectiveIds: readonly IceSlideObjectiveId[]
     scoreMultiplierBps: number
 }): string {
+    const sortedMutationIds = [...input.mutationIds].sort()
     const sortedObjectiveIds = [...input.objectiveIds].sort()
     const payload = [
-        'ice-slide-stage:v1',
+        'ice-slide-stage:v2',
         `rows=${serializeBoardRows(input.rows)}`,
         `parMoves=${input.parMoves}`,
+        `transform=${input.transform}`,
+        `mutationIds=${sortedMutationIds.join(',')}`,
+        `difficulty=${input.difficulty}`,
         `objectiveIds=${sortedObjectiveIds.join(',')}`,
         `scoreMultiplierBps=${input.scoreMultiplierBps}`,
     ].join('\u001d')
 
-    return `is1-${hashString32Hex(payload)}`
+    return `is2-${hashString32Hex(payload)}`
 }
 ```
 
@@ -1124,7 +1164,7 @@ describe('Campaign run materialization', () => {
             expect(stage.mutationIds).toEqual([])
             expect(stage.objectiveIds).toEqual([])
             expect(stage.scoreMultiplierBps).toBe(10000)
-            expect(stage.signature).toMatch(/^is1-[0-9a-f]{8}$/)
+            expect(stage.signature).toMatch(/^is2-[0-9a-f]{8}$/)
         }
     })
 
@@ -1299,6 +1339,12 @@ const DAILY_KEY_PATTERN =
 const EXPEDITION_KEY_PATTERN =
     /^ice-slide:expedition:([0-9a-f]{8}):g([1-9]\d*):r([1-9]\d*)$/
 
+// DAILY_KEY_PATTERN is lexical only. After it matches, parse the captured
+// YYYY-MM-DD segment and reject impossible calendar dates (e.g. 2026-02-30,
+// 2026-13-01) by round-tripping through `new Date(Date.UTC(year, month-1, day))`
+// and requiring the UTC year/month/day to equal the parsed integers. Throw a
+// RangeError before comparing generator/ruleset versions.
+
 const MODES = new Set<IceSlideMode>([
     'campaign',
     'daily',
@@ -1354,7 +1400,7 @@ function assertUniqueNonEmpty(
 5. stage IDs and field enums;
 6. rectangular rows and `GLYPH_TO_CELL` keys;
 7. positive `parMoves`;
-8. `scoreMultiplierBps` in `1000..50000`;
+8. `scoreMultiplierBps` is an integer in `1000..50000` (reject fractional values such as `10000.5`);
 9. unique mutation/objective IDs and recognized objectives;
 10. exact signature recomputation.
 
@@ -1463,7 +1509,10 @@ bunx vitest run \
 bun run typecheck
 ```
 
-Expected: all tests pass and TypeScript accepts the additive interfaces.
+Expected: all tests pass. `bun run typecheck` exits with the documented two-error
+baseline (`init.test.ts:36` ts 2556, `init.ts:178` ts 2358) and no errors in
+`run.ts`/`run.test.ts`/`test-fixtures.ts`; record the baseline diagnostics and confirm
+no new errors are introduced.
 
 - [ ] **Step 13: Commit run materialization**
 
@@ -1796,7 +1845,7 @@ Do not apply `scoreMultiplierBps`.
 Before replacing `this.state` in `loadLevel()`, preserve:
 
 ```ts
-const cumulative = {
+const preserved = {
     moves: this.state.moves,
     crystalsCollected: this.state.crystalsCollected,
     score: this.state.score,
@@ -1961,7 +2010,12 @@ bun run format:check
 
 Expected:
 - Vitest exits with zero failed tests.
-- Astro typecheck exits successfully.
+- Astro typecheck exits with exactly the documented two-error baseline (see
+  `docs/superpowers/specs/2026-08-02-deterministic-ice-slide-runs-design.md` §14.6):
+  `src/lib/games/ice-slide/init.test.ts:36` (ts 2556) and
+  `src/lib/games/ice-slide/init.ts:178` (ts 2358). Record the error count before and
+  after this branch; the delta must be zero. Do not fix those two baseline errors
+  here — they are out of scope.
 - ESLint exits with no errors.
 - Prettier check reports all files formatted.
 
@@ -1982,7 +2036,11 @@ git diff origin/main...HEAD -- \
 ```
 
 Expected:
-- the first command lists only files from the plan’s New/Modified sections;
+- the first command lists only files from the plan’s New/Modified sections, plus the
+  two documentation files under review
+  (`docs/superpowers/plans/2026-08-02-deterministic-ice-slide-runs.md` and
+  `docs/superpowers/specs/2026-08-02-deterministic-ice-slide-runs-design.md`), which
+  this branch is permitted to modify;
 - the second command prints no diff.
 
 Also run:
@@ -2028,7 +2086,7 @@ Before marking HPA-485 implementation complete, verify each design requirement a
 - [ ] All eight transforms match the rectangular fixture and coordinate table.
 - [ ] Canonical serialization rejects empty, zero-column, and jagged rows.
 - [ ] Symmetry dedup uses complete canonical keys.
-- [ ] First Frost signature is `is1-a387e186`.
+- [ ] First Frost signature is `is2-68616e2d`.
 - [ ] Campaign run key is derived from Campaign-specific generator and ruleset versions.
 - [ ] Run validation enforces transport-safe mode-specific key/seed/version relationships.
 - [ ] Run validation limits stages to `1..64` and multiplier BPS to `1000..50000`.
@@ -2041,7 +2099,9 @@ Before marking HPA-485 implementation complete, verify each design requirement a
 - [ ] Existing achievement fields remain present.
 - [ ] HPA-487 follow-up gates are documented but not implemented here.
 - [ ] `init.ts`, renderer implementation, scoring, levels, platform challenges, achievements, and shared type re-export remain untouched.
-- [ ] Full tests, typecheck, lint, and formatting checks pass.
+- [ ] Full tests pass; `bun run typecheck` exits with exactly the documented two-error
+      baseline (`init.test.ts:36` ts 2556, `init.ts:178` ts 2358) and zero new errors;
+      lint and formatting checks pass.
 
 ## Execution Handoff
 

--- a/docs/superpowers/plans/2026-08-02-deterministic-ice-slide-runs.md
+++ b/docs/superpowers/plans/2026-08-02-deterministic-ice-slide-runs.md
@@ -1,0 +1,2051 @@
+# Deterministic Ice Slide Runs Implementation Plan
+
+> **For agentic workers:** REQUIRED SUB-SKILL: Use `superpowers:subagent-driven-development` (recommended) or `superpowers:executing-plans` to implement this plan task-by-task. Steps use checkbox (`- [ ]`) syntax for tracking.
+
+**Goal:** Add deterministic RNG and board-transform foundations, materialize the fixed Ice Slide Campaign as a versioned run, and refactor `IceSlideGame` to consume explicit run definitions without changing current Campaign behavior.
+
+**Architecture:** Deterministic randomness lives in a dependency-free shared module. Ice Slide transforms, canonicalization, signatures, run validation, and Campaign materialization remain pure and separate from gameplay. `IceSlideGame` owns a defensive active-run snapshot and uses final stage rows only; `init.ts` continues to call the no-argument Campaign path.
+
+**Tech Stack:** TypeScript 6, Vitest 3, Astro 5, Bun 1.3.1, PixiJS 8.
+
+## Global Constraints
+
+- Follow the approved design in `docs/superpowers/specs/2026-08-02-deterministic-ice-slide-runs-design.md`.
+- Keep this implementation as four logical commits in the order defined by the tasks below.
+- `IceSlideGame.start()` with no argument must preserve the current eight-stage Campaign.
+- Do not modify `src/lib/challenges.ts`; the platform Daily Challenge rotation must remain byte-for-byte behavior-compatible.
+- Do not modify `src/lib/games/ice-slide/levels.ts`, `scoring.ts`, `init.ts`, or `renderer.ts`.
+- Do not modify `src/lib/games/shared/types.ts` or `src/lib/achievements.ts`; HPA-487 owns generated-run error-boundary and achievement-mode gates.
+- Do not add production dependencies.
+- RNG, transforms, signatures, run validation, and Campaign materialization must have no DOM, Pixi, database, network, storage, or current-date dependency.
+- No new generator code may call `Math.random()`.
+- `ICE_SLIDE_RUN_SCHEMA_VERSION` is `1`.
+- Use a Campaign-specific generator constant: `ICE_SLIDE_CAMPAIGN_GENERATOR_VERSION = 1`.
+- `ICE_SLIDE_RULESET_VERSION` is `1`.
+- `CAMPAIGN_RUN_KEY` is derived from those constants and initially equals `ice-slide:campaign:g1:r1`.
+- Public RNG seed keys and fork labels reject the reserved U+001F separator.
+- `nextInt()` accepts integer bounds from `1` through `2^31 - 1` and must not bitwise-coerce its rejection limit.
+- `shuffle()` uses descending Fisher–Yates with one `nextInt(index + 1)` draw per iteration.
+- Board transforms support rectangular inputs; quarter turns and diagonal reflections swap dimensions.
+- Canonical board equality uses the complete serialized rows, never a compact hash alone.
+- Stage signature format is `is1-<8 lowercase hex digits>` and uses the exact preimage from the design.
+- Structural run validation is not solver validation; HPA-486 owns solvability and quality checks.
+- HPA-485 initializes and preserves `starsEarned`, `falls`, and `resets` as zero; HPA-487 owns their runtime semantics.
+- Current Campaign game data remains transient because unscoped score submissions do not persist `gameDataJson`.
+- Historical contextual game-data readers must tolerate the new fields being absent.
+- Every task follows red-green TDD and ends with a focused commit.
+
+---
+
+## File Map
+
+### Create
+
+- `src/lib/games/shared/seeded-rng.ts` — stable FNV-1a hashing, Mulberry32 stream, bounded selection, pick, shuffle, and labeled forks.
+- `src/lib/games/shared/seeded-rng.test.ts` — locked vectors and public-contract tests.
+- `src/lib/games/ice-slide/transforms.ts` — eight transforms, coordinate transforms, canonical serialization/hash, and symmetry deduplication.
+- `src/lib/games/ice-slide/transforms.test.ts` — rectangular geometry, inverse, serialization, and dedup tests.
+- `src/lib/games/ice-slide/run.ts` — versions, run-key rules, signatures, structural validation/cloning, and Campaign materialization.
+- `src/lib/games/ice-slide/run.test.ts` — Campaign compatibility, golden signatures, run-key relationships, validation, and cloning.
+- `src/lib/games/ice-slide/test-fixtures.ts` — test-only explicit run/stage builders.
+
+### Modify
+
+- `src/lib/games/ice-slide/types.ts` — additive mode/run/stage/objective/transform/state/game-data contracts.
+- `src/lib/games/ice-slide/physics.ts` — parse a minimal grid-source shape with string or numeric IDs.
+- `src/lib/games/ice-slide/physics.test.ts` — stage-shaped parse coverage while preserving existing parser/solver assertions.
+- `src/lib/games/ice-slide/game.ts` — active materialized run, default Campaign adapter, defensive start, metadata-preserving stage loading.
+- `src/lib/games/ice-slide/game.test.ts` — default/explicit starts, idle metadata, mutation isolation, and invalid-run behavior.
+- `src/lib/games/ice-slide/game.win.test.ts` — remove `./levels` mock; use explicit one-stage run.
+- `src/lib/games/ice-slide/game.hazard.test.ts` — remove `./levels` mock; use explicit hazard run.
+- `src/lib/games/ice-slide/game.crystal-farm.test.ts` — remove `./levels` mock; use explicit crystal fixture.
+- `src/lib/games/ice-slide/game.crystal-hazard-farm.test.ts` — remove `./levels` mock; use explicit fixture.
+- `src/lib/games/ice-slide/renderer.test.ts` — add required Campaign metadata to the typed `makeState()` fixture.
+
+### Explicitly Unchanged
+
+- `src/lib/challenges.ts`
+- `src/lib/games/ice-slide/levels.ts`
+- `src/lib/games/ice-slide/scoring.ts`
+- `src/lib/games/ice-slide/init.ts`
+- `src/lib/games/ice-slide/renderer.ts`
+- `src/lib/games/shared/types.ts`
+- `src/lib/achievements.ts`
+- database, API, score-context, and score-submission modules
+
+---
+
+### Task 1: Add the deterministic shared RNG
+
+**Files:**
+- Create: `src/lib/games/shared/seeded-rng.ts`
+- Create: `src/lib/games/shared/seeded-rng.test.ts`
+
+**Interfaces:**
+- Consumes: no project modules.
+- Produces:
+
+```ts
+export interface SeededRng {
+    nextUint32(): number
+    nextFloat(): number
+    nextInt(maxExclusive: number): number
+    pick<T>(items: readonly T[]): T
+    shuffle<T>(items: readonly T[]): T[]
+    fork(label: string): SeededRng
+}
+
+export function hashString32(value: string): number
+export function hashString32Hex(value: string): string
+export function createSeededRng(seedKey: string): SeededRng
+```
+
+- [ ] **Step 1: Write the hash and Mulberry32 golden-vector tests**
+
+Create `src/lib/games/shared/seeded-rng.test.ts` with these first tests:
+
+```ts
+import { describe, expect, it } from 'vitest'
+import {
+    createSeededRng,
+    hashString32,
+    hashString32Hex,
+} from './seeded-rng'
+
+describe('seeded RNG hashing and stream', () => {
+    it('locks the FNV-1a seed hash', () => {
+        expect(hashString32('ice-slide:test')).toBe(2769670846)
+        expect(hashString32Hex('ice-slide:test')).toBe('a515d2be')
+    })
+
+    it('maps the seed hash directly into the Mulberry32 state', () => {
+        const rng = createSeededRng('ice-slide:test')
+        expect([
+            rng.nextUint32(),
+            rng.nextUint32(),
+            rng.nextUint32(),
+            rng.nextUint32(),
+            rng.nextUint32(),
+        ]).toEqual([
+            1843037723,
+            574486829,
+            1018436590,
+            1120027984,
+            770965377,
+        ])
+    })
+})
+```
+
+- [ ] **Step 2: Run the focused test and confirm module resolution fails**
+
+Run:
+
+```bash
+bunx vitest run src/lib/games/shared/seeded-rng.test.ts
+```
+
+Expected: FAIL because `./seeded-rng` does not exist.
+
+- [ ] **Step 3: Implement FNV-1a and the exact Mulberry32 stream**
+
+Create `src/lib/games/shared/seeded-rng.ts` with these foundations:
+
+```ts
+const FORK_SEPARATOR = '\u001f'
+const UINT32_RANGE = 0x1_0000_0000
+const MAX_INT_BOUND = 0x7fffffff
+
+export function hashString32(value: string): number {
+    let hash = 0x811c9dc5
+    for (let index = 0; index < value.length; index++) {
+        hash ^= value.charCodeAt(index)
+        hash = Math.imul(hash, 0x01000193)
+    }
+    return hash >>> 0
+}
+
+export function hashString32Hex(value: string): string {
+    return hashString32(value).toString(16).padStart(8, '0')
+}
+
+function assertSeedSegment(value: string, field: string): void {
+    if (value.length === 0 || value.includes(FORK_SEPARATOR)) {
+        throw new RangeError(
+            `${field} must be non-empty and must not contain U+001F`
+        )
+    }
+}
+
+function createSeededRngFromPath(seedPath: string): SeededRng {
+    let state = hashString32(seedPath)
+
+    const nextUint32 = (): number => {
+        state = (state + 0x6d2b79f5) >>> 0
+        let value = state
+        value = Math.imul(value ^ (value >>> 15), value | 1)
+        value ^=
+            value + Math.imul(value ^ (value >>> 7), value | 61)
+        return (value ^ (value >>> 14)) >>> 0
+    }
+
+    // Remaining methods are added in the next steps.
+    throw new Error('SeededRng methods not implemented')
+}
+
+export function createSeededRng(seedKey: string): SeededRng {
+    assertSeedSegment(seedKey, 'seedKey')
+    return createSeededRngFromPath(seedKey)
+}
+```
+
+Replace the temporary throw while completing Steps 5–9; do not commit an intermediate broken implementation.
+
+- [ ] **Step 4: Add bounded-selection tests with independent fresh streams**
+
+Append:
+
+```ts
+describe('seeded RNG bounded selection', () => {
+    it('returns zero for a unit bound from a fresh stream', () => {
+        expect(createSeededRng('ice-slide:test').nextInt(1)).toBe(0)
+    })
+
+    it('locks five nextInt(7) draws from a separate fresh stream', () => {
+        const rng = createSeededRng('ice-slide:test')
+        expect([
+            rng.nextInt(7),
+            rng.nextInt(7),
+            rng.nextInt(7),
+            rng.nextInt(7),
+            rng.nextInt(7),
+        ]).toEqual([2, 0, 3, 5, 0])
+    })
+
+    it.each([0, -1, 1.5, Number.NaN, Number.POSITIVE_INFINITY, 0x80000000])(
+        'rejects invalid maxExclusive %s',
+        maxExclusive => {
+            expect(() =>
+                createSeededRng('ice-slide:test').nextInt(maxExclusive)
+            ).toThrow(RangeError)
+        }
+    )
+
+    it('accepts the signed 32-bit upper bound', () => {
+        const value = createSeededRng('ice-slide:test').nextInt(0x7fffffff)
+        expect(value).toBeGreaterThanOrEqual(0)
+        expect(value).toBeLessThan(0x7fffffff)
+    })
+})
+```
+
+- [ ] **Step 5: Implement `nextFloat()` and the exact rejection-sampled `nextInt()`**
+
+Inside `createSeededRngFromPath`:
+
+```ts
+const nextFloat = (): number => nextUint32() / UINT32_RANGE
+
+const nextInt = (maxExclusive: number): number => {
+    if (
+        !Number.isInteger(maxExclusive) ||
+        maxExclusive < 1 ||
+        maxExclusive > MAX_INT_BOUND
+    ) {
+        throw new RangeError(
+            'maxExclusive must be an integer from 1 through 2147483647'
+        )
+    }
+
+    const limit =
+        Math.floor(UINT32_RANGE / maxExclusive) * maxExclusive
+    let value: number
+    do {
+        value = nextUint32()
+    } while (value >= limit)
+
+    return value % maxExclusive
+}
+```
+
+Do not apply `>>> 0`, `| 0`, or any other bitwise operation to `UINT32_RANGE`, `maxExclusive`, or `limit`.
+
+- [ ] **Step 6: Add `pick()` and shuffle contract tests**
+
+Append:
+
+```ts
+describe('seeded RNG collection helpers', () => {
+    it('pick consumes one bounded draw', () => {
+        expect(
+            createSeededRng('ice-slide:test').pick([
+                'A',
+                'B',
+                'C',
+                'D',
+                'E',
+            ])
+        ).toBe('D')
+    })
+
+    it('pick rejects an empty collection', () => {
+        expect(() =>
+            createSeededRng('ice-slide:test').pick([])
+        ).toThrow(RangeError)
+    })
+
+    it('pick still consumes a draw for one item', () => {
+        const rng = createSeededRng('ice-slide:test')
+        expect(rng.pick(['only'])).toBe('only')
+        expect(rng.nextUint32()).toBe(574486829)
+    })
+
+    it('uses descending Fisher-Yates without mutating input', () => {
+        const input = ['A', 'B', 'C', 'D', 'E'] as const
+        const shuffled =
+            createSeededRng('ice-slide:test').shuffle(input)
+
+        expect(shuffled).toEqual(['C', 'A', 'E', 'B', 'D'])
+        expect(input).toEqual(['A', 'B', 'C', 'D', 'E'])
+    })
+})
+```
+
+The one-item assertion proves `pick(['only'])` consumed the first RNG output through `nextInt(1)`; the next raw output must therefore be the second locked stream value.
+
+- [ ] **Step 7: Implement `pick()` and descending Fisher–Yates `shuffle()`**
+
+```ts
+const pick = <T>(items: readonly T[]): T => {
+    if (items.length === 0) {
+        throw new RangeError('pick requires at least one item')
+    }
+    return items[nextInt(items.length)]
+}
+
+const shuffle = <T>(items: readonly T[]): T[] => {
+    const result = [...items]
+    for (let index = result.length - 1; index > 0; index--) {
+        const swapIndex = nextInt(index + 1)
+        ;[result[index], result[swapIndex]] = [
+            result[swapIndex],
+            result[index],
+        ]
+    }
+    return result
+}
+```
+
+- [ ] **Step 8: Add labeled-fork and input-validation tests**
+
+Append:
+
+```ts
+describe('seeded RNG labeled forks', () => {
+    it('derives forks from immutable paths, not draw position', () => {
+        const parent = createSeededRng('ice-slide:test')
+        const before = parent.fork('stage:1')
+        parent.nextUint32()
+        parent.nextUint32()
+        const after = parent.fork('stage:1')
+
+        expect(before.nextUint32()).toBe(694760629)
+        expect(after.nextUint32()).toBe(694760629)
+        expect(
+            createSeededRng('ice-slide:test')
+                .fork('stage:2')
+                .nextUint32()
+        ).toBe(2216382472)
+    })
+
+    it('keeps nested fork paths and instances independent', () => {
+        const parent = createSeededRng('ice-slide:test')
+        const first = parent.fork('stage').fork('objective')
+        const second = parent.fork('stage').fork('objective')
+
+        expect(first.nextUint32()).toBe(second.nextUint32())
+        first.nextUint32()
+        expect(first.nextUint32()).not.toBe(second.nextUint32())
+    })
+
+    it.each(['', 'a\u001fb'])('rejects invalid seed key %j', seed => {
+        expect(() => createSeededRng(seed)).toThrow(RangeError)
+    })
+
+    it.each(['', 'a\u001fb'])('rejects invalid fork label %j', label => {
+        expect(() =>
+            createSeededRng('ice-slide:test').fork(label)
+        ).toThrow(RangeError)
+    })
+})
+```
+
+- [ ] **Step 9: Implement forks and return the complete API**
+
+Inside `createSeededRngFromPath`:
+
+```ts
+const fork = (label: string): SeededRng => {
+    assertSeedSegment(label, 'label')
+    return createSeededRngFromPath(
+        `${seedPath}${FORK_SEPARATOR}${label}`
+    )
+}
+
+return {
+    nextUint32,
+    nextFloat,
+    nextInt,
+    pick,
+    shuffle,
+    fork,
+}
+```
+
+- [ ] **Step 10: Prove no public path calls `Math.random()`**
+
+Append:
+
+```ts
+import { afterEach, vi } from 'vitest'
+
+afterEach(() => {
+    vi.restoreAllMocks()
+})
+
+it('never calls Math.random', () => {
+    const randomSpy = vi
+        .spyOn(Math, 'random')
+        .mockImplementation(() => {
+            throw new Error('Math.random must not be called')
+        })
+
+    const rng = createSeededRng('ice-slide:test')
+    rng.nextUint32()
+    rng.nextFloat()
+    rng.nextInt(7)
+    rng.pick(['A', 'B'])
+    rng.shuffle(['A', 'B', 'C'])
+    rng.fork('stage').nextUint32()
+
+    expect(randomSpy).not.toHaveBeenCalled()
+})
+```
+
+- [ ] **Step 11: Run the focused suite**
+
+Run:
+
+```bash
+bunx vitest run src/lib/games/shared/seeded-rng.test.ts
+```
+
+Expected: PASS with all hash, stream, bound, pick, shuffle, fork, validation, and `Math.random()` tests green.
+
+- [ ] **Step 12: Commit the shared RNG**
+
+```bash
+git add \
+  src/lib/games/shared/seeded-rng.ts \
+  src/lib/games/shared/seeded-rng.test.ts
+git commit -m "feat(games): add deterministic seeded rng"
+```
+
+---
+
+### Task 2: Add board transforms and canonical variants
+
+**Files:**
+- Modify: `src/lib/games/ice-slide/types.ts`
+- Create: `src/lib/games/ice-slide/transforms.ts`
+- Create: `src/lib/games/ice-slide/transforms.test.ts`
+
+**Interfaces:**
+- Consumes:
+  - `hashString32Hex(value: string): string` from Task 1.
+  - existing `GridPosition` from `types.ts`.
+- Produces:
+
+```ts
+export type BoardTransform =
+    | 'identity'
+    | 'rotate_90'
+    | 'rotate_180'
+    | 'rotate_270'
+    | 'reflect_horizontal'
+    | 'reflect_vertical'
+    | 'reflect_main_diagonal'
+    | 'reflect_anti_diagonal'
+
+export const BOARD_TRANSFORMS: readonly BoardTransform[]
+
+export interface TransformedBoardVariant {
+    transform: BoardTransform
+    rows: string[]
+    canonicalKey: string
+    hash: string
+}
+
+export function transformRows(
+    rows: readonly string[],
+    transform: BoardTransform
+): string[]
+
+export function transformPosition(
+    position: GridPosition,
+    inputRows: number,
+    inputCols: number,
+    transform: BoardTransform
+): GridPosition
+
+export function inverseBoardTransform(
+    transform: BoardTransform
+): BoardTransform
+
+export function serializeBoardRows(rows: readonly string[]): string
+export function hashBoardRows(rows: readonly string[]): string
+export function getUniqueBoardTransforms(
+    rows: readonly string[]
+): TransformedBoardVariant[]
+```
+
+- [ ] **Step 1: Add the additive transform and future run-domain types**
+
+In `types.ts`, add:
+
+```ts
+export type IceSlideMode = 'campaign' | 'daily' | 'expedition'
+export type IceSlideDifficulty =
+    | 'tutorial'
+    | 'easy'
+    | 'medium'
+    | 'hard'
+
+export type IceSlideObjectiveId =
+    | 'collect_all_crystals'
+    | 'no_falls'
+    | 'no_reset'
+
+export type BoardTransform =
+    | 'identity'
+    | 'rotate_90'
+    | 'rotate_180'
+    | 'rotate_270'
+    | 'reflect_horizontal'
+    | 'reflect_vertical'
+    | 'reflect_main_diagonal'
+    | 'reflect_anti_diagonal'
+```
+
+Do not add implementation logic to `types.ts`.
+
+- [ ] **Step 2: Write all eight rectangular row-transform tests**
+
+Create `transforms.test.ts`:
+
+```ts
+import { describe, expect, it } from 'vitest'
+import {
+    BOARD_TRANSFORMS,
+    transformRows,
+} from './transforms'
+
+describe('Ice Slide board transforms', () => {
+    const rows = ['ABC', 'DEF'] as const
+
+    it.each([
+        ['identity', ['ABC', 'DEF']],
+        ['rotate_90', ['DA', 'EB', 'FC']],
+        ['rotate_180', ['FED', 'CBA']],
+        ['rotate_270', ['CF', 'BE', 'AD']],
+        ['reflect_horizontal', ['DEF', 'ABC']],
+        ['reflect_vertical', ['CBA', 'FED']],
+        ['reflect_main_diagonal', ['AD', 'BE', 'CF']],
+        ['reflect_anti_diagonal', ['FC', 'EB', 'DA']],
+    ] as const)('applies %s', (transform, expected) => {
+        expect(transformRows(rows, transform)).toEqual(expected)
+    })
+
+    it('locks transform enumeration order', () => {
+        expect(BOARD_TRANSFORMS).toEqual([
+            'identity',
+            'rotate_90',
+            'rotate_180',
+            'rotate_270',
+            'reflect_horizontal',
+            'reflect_vertical',
+            'reflect_main_diagonal',
+            'reflect_anti_diagonal',
+        ])
+    })
+})
+```
+
+- [ ] **Step 3: Run the focused test and verify it fails**
+
+```bash
+bunx vitest run src/lib/games/ice-slide/transforms.test.ts
+```
+
+Expected: FAIL because `transforms.ts` does not exist.
+
+- [ ] **Step 4: Implement shared row validation and coordinate mapping**
+
+Create `transforms.ts` with:
+
+```ts
+import { hashString32Hex } from '../shared/seeded-rng'
+import type { BoardTransform, GridPosition } from './types'
+
+export const BOARD_TRANSFORMS: readonly BoardTransform[] = [
+    'identity',
+    'rotate_90',
+    'rotate_180',
+    'rotate_270',
+    'reflect_horizontal',
+    'reflect_vertical',
+    'reflect_main_diagonal',
+    'reflect_anti_diagonal',
+]
+
+function validateRows(rows: readonly string[]): {
+    rowCount: number
+    columnCount: number
+} {
+    if (rows.length === 0) {
+        throw new RangeError('board rows must not be empty')
+    }
+    const columnCount = rows[0].length
+    if (columnCount === 0) {
+        throw new RangeError('board rows must not have zero columns')
+    }
+    for (const row of rows) {
+        if (row.length !== columnCount) {
+            throw new RangeError('board rows must be rectangular')
+        }
+    }
+    return { rowCount: rows.length, columnCount }
+}
+
+export function transformPosition(
+    position: GridPosition,
+    inputRows: number,
+    inputCols: number,
+    transform: BoardTransform
+): GridPosition {
+    if (
+        !Number.isInteger(inputRows) ||
+        !Number.isInteger(inputCols) ||
+        inputRows < 1 ||
+        inputCols < 1 ||
+        position.row < 0 ||
+        position.row >= inputRows ||
+        position.col < 0 ||
+        position.col >= inputCols
+    ) {
+        throw new RangeError('position is outside the input board')
+    }
+
+    const { row, col } = position
+    switch (transform) {
+        case 'identity':
+            return { row, col }
+        case 'rotate_90':
+            return { row: col, col: inputRows - 1 - row }
+        case 'rotate_180':
+            return {
+                row: inputRows - 1 - row,
+                col: inputCols - 1 - col,
+            }
+        case 'rotate_270':
+            return { row: inputCols - 1 - col, col: row }
+        case 'reflect_horizontal':
+            return { row: inputRows - 1 - row, col }
+        case 'reflect_vertical':
+            return { row, col: inputCols - 1 - col }
+        case 'reflect_main_diagonal':
+            return { row: col, col: row }
+        case 'reflect_anti_diagonal':
+            return {
+                row: inputCols - 1 - col,
+                col: inputRows - 1 - row,
+            }
+    }
+}
+```
+
+- [ ] **Step 5: Implement `transformRows()` through the same coordinate mapping**
+
+```ts
+function outputDimensions(
+    inputRows: number,
+    inputCols: number,
+    transform: BoardTransform
+): { rows: number; cols: number } {
+    switch (transform) {
+        case 'rotate_90':
+        case 'rotate_270':
+        case 'reflect_main_diagonal':
+        case 'reflect_anti_diagonal':
+            return { rows: inputCols, cols: inputRows }
+        default:
+            return { rows: inputRows, cols: inputCols }
+    }
+}
+
+export function transformRows(
+    rows: readonly string[],
+    transform: BoardTransform
+): string[] {
+    const { rowCount, columnCount } = validateRows(rows)
+    const dimensions = outputDimensions(
+        rowCount,
+        columnCount,
+        transform
+    )
+    const output = Array.from(
+        { length: dimensions.rows },
+        () => Array<string>(dimensions.cols)
+    )
+
+    for (let row = 0; row < rowCount; row++) {
+        for (let col = 0; col < columnCount; col++) {
+            const target = transformPosition(
+                { row, col },
+                rowCount,
+                columnCount,
+                transform
+            )
+            output[target.row][target.col] = rows[row][col]
+        }
+    }
+
+    return output.map(row => row.join(''))
+}
+```
+
+- [ ] **Step 6: Add coordinate/glyph and inverse round-trip tests**
+
+Append:
+
+```ts
+import {
+    inverseBoardTransform,
+    transformPosition,
+} from './transforms'
+
+it.each(BOARD_TRANSFORMS)(
+    'keeps transformed coordinates aligned for %s',
+    transform => {
+        const source = ['ABC', 'DEF']
+        const transformed = transformRows(source, transform)
+
+        for (let row = 0; row < source.length; row++) {
+            for (let col = 0; col < source[0].length; col++) {
+                const target = transformPosition(
+                    { row, col },
+                    2,
+                    3,
+                    transform
+                )
+                expect(transformed[target.row][target.col]).toBe(
+                    source[row][col]
+                )
+            }
+        }
+    }
+)
+
+it.each(BOARD_TRANSFORMS)(
+    'round-trips rows through inverse %s',
+    transform => {
+        const source = ['ABC', 'DEF']
+        const transformed = transformRows(source, transform)
+        expect(
+            transformRows(
+                transformed,
+                inverseBoardTransform(transform)
+            )
+        ).toEqual(source)
+    }
+)
+```
+
+- [ ] **Step 7: Implement inverse lookup**
+
+```ts
+export function inverseBoardTransform(
+    transform: BoardTransform
+): BoardTransform {
+    switch (transform) {
+        case 'rotate_90':
+            return 'rotate_270'
+        case 'rotate_270':
+            return 'rotate_90'
+        default:
+            return transform
+    }
+}
+```
+
+- [ ] **Step 8: Add malformed canonicalization and hash tests**
+
+Append:
+
+```ts
+import {
+    hashBoardRows,
+    serializeBoardRows,
+} from './transforms'
+
+it('serializes dimensions and row boundaries exactly', () => {
+    expect(serializeBoardRows(['AB', 'CD'])).toBe(
+        '2x2\u001fAB\u001eCD'
+    )
+    expect(hashBoardRows(['AB', 'CD'])).toMatch(/^[0-9a-f]{8}$/)
+})
+
+it.each([
+    [] as string[],
+    [''] as string[],
+    ['ABC', 'DE'] as string[],
+])('rejects malformed canonical rows %j', rows => {
+    expect(() => serializeBoardRows(rows)).toThrow(RangeError)
+    expect(() => hashBoardRows(rows)).toThrow(RangeError)
+})
+```
+
+- [ ] **Step 9: Implement canonical serialization and compact hashing**
+
+```ts
+export function serializeBoardRows(
+    rows: readonly string[]
+): string {
+    const { rowCount, columnCount } = validateRows(rows)
+    return `${rowCount}x${columnCount}\u001f${rows.join('\u001e')}`
+}
+
+export function hashBoardRows(rows: readonly string[]): string {
+    return hashString32Hex(serializeBoardRows(rows))
+}
+```
+
+- [ ] **Step 10: Add stable symmetry-dedup tests**
+
+Append:
+
+```ts
+import { getUniqueBoardTransforms } from './transforms'
+
+it('deduplicates by complete canonical serialization', () => {
+    const variants = getUniqueBoardTransforms([
+        'AAA',
+        'ABA',
+        'AAA',
+    ])
+    expect(variants).toHaveLength(1)
+    expect(variants[0].transform).toBe('identity')
+})
+
+it('retains all variants for an asymmetric rectangle', () => {
+    const variants = getUniqueBoardTransforms(['ABC', 'DEF'])
+    expect(variants).toHaveLength(8)
+    expect(variants.map(variant => variant.transform)).toEqual(
+        BOARD_TRANSFORMS
+    )
+    expect(
+        new Set(variants.map(variant => variant.canonicalKey)).size
+    ).toBe(8)
+})
+```
+
+- [ ] **Step 11: Implement unique transform generation**
+
+```ts
+export interface TransformedBoardVariant {
+    transform: BoardTransform
+    rows: string[]
+    canonicalKey: string
+    hash: string
+}
+
+export function getUniqueBoardTransforms(
+    rows: readonly string[]
+): TransformedBoardVariant[] {
+    validateRows(rows)
+    const seen = new Set<string>()
+    const variants: TransformedBoardVariant[] = []
+
+    for (const transform of BOARD_TRANSFORMS) {
+        const transformed = transformRows(rows, transform)
+        const canonicalKey = serializeBoardRows(transformed)
+        if (seen.has(canonicalKey)) {
+            continue
+        }
+        seen.add(canonicalKey)
+        variants.push({
+            transform,
+            rows: transformed,
+            canonicalKey,
+            hash: hashString32Hex(canonicalKey),
+        })
+    }
+
+    return variants
+}
+```
+
+- [ ] **Step 12: Run transform tests and typecheck the touched modules**
+
+```bash
+bunx vitest run src/lib/games/ice-slide/transforms.test.ts
+bun run typecheck
+```
+
+Expected: both commands succeed.
+
+- [ ] **Step 13: Commit transforms and additive types**
+
+```bash
+git add \
+  src/lib/games/ice-slide/types.ts \
+  src/lib/games/ice-slide/transforms.ts \
+  src/lib/games/ice-slide/transforms.test.ts
+git commit -m "feat(ice-slide): add board transforms and canonical variants"
+```
+
+---
+
+### Task 3: Materialize versioned Campaign runs
+
+**Files:**
+- Modify: `src/lib/games/ice-slide/types.ts`
+- Create: `src/lib/games/ice-slide/run.ts`
+- Create: `src/lib/games/ice-slide/run.test.ts`
+- Modify: `src/lib/games/ice-slide/physics.ts`
+- Modify: `src/lib/games/ice-slide/physics.test.ts`
+
+**Interfaces:**
+- Consumes:
+  - `hashString32Hex()` from Task 1.
+  - `serializeBoardRows()` from Task 2.
+  - `ICE_SLIDE_LEVELS` from unchanged `levels.ts`.
+  - `GLYPH_TO_CELL` from `types.ts`.
+- Produces:
+
+```ts
+export const ICE_SLIDE_RUN_SCHEMA_VERSION: 1
+export const ICE_SLIDE_CAMPAIGN_GENERATOR_VERSION: number
+export const ICE_SLIDE_RULESET_VERSION: number
+export const CAMPAIGN_RUN_KEY: string
+
+export function createIceSlideStageSignature(input: {
+    rows: readonly string[]
+    parMoves: number
+    objectiveIds: readonly IceSlideObjectiveId[]
+    scoreMultiplierBps: number
+}): string
+
+export function assertValidIceSlideRunDefinition(
+    run: IceSlideRunDefinition
+): void
+
+export function cloneIceSlideRunDefinition(
+    run: IceSlideRunDefinition
+): IceSlideRunDefinition
+
+export function createCampaignRunDefinition(): IceSlideRunDefinition
+```
+
+- [ ] **Step 1: Add the complete run, stage, state, and game-data contracts**
+
+In `types.ts`, add:
+
+```ts
+export interface IceSlideRunDefinition {
+    schemaVersion: 1
+    generatorVersion: number
+    rulesetVersion: number
+    mode: IceSlideMode
+    runKey: string
+    seed: string | null
+    stages: IceSlideStageDefinition[]
+}
+
+export interface IceSlideStageDefinition {
+    id: string
+    name: string
+    templateId: string
+    difficulty: IceSlideDifficulty
+    rows: string[]
+    parMoves: number
+    transform: BoardTransform
+    mutationIds: string[]
+    objectiveIds: IceSlideObjectiveId[]
+    scoreMultiplierBps: number
+    signature: string
+}
+```
+
+Extend `IceSlideState` and `IceSlideGameData` with these required fields:
+
+```ts
+mode: IceSlideMode
+runKey: string
+runSchemaVersion: 1
+generatorVersion: number
+rulesetVersion: number
+stagesTotal: number
+starsEarned: number
+falls: number
+resets: number
+stageSignatures: string[]
+```
+
+Do not remove or rename any existing field.
+
+- [ ] **Step 2: Write version, key, and First Frost golden tests**
+
+Create `run.test.ts`:
+
+```ts
+import { describe, expect, it } from 'vitest'
+import { ICE_SLIDE_LEVELS } from './levels'
+import {
+    CAMPAIGN_RUN_KEY,
+    ICE_SLIDE_CAMPAIGN_GENERATOR_VERSION,
+    ICE_SLIDE_RULESET_VERSION,
+    ICE_SLIDE_RUN_SCHEMA_VERSION,
+    createCampaignRunDefinition,
+    createIceSlideStageSignature,
+} from './run'
+
+describe('Ice Slide run versions and signatures', () => {
+    it('derives the Campaign key from mode-specific versions', () => {
+        expect(ICE_SLIDE_RUN_SCHEMA_VERSION).toBe(1)
+        expect(ICE_SLIDE_CAMPAIGN_GENERATOR_VERSION).toBe(1)
+        expect(ICE_SLIDE_RULESET_VERSION).toBe(1)
+        expect(CAMPAIGN_RUN_KEY).toBe(
+            'ice-slide:campaign:g1:r1'
+        )
+    })
+
+    it('locks the First Frost signature preimage', () => {
+        expect(
+            createIceSlideStageSignature({
+                rows: ICE_SLIDE_LEVELS[0].rows,
+                parMoves: 1,
+                objectiveIds: [],
+                scoreMultiplierBps: 10000,
+            })
+        ).toBe('is1-a387e186')
+    })
+})
+```
+
+- [ ] **Step 3: Run the focused test and verify it fails**
+
+```bash
+bunx vitest run src/lib/games/ice-slide/run.test.ts
+```
+
+Expected: FAIL because `run.ts` does not exist.
+
+- [ ] **Step 4: Implement version constants and exact signature generation**
+
+Create `run.ts`:
+
+```ts
+import { hashString32Hex } from '../shared/seeded-rng'
+import { serializeBoardRows } from './transforms'
+import type {
+    IceSlideObjectiveId,
+    IceSlideRunDefinition,
+} from './types'
+
+export const ICE_SLIDE_RUN_SCHEMA_VERSION = 1 as const
+export const ICE_SLIDE_CAMPAIGN_GENERATOR_VERSION = 1
+export const ICE_SLIDE_RULESET_VERSION = 1
+
+export const CAMPAIGN_RUN_KEY =
+    `ice-slide:campaign:` +
+    `g${ICE_SLIDE_CAMPAIGN_GENERATOR_VERSION}:` +
+    `r${ICE_SLIDE_RULESET_VERSION}`
+
+export function createIceSlideStageSignature(input: {
+    rows: readonly string[]
+    parMoves: number
+    objectiveIds: readonly IceSlideObjectiveId[]
+    scoreMultiplierBps: number
+}): string {
+    const sortedObjectiveIds = [...input.objectiveIds].sort()
+    const payload = [
+        'ice-slide-stage:v1',
+        `rows=${serializeBoardRows(input.rows)}`,
+        `parMoves=${input.parMoves}`,
+        `objectiveIds=${sortedObjectiveIds.join(',')}`,
+        `scoreMultiplierBps=${input.scoreMultiplierBps}`,
+    ].join('\u001d')
+
+    return `is1-${hashString32Hex(payload)}`
+}
+```
+
+- [ ] **Step 5: Add exact Campaign materialization tests**
+
+Append:
+
+```ts
+describe('Campaign run materialization', () => {
+    it('materializes exactly the authored eight levels', () => {
+        const run = createCampaignRunDefinition()
+
+        expect(run).toMatchObject({
+            schemaVersion: 1,
+            generatorVersion: 1,
+            rulesetVersion: 1,
+            mode: 'campaign',
+            runKey: 'ice-slide:campaign:g1:r1',
+            seed: null,
+        })
+        expect(run.stages).toHaveLength(8)
+
+        for (let index = 0; index < ICE_SLIDE_LEVELS.length; index++) {
+            const level = ICE_SLIDE_LEVELS[index]
+            const stage = run.stages[index]
+
+            expect(stage.id).toBe(`campaign:${level.id}`)
+            expect(stage.templateId).toBe(`campaign:${level.id}`)
+            expect(stage.name).toBe(level.name)
+            expect(stage.rows).toEqual(level.rows)
+            expect(stage.rows).not.toBe(level.rows)
+            expect(stage.parMoves).toBe(level.parMoves)
+            expect(stage.transform).toBe('identity')
+            expect(stage.mutationIds).toEqual([])
+            expect(stage.objectiveIds).toEqual([])
+            expect(stage.scoreMultiplierBps).toBe(10000)
+            expect(stage.signature).toMatch(/^is1-[0-9a-f]{8}$/)
+        }
+    })
+
+    it('returns fresh snapshots on every call', () => {
+        const first = createCampaignRunDefinition()
+        const second = createCampaignRunDefinition()
+
+        first.stages[0].rows[0] = 'xxxxx'
+        first.stages[0].objectiveIds.push('no_reset')
+
+        expect(second.stages[0].rows[0]).toBe('#####')
+        expect(second.stages[0].objectiveIds).toEqual([])
+    })
+})
+```
+
+- [ ] **Step 6: Implement Campaign difficulty mapping and adapter**
+
+```ts
+import { ICE_SLIDE_LEVELS } from './levels'
+import type {
+    IceSlideDifficulty,
+    IceSlideRunDefinition,
+} from './types'
+
+const CAMPAIGN_DIFFICULTIES: readonly IceSlideDifficulty[] = [
+    'tutorial',
+    'easy',
+    'easy',
+    'medium',
+    'medium',
+    'medium',
+    'hard',
+    'hard',
+]
+
+export function createCampaignRunDefinition(): IceSlideRunDefinition {
+    return {
+        schemaVersion: ICE_SLIDE_RUN_SCHEMA_VERSION,
+        generatorVersion:
+            ICE_SLIDE_CAMPAIGN_GENERATOR_VERSION,
+        rulesetVersion: ICE_SLIDE_RULESET_VERSION,
+        mode: 'campaign',
+        runKey: CAMPAIGN_RUN_KEY,
+        seed: null,
+        stages: ICE_SLIDE_LEVELS.map((level, index) => {
+            const rows = [...level.rows]
+            const stage = {
+                id: `campaign:${level.id}`,
+                name: level.name,
+                templateId: `campaign:${level.id}`,
+                difficulty: CAMPAIGN_DIFFICULTIES[index],
+                rows,
+                parMoves: level.parMoves,
+                transform: 'identity' as const,
+                mutationIds: [],
+                objectiveIds: [],
+                scoreMultiplierBps: 10000,
+                signature: '',
+            }
+            stage.signature = createIceSlideStageSignature(stage)
+            return stage
+        }),
+    }
+}
+```
+
+- [ ] **Step 7: Add run-key validation fixtures for all modes**
+
+Append:
+
+```ts
+import { hashString32Hex } from '../shared/seeded-rng'
+import {
+    assertValidIceSlideRunDefinition,
+    cloneIceSlideRunDefinition,
+} from './run'
+
+function cloneRun(
+    run = createCampaignRunDefinition()
+): ReturnType<typeof createCampaignRunDefinition> {
+    return structuredClone(run)
+}
+
+it('accepts the Campaign run', () => {
+    expect(() =>
+        assertValidIceSlideRunDefinition(
+            createCampaignRunDefinition()
+        )
+    ).not.toThrow()
+})
+
+it.each([
+    ['bad key characters', run => {
+        run.runKey = 'ice slide'
+    }],
+    ['version mismatch', run => {
+        run.runKey = 'ice-slide:campaign:g2:r1'
+    }],
+    ['Campaign seed', run => {
+        run.seed = 'not-null'
+    }],
+    ['too many stages', run => {
+        run.stages = Array.from(
+            { length: 65 },
+            (_, index) => ({
+                ...structuredClone(run.stages[0]),
+                id: `campaign:${index + 1}`,
+            })
+        )
+    }],
+    ['multiplier below band', run => {
+        run.stages[0].scoreMultiplierBps = 999
+    }],
+    ['multiplier above band', run => {
+        run.stages[0].scoreMultiplierBps = 50001
+    }],
+] as const)('rejects %s', (_name, mutate) => {
+    const run = cloneRun()
+    mutate(run)
+    expect(() =>
+        assertValidIceSlideRunDefinition(run)
+    ).toThrow()
+})
+
+it('validates a Daily key/date/seed relationship', () => {
+    const run = cloneRun()
+    run.mode = 'daily'
+    run.generatorVersion = 3
+    run.rulesetVersion = 2
+    run.runKey = 'ice-slide:daily:2026-08-02:g3:r2'
+    run.seed = 'ice-slide:daily:3:2:2026-08-02'
+    expect(() =>
+        assertValidIceSlideRunDefinition(run)
+    ).not.toThrow()
+})
+
+it('validates an Expedition key against the seed hash', () => {
+    const run = cloneRun()
+    run.mode = 'expedition'
+    run.generatorVersion = 4
+    run.rulesetVersion = 2
+    run.seed = 'ice-slide:expedition:sample-seed'
+    run.runKey =
+        `ice-slide:expedition:${hashString32Hex(run.seed)}:` +
+        'g4:r2'
+
+    expect(() =>
+        assertValidIceSlideRunDefinition(run)
+    ).not.toThrow()
+})
+```
+
+- [ ] **Step 8: Implement structural run validation**
+
+Use these constants:
+
+```ts
+import { BOARD_TRANSFORMS } from './transforms'
+import { GLYPH_TO_CELL } from './types'
+import type {
+    BoardTransform,
+    IceSlideDifficulty,
+    IceSlideMode,
+    IceSlideObjectiveId,
+} from './types'
+
+const RUN_KEY_PATTERN = /^[A-Za-z0-9:._-]+$/
+const RUN_KEY_MAX_LENGTH = 128
+const DAILY_KEY_PATTERN =
+    /^ice-slide:daily:(\d{4}-\d{2}-\d{2}):g([1-9]\d*):r([1-9]\d*)$/
+const EXPEDITION_KEY_PATTERN =
+    /^ice-slide:expedition:([0-9a-f]{8}):g([1-9]\d*):r([1-9]\d*)$/
+
+const MODES = new Set<IceSlideMode>([
+    'campaign',
+    'daily',
+    'expedition',
+])
+const DIFFICULTIES = new Set<IceSlideDifficulty>([
+    'tutorial',
+    'easy',
+    'medium',
+    'hard',
+])
+const OBJECTIVES = new Set<IceSlideObjectiveId>([
+    'collect_all_crystals',
+    'no_falls',
+    'no_reset',
+])
+const TRANSFORMS = new Set<BoardTransform>(BOARD_TRANSFORMS)
+```
+
+Implement focused helpers:
+
+```ts
+function assertPositiveInt(value: number, field: string): void {
+    if (
+        !Number.isInteger(value) ||
+        value < 1 ||
+        value > 0x7fffffff
+    ) {
+        throw new RangeError(`${field} must be a positive signed integer`)
+    }
+}
+
+function assertUniqueNonEmpty(
+    values: readonly string[],
+    field: string
+): void {
+    const seen = new Set<string>()
+    for (const value of values) {
+        if (value.length === 0 || seen.has(value)) {
+            throw new RangeError(`${field} must contain unique non-empty values`)
+        }
+        seen.add(value)
+    }
+}
+```
+
+`assertValidIceSlideRunDefinition` must check, in order:
+
+1. schema/version/mode;
+2. transport-safe run key and maximum length;
+3. mode-specific key/version/seed relationship;
+4. stage count `1..64`;
+5. stage IDs and field enums;
+6. rectangular rows and `GLYPH_TO_CELL` keys;
+7. positive `parMoves`;
+8. `scoreMultiplierBps` in `1000..50000`;
+9. unique mutation/objective IDs and recognized objectives;
+10. exact signature recomputation.
+
+For Campaign, require exact equality with `CAMPAIGN_RUN_KEY`, versions, and null seed. For Daily, parse the date/key and require the exact design seed. For Expedition, require non-empty seed without U+001F and key hash equal to `hashString32Hex(seed)`.
+
+- [ ] **Step 9: Add deep-cloning tests and implementation**
+
+Test:
+
+```ts
+it('deep-clones every mutable run array', () => {
+    const source = createCampaignRunDefinition()
+    const clone = cloneIceSlideRunDefinition(source)
+
+    clone.stages[0].rows[0] = 'xxxxx'
+    clone.stages[0].mutationIds.push('mutation:a')
+    clone.stages[0].objectiveIds.push('no_reset')
+    clone.stages.push(structuredClone(clone.stages[0]))
+
+    expect(source.stages).toHaveLength(8)
+    expect(source.stages[0].rows[0]).toBe('#####')
+    expect(source.stages[0].mutationIds).toEqual([])
+    expect(source.stages[0].objectiveIds).toEqual([])
+})
+```
+
+Implementation:
+
+```ts
+export function cloneIceSlideRunDefinition(
+    run: IceSlideRunDefinition
+): IceSlideRunDefinition {
+    return {
+        ...run,
+        stages: run.stages.map(stage => ({
+            ...stage,
+            rows: [...stage.rows],
+            mutationIds: [...stage.mutationIds],
+            objectiveIds: [...stage.objectiveIds],
+        })),
+    }
+}
+```
+
+- [ ] **Step 10: Narrow the physics parser input contract**
+
+In `physics.ts`, replace the `IceSlideLevel` dependency with:
+
+```ts
+export interface IceSlideGridSource {
+    id: string | number
+    rows: readonly string[]
+}
+
+export function parseGrid(
+    source: IceSlideGridSource
+): CellType[][] {
+    if (source.rows.length === 0) {
+        throw new Error(`Level ${source.id} has no rows`)
+    }
+    const cols = source.rows[0].length
+    return source.rows.map((row, rowIndex) => {
+        if (row.length !== cols) {
+            throw new Error(
+                `Level ${source.id} row ${rowIndex} length ${row.length} != ${cols}`
+            )
+        }
+        return [...row].map(glyph => {
+            const cell = GLYPH_TO_CELL[glyph]
+            if (!cell) {
+                throw new Error(
+                    `Level ${source.id} unknown glyph "${glyph}" at row ${rowIndex}`
+                )
+            }
+            return cell
+        })
+    })
+}
+```
+
+Keep the validation categories and message templates; string IDs are allowed to appear in interpolated messages.
+
+- [ ] **Step 11: Add a string-ID parser test**
+
+In `physics.test.ts`:
+
+```ts
+it('parses materialized stage rows with a string id', () => {
+    const grid = parseGrid({
+        id: 'campaign:1',
+        rows: ['#####', '#S.G#', '#####'],
+    })
+    expect(grid[1][1]).toBe('start')
+    expect(grid[1][3]).toBe('goal')
+})
+```
+
+Keep all existing parsing, slide, authored-par, and crystal-reachability tests unchanged.
+
+- [ ] **Step 12: Run the run and physics suites**
+
+```bash
+bunx vitest run \
+  src/lib/games/ice-slide/run.test.ts \
+  src/lib/games/ice-slide/physics.test.ts
+bun run typecheck
+```
+
+Expected: all tests pass and TypeScript accepts the additive interfaces.
+
+- [ ] **Step 13: Commit run materialization**
+
+```bash
+git add \
+  src/lib/games/ice-slide/types.ts \
+  src/lib/games/ice-slide/run.ts \
+  src/lib/games/ice-slide/run.test.ts \
+  src/lib/games/ice-slide/physics.ts \
+  src/lib/games/ice-slide/physics.test.ts
+git commit -m "feat(ice-slide): materialize versioned campaign runs"
+```
+
+---
+
+### Task 4: Refactor `IceSlideGame` to consume explicit runs
+
+**Files:**
+- Create: `src/lib/games/ice-slide/test-fixtures.ts`
+- Modify: `src/lib/games/ice-slide/game.ts`
+- Modify: `src/lib/games/ice-slide/game.test.ts`
+- Modify: `src/lib/games/ice-slide/game.win.test.ts`
+- Modify: `src/lib/games/ice-slide/game.hazard.test.ts`
+- Modify: `src/lib/games/ice-slide/game.crystal-farm.test.ts`
+- Modify: `src/lib/games/ice-slide/game.crystal-hazard-farm.test.ts`
+- Modify: `src/lib/games/ice-slide/renderer.test.ts`
+
+**Interfaces:**
+- Consumes:
+  - `createCampaignRunDefinition()`
+  - `assertValidIceSlideRunDefinition()`
+  - `cloneIceSlideRunDefinition()`
+  - `IceSlideRunDefinition`
+- Produces:
+  - `IceSlideGame.start(run?: IceSlideRunDefinition): void`
+  - state/game-data getters containing complete run metadata and copied signatures.
+
+- [ ] **Step 1: Create test-only run builders**
+
+Create `test-fixtures.ts`:
+
+```ts
+import { hashString32Hex } from '../shared/seeded-rng'
+import {
+    createIceSlideStageSignature,
+    ICE_SLIDE_RULESET_VERSION,
+    ICE_SLIDE_RUN_SCHEMA_VERSION,
+} from './run'
+import type {
+    IceSlideRunDefinition,
+    IceSlideStageDefinition,
+} from './types'
+
+export function createTestStage(
+    overrides: Partial<IceSlideStageDefinition> = {}
+): IceSlideStageDefinition {
+    const base: IceSlideStageDefinition = {
+        id: 'test:1',
+        name: 'Test Stage',
+        templateId: 'test:1',
+        difficulty: 'easy',
+        rows: ['#####', '#S.G#', '#####'],
+        parMoves: 1,
+        transform: 'identity',
+        mutationIds: [],
+        objectiveIds: [],
+        scoreMultiplierBps: 10000,
+        signature: '',
+    }
+    const stage = {
+        ...base,
+        ...overrides,
+        rows: [...(overrides.rows ?? base.rows)],
+        mutationIds: [
+            ...(overrides.mutationIds ?? base.mutationIds),
+        ],
+        objectiveIds: [
+            ...(overrides.objectiveIds ?? base.objectiveIds),
+        ],
+    }
+    stage.signature = createIceSlideStageSignature(stage)
+    return stage
+}
+
+export function createTestRun(
+    stages: IceSlideStageDefinition[] = [createTestStage()],
+    overrides: Partial<IceSlideRunDefinition> = {}
+): IceSlideRunDefinition {
+    return {
+        schemaVersion: ICE_SLIDE_RUN_SCHEMA_VERSION,
+        generatorVersion: 1,
+        rulesetVersion: ICE_SLIDE_RULESET_VERSION,
+        mode: 'expedition',
+        runKey:
+            'ice-slide:expedition:' +
+            hashString32Hex('test-seed') +
+            ':g1:r1',
+        seed: 'test-seed',
+        stages: stages.map(stage => ({
+            ...stage,
+            rows: [...stage.rows],
+            mutationIds: [...stage.mutationIds],
+            objectiveIds: [...stage.objectiveIds],
+        })),
+        ...overrides,
+    }
+}
+```
+
+When applying `overrides`, recalculate or explicitly supply a matching `runKey` whenever mode/seed/version changes.
+
+- [ ] **Step 2: Add idle-state and default-start tests first**
+
+In `game.test.ts`, add:
+
+```ts
+import { CAMPAIGN_RUN_KEY } from './run'
+
+it('exposes complete Campaign metadata while idle', () => {
+    const game = new IceSlideGame()
+    const state = game.getState()
+    const data = game.getGameData()
+
+    expect(state).toMatchObject({
+        status: 'idle',
+        mode: 'campaign',
+        runKey: CAMPAIGN_RUN_KEY,
+        runSchemaVersion: 1,
+        generatorVersion: 1,
+        rulesetVersion: 1,
+        stagesTotal: 8,
+        starsEarned: 0,
+        falls: 0,
+        resets: 0,
+    })
+    expect(state.stageSignatures).toHaveLength(8)
+    expect(data).toMatchObject({
+        solved: false,
+        stagesTotal: 8,
+        starsEarned: 0,
+        falls: 0,
+        resets: 0,
+    })
+    expect(data.stageSignatures).toEqual(state.stageSignatures)
+    expect(data.stageSignatures).not.toBe(state.stageSignatures)
+    game.destroy()
+})
+
+it('constructs and starts the default Campaign without throwing', () => {
+    const game = new IceSlideGame()
+    expect(() => game.start()).not.toThrow()
+    expect(game.getState().levelName).toBe('First Frost')
+    game.destroy()
+})
+```
+
+- [ ] **Step 3: Refactor constructor and idle state around a default active run**
+
+In `game.ts`:
+
+```ts
+import type {
+    IceSlideRunDefinition,
+    IceSlideStageDefinition,
+} from './types'
+import {
+    assertValidIceSlideRunDefinition,
+    cloneIceSlideRunDefinition,
+    createCampaignRunDefinition,
+} from './run'
+
+export class IceSlideGame {
+    private activeRun: IceSlideRunDefinition
+    // existing fields...
+
+    constructor(callbacks: Partial<IceSlideCallbacks> = {}) {
+        this.callbacks = callbacks
+        this.activeRun = createCampaignRunDefinition()
+        this.state = this.createIdleState()
+    }
+}
+```
+
+Do not call the public structural assertion in the constructor. The checked-in Campaign is protected by adapter tests, and `new IceSlideGame()` must not introduce a new throw path.
+
+Create a helper:
+
+```ts
+private runMetadata(): Pick<
+    IceSlideState,
+    | 'mode'
+    | 'runKey'
+    | 'runSchemaVersion'
+    | 'generatorVersion'
+    | 'rulesetVersion'
+    | 'stagesTotal'
+    | 'stageSignatures'
+> {
+    return {
+        mode: this.activeRun.mode,
+        runKey: this.activeRun.runKey,
+        runSchemaVersion: this.activeRun.schemaVersion,
+        generatorVersion: this.activeRun.generatorVersion,
+        rulesetVersion: this.activeRun.rulesetVersion,
+        stagesTotal: this.activeRun.stages.length,
+        stageSignatures: this.activeRun.stages.map(
+            stage => stage.signature
+        ),
+    }
+}
+```
+
+Add `...this.runMetadata()` plus zero `starsEarned`, `falls`, and `resets` to `createIdleState()`.
+
+- [ ] **Step 4: Add explicit-run and invalid-run tests**
+
+```ts
+import {
+    createTestRun,
+    createTestStage,
+} from './test-fixtures'
+
+it('plays an explicit run according to its own stage count', () => {
+    const stages = [
+        createTestStage({
+            id: 'test:1',
+            name: 'First Test',
+            rows: ['#####', '#S.G#', '#####'],
+        }),
+        createTestStage({
+            id: 'test:2',
+            name: 'Second Test',
+            rows: ['#####', '#S.G#', '#####'],
+        }),
+    ]
+    const game = new IceSlideGame()
+    game.start(createTestRun(stages))
+
+    expect(game.getState().levelName).toBe('First Test')
+    game.move('E')
+    expect(game.getState().levelName).toBe('Second Test')
+    game.move('E')
+    expect(game.getState().status).toBe('won')
+    expect(game.getState().levelsCleared).toBe(2)
+    game.destroy()
+})
+
+it('rejects an invalid explicit run before mutating prior state', () => {
+    const game = new IceSlideGame()
+    const before = game.getState()
+    const invalid = createTestRun()
+    invalid.runKey = 'invalid key'
+
+    expect(() => game.start(invalid)).toThrow()
+    expect(game.getState()).toEqual(before)
+    game.destroy()
+})
+
+it('isolates the active run from caller mutation', () => {
+    const run = createTestRun()
+    const game = new IceSlideGame()
+    game.start(run)
+
+    run.stages[0].rows[1] = '#...#'
+    run.stages[0].name = 'Mutated'
+    run.stages[0].objectiveIds.push('no_reset')
+
+    expect(game.getState().levelName).toBe('Test Stage')
+    expect(game.getState().rows).toBe(3)
+    game.destroy()
+})
+```
+
+- [ ] **Step 5: Change `start()` to validate only explicit runs before state mutation**
+
+```ts
+start(run?: IceSlideRunDefinition): void {
+    const nextRun = run
+        ? (() => {
+              assertValidIceSlideRunDefinition(run)
+              return cloneIceSlideRunDefinition(run)
+          })()
+        : createCampaignRunDefinition()
+
+    this.stopTimer()
+    this.activeRun = nextRun
+    this.state = this.createIdleState()
+    this.state.status = 'playing'
+    this.loadLevel(0)
+    this.startTimer()
+    this.callbacks.onGameStart?.()
+    this.callbacks.onScoreUpdate?.(this.state.score)
+    this.callbacks.onTimeUpdate?.(0)
+}
+```
+
+The explicit validation/clone must finish before stopping the prior timer, assigning `activeRun`, or changing `state`.
+
+- [ ] **Step 6: Replace direct level access with the active stage**
+
+Add:
+
+```ts
+private getStage(index: number): IceSlideStageDefinition {
+    const stage = this.activeRun.stages[index]
+    if (!stage) {
+        throw new Error(`Ice Slide stage index out of range: ${index}`)
+    }
+    return stage
+}
+```
+
+In `clearLevel()` and `loadLevel()`, replace `getLevel(index)` with `this.getStage(index)`. Replace the completion comparison against `ICE_SLIDE_LEVELS.length` with `this.activeRun.stages.length`.
+
+Keep existing scoring calls unchanged:
+
+```ts
+const gained = levelScore({
+    levelNumber: this.state.levelIndex + 1,
+    parMoves: stage.parMoves,
+    movesUsed: this.state.levelMoves,
+    crystalsCollected: this.state.levelCrystalsCollected,
+})
+```
+
+Do not apply `scoreMultiplierBps`.
+
+- [ ] **Step 7: Preserve metadata and cumulative counters across every state rebuild**
+
+Before replacing `this.state` in `loadLevel()`, preserve:
+
+```ts
+const cumulative = {
+    moves: this.state.moves,
+    crystalsCollected: this.state.crystalsCollected,
+    score: this.state.score,
+    elapsedSeconds: this.state.elapsedSeconds,
+    perfectLevels: this.state.perfectLevels,
+    levelsCleared: this.state.levelsCleared,
+    starsEarned: this.state.starsEarned,
+    falls: this.state.falls,
+    resets: this.state.resets,
+    status: this.state.status,
+}
+```
+
+The new state object must always include:
+
+```ts
+...this.runMetadata(),
+starsEarned: preserved?.starsEarned ?? 0,
+falls: preserved?.falls ?? 0,
+resets: preserved?.resets ?? 0,
+```
+
+`stageSignatures` must always come from the complete `activeRun`, not cleared stages.
+
+Do not increment falls/resets in HPA-485.
+
+- [ ] **Step 8: Extend getters with copied metadata arrays**
+
+`getState()` must retain its existing defensive grid/player/path copies and add:
+
+```ts
+stageSignatures: [...this.state.stageSignatures],
+```
+
+`getGameData()` must return all existing fields plus:
+
+```ts
+mode: this.state.mode,
+runKey: this.state.runKey,
+runSchemaVersion: this.state.runSchemaVersion,
+generatorVersion: this.state.generatorVersion,
+rulesetVersion: this.state.rulesetVersion,
+stagesTotal: this.state.stagesTotal,
+starsEarned: this.state.starsEarned,
+falls: this.state.falls,
+resets: this.state.resets,
+stageSignatures: [...this.state.stageSignatures],
+```
+
+- [ ] **Step 9: Add stage-advance/reset/hazard carry tests**
+
+In `game.test.ts` or focused branch tests, assert that these fields remain identical after:
+
+1. normal stage advance;
+2. manual `resetLevel()`;
+3. hazard reload.
+
+Use this helper:
+
+```ts
+function expectRunMetadataPreserved(
+    before: ReturnType<IceSlideGame['getState']>,
+    after: ReturnType<IceSlideGame['getState']>
+): void {
+    expect(after).toMatchObject({
+        mode: before.mode,
+        runKey: before.runKey,
+        runSchemaVersion: before.runSchemaVersion,
+        generatorVersion: before.generatorVersion,
+        rulesetVersion: before.rulesetVersion,
+        stagesTotal: before.stagesTotal,
+        starsEarned: before.starsEarned,
+        falls: before.falls,
+        resets: before.resets,
+    })
+    expect(after.stageSignatures).toEqual(before.stageSignatures)
+}
+```
+
+- [ ] **Step 10: Replace all four `vi.mock('./levels')` suites with explicit runs**
+
+For each branch test:
+
+- delete the top-level `vi.mock('./levels', ...)`;
+- import `createTestRun` and `createTestStage`;
+- pass the explicit run to `game.start(run)`.
+
+Example for `game.win.test.ts`:
+
+```ts
+const run = createTestRun([
+    createTestStage({
+        name: 'Crystal Dash',
+        rows: ['######', '#SC.G#', '######'],
+        parMoves: 1,
+    }),
+])
+const game = new IceSlideGame({ onCrystal, onWin, onLevelClear })
+game.start(run)
+```
+
+Example for `game.hazard.test.ts`:
+
+```ts
+const run = createTestRun([
+    createTestStage({
+        name: 'Hazard Lane',
+        rows: ['#####', '#S.H#', '#G..#', '#####'],
+        parMoves: 1,
+    }),
+])
+game.start(run)
+```
+
+Keep each suite’s existing behavioral assertions.
+
+- [ ] **Step 11: Update the renderer test fixture**
+
+In `renderer.test.ts`, add these defaults to `makeState()`:
+
+```ts
+mode: 'campaign',
+runKey: 'ice-slide:campaign:g1:r1',
+runSchemaVersion: 1,
+generatorVersion: 1,
+rulesetVersion: 1,
+stagesTotal: 8,
+starsEarned: 0,
+falls: 0,
+resets: 0,
+stageSignatures: [],
+```
+
+This is a test-only fixture update. Do not modify `renderer.ts`.
+
+- [ ] **Step 12: Run the complete targeted Ice Slide suite**
+
+```bash
+bunx vitest run \
+  src/lib/games/shared/seeded-rng.test.ts \
+  src/lib/games/ice-slide/transforms.test.ts \
+  src/lib/games/ice-slide/run.test.ts \
+  src/lib/games/ice-slide/physics.test.ts \
+  src/lib/games/ice-slide/game.test.ts \
+  src/lib/games/ice-slide/game.win.test.ts \
+  src/lib/games/ice-slide/game.hazard.test.ts \
+  src/lib/games/ice-slide/game.crystal-farm.test.ts \
+  src/lib/games/ice-slide/game.crystal-hazard-farm.test.ts \
+  src/lib/games/ice-slide/renderer.test.ts
+```
+
+Expected: PASS with no `./levels` mocks remaining in the four branch suites.
+
+- [ ] **Step 13: Run repository-wide verification**
+
+```bash
+bun run test:run
+bun run typecheck
+bun run lint
+bun run format:check
+```
+
+Expected:
+- Vitest exits with zero failed tests.
+- Astro typecheck exits successfully.
+- ESLint exits with no errors.
+- Prettier check reports all files formatted.
+
+- [ ] **Step 14: Verify unchanged boundaries**
+
+Run:
+
+```bash
+git diff --name-only origin/main...HEAD
+git diff origin/main...HEAD -- \
+  src/lib/challenges.ts \
+  src/lib/games/ice-slide/levels.ts \
+  src/lib/games/ice-slide/scoring.ts \
+  src/lib/games/ice-slide/init.ts \
+  src/lib/games/ice-slide/renderer.ts \
+  src/lib/games/shared/types.ts \
+  src/lib/achievements.ts
+```
+
+Expected:
+- the first command lists only files from the plan’s New/Modified sections;
+- the second command prints no diff.
+
+Also run:
+
+```bash
+rg "vi\.mock\('./levels'" src/lib/games/ice-slide
+rg "Math\.random" \
+  src/lib/games/shared/seeded-rng.ts \
+  src/lib/games/ice-slide/run.ts \
+  src/lib/games/ice-slide/transforms.ts
+```
+
+Expected:
+- no remaining `./levels` mocks in Ice Slide branch tests;
+- no `Math.random` references in deterministic modules.
+
+- [ ] **Step 15: Commit the game migration**
+
+```bash
+git add \
+  src/lib/games/ice-slide/test-fixtures.ts \
+  src/lib/games/ice-slide/game.ts \
+  src/lib/games/ice-slide/game.test.ts \
+  src/lib/games/ice-slide/game.win.test.ts \
+  src/lib/games/ice-slide/game.hazard.test.ts \
+  src/lib/games/ice-slide/game.crystal-farm.test.ts \
+  src/lib/games/ice-slide/game.crystal-hazard-farm.test.ts \
+  src/lib/games/ice-slide/renderer.test.ts
+git commit -m "refactor(ice-slide): consume explicit run definitions"
+```
+
+---
+
+## Final Review Checklist
+
+Before marking HPA-485 implementation complete, verify each design requirement against the implementation:
+
+- [ ] FNV-1a numeric/hex vectors match.
+- [ ] `createSeededRng()` uses `hashString32(seedKey)` as initial Mulberry32 state.
+- [ ] Raw stream, `nextInt`, `pick`, shuffle, and fork vectors match.
+- [ ] Public seed keys and fork labels reject U+001F.
+- [ ] No deterministic module calls `Math.random()`.
+- [ ] All eight transforms match the rectangular fixture and coordinate table.
+- [ ] Canonical serialization rejects empty, zero-column, and jagged rows.
+- [ ] Symmetry dedup uses complete canonical keys.
+- [ ] First Frost signature is `is1-a387e186`.
+- [ ] Campaign run key is derived from Campaign-specific generator and ruleset versions.
+- [ ] Run validation enforces transport-safe mode-specific key/seed/version relationships.
+- [ ] Run validation limits stages to `1..64` and multiplier BPS to `1000..50000`.
+- [ ] Structural validation does not perform solver-quality checks.
+- [ ] `new IceSlideGame()` and default `start()` do not add a new structural-validation throw path.
+- [ ] Invalid explicit starts throw before changing state or starting a timer.
+- [ ] Campaign content, order, names, pars, scoring, completion, and partial-End behavior remain unchanged.
+- [ ] State rebuilds preserve full-run signatures, metadata, and zero counters.
+- [ ] `getState()` and `getGameData()` copy signature arrays.
+- [ ] Existing achievement fields remain present.
+- [ ] HPA-487 follow-up gates are documented but not implemented here.
+- [ ] `init.ts`, renderer implementation, scoring, levels, platform challenges, achievements, and shared type re-export remain untouched.
+- [ ] Full tests, typecheck, lint, and formatting checks pass.
+
+## Execution Handoff
+
+Plan implementation options:
+
+1. **Subagent-Driven (recommended)** — use `superpowers:subagent-driven-development`, dispatch one fresh subagent per task, and review each task before moving on.
+2. **Inline Execution** — use `superpowers:executing-plans`, execute the four tasks in order with checkpoints after each commit.

--- a/docs/superpowers/plans/2026-08-02-deterministic-ice-slide-runs.md
+++ b/docs/superpowers/plans/2026-08-02-deterministic-ice-slide-runs.md
@@ -1071,7 +1071,7 @@ describe('Ice Slide run versions and signatures', () => {
                 objectiveIds: [],
                 scoreMultiplierBps: 10000,
             })
-        ).toBe('is2-68616e2d')
+        ).toBe('is2-d1feaba1')
     })
 })
 ```
@@ -1121,7 +1121,7 @@ export function createIceSlideStageSignature(input: {
         `rows=${serializeBoardRows(input.rows)}`,
         `parMoves=${input.parMoves}`,
         `transform=${input.transform}`,
-        `mutationIds=${sortedMutationIds.join(',')}`,
+        `mutationIds=${JSON.stringify(sortedMutationIds)}`,
         `difficulty=${input.difficulty}`,
         `objectiveIds=${sortedObjectiveIds.join(',')}`,
         `scoreMultiplierBps=${input.scoreMultiplierBps}`,
@@ -2086,7 +2086,7 @@ Before marking HPA-485 implementation complete, verify each design requirement a
 - [ ] All eight transforms match the rectangular fixture and coordinate table.
 - [ ] Canonical serialization rejects empty, zero-column, and jagged rows.
 - [ ] Symmetry dedup uses complete canonical keys.
-- [ ] First Frost signature is `is2-68616e2d`.
+- [ ] First Frost signature is `is2-d1feaba1`.
 - [ ] Campaign run key is derived from Campaign-specific generator and ruleset versions.
 - [ ] Run validation enforces transport-safe mode-specific key/seed/version relationships.
 - [ ] Run validation limits stages to `1..64` and multiplier BPS to `1000..50000`.

--- a/docs/superpowers/specs/2026-08-02-deterministic-ice-slide-runs-design.md
+++ b/docs/superpowers/specs/2026-08-02-deterministic-ice-slide-runs-design.md
@@ -1,0 +1,1247 @@
+# Deterministic Ice Slide Runs — Design Spec
+
+- **Linear issue:** [HPA-485 — Introduce deterministic Ice Slide run definitions, seeded RNG, and board transforms](https://linear.app/cwchanap/issue/HPA-485/introduce-deterministic-ice-slide-run-definitions-seeded-rng-and-board)
+- **Parent roadmap:** [HPA-483 — Ice Slide replayability](https://linear.app/cwchanap/issue/HPA-483/ice-slide-replayability-daily-challenge-seeded-expedition-and-evolving)
+- **Parent requirements:** [Ice Slide replayability design](https://github.com/cwchanap/cetus/blob/docs/ice-slide-replayability-spec/docs/superpowers/specs/2026-07-30-ice-slide-replayability-design.md)
+- **Date:** 2026-08-02
+- **Status:** Draft for review
+
+## 1. Summary
+
+Ice Slide currently treats its checked-in `ICE_SLIDE_LEVELS` array as both authored
+content and the active run. `IceSlideGame` selects levels directly from that array,
+which is sufficient for the fixed Campaign but does not provide a stable boundary for
+Daily Challenge or Expedition runs.
+
+This design introduces that boundary in four parts:
+
+1. A dependency-free deterministic RNG with stable string hashing, bounded integer
+   selection, deterministic pick/shuffle behavior, and independent labeled forks.
+2. Pure utilities for all eight rotations/reflections of a rectangular board.
+3. Versioned materialized run and stage contracts with canonical board hashes and
+   stable stage signatures.
+4. A Campaign adapter that materializes the existing eight levels, followed by a
+   refactor of `IceSlideGame` to consume an explicit run while keeping `start()` with
+   no argument behavior-compatible with the current Campaign.
+
+The key architectural decision is that **generation finishes before gameplay starts**.
+A run contains final rows, par values, objectives, multipliers, and signatures. The
+game engine consumes this snapshot; it never reads a date, chooses a transform, or
+makes a random selection.
+
+## 2. Problem
+
+The current implementation has useful module boundaries but no run abstraction:
+
+- `levels.ts` owns the eight authored Campaign levels.
+- `physics.ts` parses rows and resolves slides.
+- `game.ts` directly imports `getLevel()` and `ICE_SLIDE_LEVELS` for loading,
+  progression, scoring, and completion.
+- `init.ts` calls `game.start()` and preserves the existing Campaign partial-End and
+  score-submission behavior.
+- Several branch tests replace `./levels` with module-level mocks to force a one-stage
+  board.
+
+This creates three constraints for replayable modes:
+
+1. A generated or selected run cannot be passed into the game as data.
+2. Random/date selection could become entangled with gameplay and retry behavior.
+3. Future work would need to keep revisiting `game.ts` as Daily and Expedition add
+   generation rules.
+
+The deterministic primitives also need explicit compatibility guarantees. A seed is a
+long-lived identifier: changing its hash, stream, bounded-selection algorithm, pick or
+shuffle draw pattern, transform ordering, fork semantics, canonical serialization, or
+signature preimage would silently change historical runs. Those details therefore need
+versioned, golden-tested contracts rather than incidental helper implementations.
+
+## 3. Goals
+
+1. Define versioned Ice Slide mode, run, stage, transform, objective-ID, and signature
+   contracts.
+2. Provide a stable integer-only seeded RNG with deterministic string hashing,
+   unbiased bounded integers, deterministic pick/shuffle behavior, independent labeled
+   streams, and no `Math.random()` dependency.
+3. Support all eight dihedral transforms for row grids and coordinates, including
+   rectangular boards whose dimensions swap on quarter turns and diagonal
+   reflections.
+4. Provide canonical row serialization, compact board hashes, inverse transforms, and
+   collision-safe symmetric-output deduplication.
+5. Materialize the current eight authored levels as a Campaign run without changing
+   rows, order, names, pars, scoring, completion, or partial-End semantics.
+6. Make `IceSlideGame` consume a complete run snapshot while preserving `start()` as
+   the existing Campaign entry point.
+7. Extend state and current-write game data additively with run identity/version
+   metadata and zero-valued counters required by later replayability work.
+8. Keep RNG, transforms, signatures, and run construction pure and reusable without
+   DOM, Pixi, database, network, storage, or date dependencies.
+
+## 4. Non-goals
+
+This issue does not implement:
+
+- Daily stage selection, UTC date capture, mode selection UI, objectives UI, Daily
+  scoring, or Daily submission gating.
+- Production solver extraction or generated-stage quality validation.
+- Mutation templates, bounded Expedition generation, fallbacks, or Expedition UI.
+- Score-context persistence or scoped leaderboard queries.
+- Snow, cracked ice, route choices, Undo, or other evolving mechanics.
+- `routeChoices` or `undoChargesUsed` fields from the parent design; evolving-mechanics
+  work introduces them when their runtime meaning exists.
+- Any change to the existing platform Daily Challenge rotation in
+  `src/lib/challenges.ts`.
+- A migration of Ice Slide to the generic `BaseGame` framework. The existing
+  handle-based architecture remains intentional.
+
+## 5. Design principles
+
+### 5.1 Materialize before play
+
+A generator or adapter produces an `IceSlideRunDefinition` containing final stage rows.
+`IceSlideGame` only interprets the supplied data. This separation makes retries exact,
+keeps date/random logic out of the runtime loop, and gives downstream work a stable
+input contract.
+
+### 5.2 Compatibility is additive
+
+Existing state fields, callbacks, achievement data, scoring functions, and UI behavior
+remain available. New fields are added rather than replacing `levelIndex`,
+`levelName`, `levelsCleared`, or `perfectLevels` with stage-oriented names.
+
+### 5.3 Determinism is an API
+
+The hash algorithm, seed-to-state mapping, PRNG algorithm, bounded-integer algorithm,
+pick draw pattern, shuffle direction/draw pattern, transform order, transform labels,
+canonical row format, signature preimage, signature format, and fork derivation are
+observable behavior. Golden tests lock them.
+
+Generator versions are **per materializer/mode**, not one global counter shared by all
+modes. A future RNG or Expedition-generation change increments the versions of modes
+whose output can change; it does not change the fixed Campaign version or run key when
+Campaign materialization is unaffected.
+
+### 5.4 Compact hashes are identifiers, not equality proofs
+
+A 32-bit hash is sufficient for compact metadata, but it is not used as the sole
+equality key. Board deduplication stores complete canonical row serialization, so a
+hash collision cannot incorrectly remove a distinct board. Stage signatures are also
+compact identifiers rather than uniqueness or security proofs.
+
+## 6. Versioned contracts
+
+Add the following contracts to `src/lib/games/ice-slide/types.ts`:
+
+```ts
+export type IceSlideMode = 'campaign' | 'daily' | 'expedition'
+
+export type IceSlideDifficulty =
+    | 'tutorial'
+    | 'easy'
+    | 'medium'
+    | 'hard'
+
+export type IceSlideObjectiveId =
+    | 'collect_all_crystals'
+    | 'no_falls'
+    | 'no_reset'
+
+export type BoardTransform =
+    | 'identity'
+    | 'rotate_90'
+    | 'rotate_180'
+    | 'rotate_270'
+    | 'reflect_horizontal'
+    | 'reflect_vertical'
+    | 'reflect_main_diagonal'
+    | 'reflect_anti_diagonal'
+
+export interface IceSlideRunDefinition {
+    schemaVersion: 1
+    generatorVersion: number
+    rulesetVersion: number
+    mode: IceSlideMode
+    runKey: string
+    seed: string | null
+    stages: IceSlideStageDefinition[]
+}
+
+export interface IceSlideStageDefinition {
+    id: string
+    name: string
+    templateId: string
+    difficulty: IceSlideDifficulty
+    rows: string[]
+    parMoves: number
+    transform: BoardTransform
+    mutationIds: string[]
+    objectiveIds: IceSlideObjectiveId[]
+    scoreMultiplierBps: number
+    signature: string
+}
+```
+
+`scoreMultiplierBps` is an integer basis-point representation of a unit multiplier:
+
+```text
+10000 = 1.00×
+12500 = 1.25×
+```
+
+HPA-485 transports and signs this value but does not apply it to Campaign scoring.
+Structural validation accepts `1000..50000` inclusive (`0.10×..5.00×`). This keeps
+future authored values within a deliberate scoring range and prevents nonsensical or
+overflow-prone multipliers from entering materialized runs.
+
+### 6.1 Version meanings
+
+- `schemaVersion` changes only when the serialized run/stage shape is no longer
+  compatible.
+- `generatorVersion` belongs to the run's materializer. It changes whenever the same
+  mode-specific seed and inputs can materialize a different run.
+- `rulesetVersion` changes whenever physics, objective interpretation, or scoring
+  changes competitive meaning.
+
+Initial HPA-485 constants are:
+
+```ts
+export const ICE_SLIDE_RUN_SCHEMA_VERSION = 1 as const
+export const ICE_SLIDE_CAMPAIGN_GENERATOR_VERSION = 1
+export const ICE_SLIDE_RULESET_VERSION = 1
+
+export const CAMPAIGN_RUN_KEY =
+    `ice-slide:campaign:` +
+    `g${ICE_SLIDE_CAMPAIGN_GENERATOR_VERSION}:` +
+    `r${ICE_SLIDE_RULESET_VERSION}`
+```
+
+The initial golden Campaign key is:
+
+```text
+ice-slide:campaign:g1:r1
+```
+
+Daily and Expedition add their own generator-version constants. Changing their RNG,
+selection pools, mutation logic, or fallback behavior does not bump
+`ICE_SLIDE_CAMPAIGN_GENERATOR_VERSION` unless the fixed Campaign adapter output changes.
+
+### 6.2 Objective-ID evolution
+
+`IceSlideObjectiveId` is a closed serialized contract, not an open string bag.
+
+- Adding an objective ID is a type/contract change.
+- If generated runs begin emitting it, increment that mode's `generatorVersion`.
+- If the interpretation of an existing objective ID changes, increment
+  `rulesetVersion`.
+- A schema-version bump is needed only when the serialized shape changes.
+
+### 6.3 Run-key formats and cross-field validation
+
+Run keys are transport-safe identifiers compatible with score-context competition keys:
+
+```ts
+const RUN_KEY_PATTERN = /^[A-Za-z0-9:._-]+$/
+const RUN_KEY_MAX_LENGTH = 128
+```
+
+Every run key must:
+
+- be `1..128` characters;
+- match `RUN_KEY_PATTERN`;
+- start with the exact prefix for its mode;
+- end in `:g<generatorVersion>:r<rulesetVersion>` whose integers exactly match the
+  run fields.
+
+Per-mode formats are:
+
+```text
+Campaign:
+ice-slide:campaign:g<generatorVersion>:r<rulesetVersion>
+
+Daily:
+ice-slide:daily:YYYY-MM-DD:g<generatorVersion>:r<rulesetVersion>
+
+Expedition:
+ice-slide:expedition:<seedHash>:g<generatorVersion>:r<rulesetVersion>
+```
+
+Additional relationships:
+
+- Campaign key must equal `CAMPAIGN_RUN_KEY` and `seed` must be `null`.
+- Daily `seed` must equal
+  `ice-slide:daily:<generatorVersion>:<rulesetVersion>:YYYY-MM-DD`, using the same date
+  captured in the run key.
+- Expedition `seed` must be non-empty and contain no U+001F. `<seedHash>` must equal
+  `hashString32Hex(seed)`.
+
+The Expedition hash is compact routing metadata, not sole identity. Complete identity
+still includes mode, key, explicit versions, and ordered stage signatures.
+
+## 7. Stable seeded RNG
+
+Create `src/lib/games/shared/seeded-rng.ts`. It is generic enough for other level-based
+games but does not replace the existing platform challenge rotation.
+
+### 7.1 Public API
+
+```ts
+export interface SeededRng {
+    nextUint32(): number
+    nextFloat(): number
+    nextInt(maxExclusive: number): number
+    pick<T>(items: readonly T[]): T
+    shuffle<T>(items: readonly T[]): T[]
+    fork(label: string): SeededRng
+}
+
+export function hashString32(value: string): number
+export function hashString32Hex(value: string): string
+export function createSeededRng(seedKey: string): SeededRng
+```
+
+### 7.2 String hashing
+
+Use FNV-1a over JavaScript UTF-16 code units:
+
+```ts
+export function hashString32(value: string): number {
+    let hash = 0x811c9dc5
+    for (let index = 0; index < value.length; index++) {
+        hash ^= value.charCodeAt(index)
+        hash = Math.imul(hash, 0x01000193)
+    }
+    return hash >>> 0
+}
+```
+
+Locked vector:
+
+```text
+hashString32('ice-slide:test') = 2769670846
+hashString32Hex('ice-slide:test') = a515d2be
+```
+
+### 7.3 Seed validation, seed-to-state mapping, and Mulberry32
+
+The public `createSeededRng(seedKey)` rejects an empty seed key or a key containing the
+reserved U+001F fork-path separator. This prevents a top-level seed such as
+`a\u001fb` from colliding with the nested path `createSeededRng('a').fork('b')`.
+
+The exact initial-state rule is:
+
+```ts
+initial state = hashString32(seedKey)
+```
+
+Use this Mulberry32 reference implementation:
+
+```ts
+function createSeededRng(seedKey: string): SeededRng {
+    assertSeedSegment(seedKey, 'seedKey')
+    return createSeededRngFromPath(seedKey)
+}
+
+function createSeededRngFromPath(seedPath: string): SeededRng {
+    let state = hashString32(seedPath)
+
+    const nextUint32 = (): number => {
+        state = (state + 0x6d2b79f5) >>> 0
+        let value = state
+        value = Math.imul(value ^ (value >>> 15), value | 1)
+        value ^=
+            value + Math.imul(value ^ (value >>> 7), value | 61)
+        return (value ^ (value >>> 14)) >>> 0
+    }
+
+    // nextFloat, nextInt, pick, shuffle, and fork close over this stream.
+    // fork uses createSeededRngFromPath so the internal separator is allowed.
+}
+```
+
+The first five `nextUint32()` values for a **fresh**
+`createSeededRng('ice-slide:test')` are:
+
+```text
+1843037723
+574486829
+1018436590
+1120027984
+770965377
+```
+
+`nextFloat()` divides the unsigned output by `2^32`, producing `[0, 1)`.
+
+### 7.4 Bounded integer selection
+
+`nextInt(maxExclusive)` accepts integer bounds from `1` through `2^31 - 1` inclusive.
+Use this exact rejection-sampling algorithm:
+
+```ts
+function nextInt(maxExclusive: number): number {
+    if (
+        !Number.isInteger(maxExclusive) ||
+        maxExclusive < 1 ||
+        maxExclusive > 0x7fffffff
+    ) {
+        throw new RangeError(
+            'maxExclusive must be an integer from 1 through 2147483647'
+        )
+    }
+
+    const range = 0x1_0000_0000
+    const limit = Math.floor(range / maxExclusive) * maxExclusive
+
+    let value: number
+    do {
+        value = nextUint32()
+    } while (value >= limit)
+
+    return value % maxExclusive
+}
+```
+
+`range` and `limit` are ordinary JavaScript numbers and must not be coerced through a
+bitwise operation.
+
+Each locked example below starts from a **separate fresh RNG**:
+
+```text
+createSeededRng('ice-slide:test').nextInt(1) = 0
+
+const rng = createSeededRng('ice-slide:test')
+five consecutive rng.nextInt(7) values = 2, 0, 3, 5, 0
+```
+
+The `nextInt(7)` sequence is not measured after consuming the `nextInt(1)` example.
+
+### 7.5 Deterministic pick
+
+`pick()` consumes exactly one `nextInt(items.length)` draw and returns that element:
+
+```ts
+function pick<T>(items: readonly T[]): T {
+    if (items.length === 0) {
+        throw new RangeError('Cannot pick from an empty array')
+    }
+    return items[nextInt(items.length)]
+}
+```
+
+A one-item pick still consumes one `nextInt(1)` draw. This draw pattern is observable
+generator behavior.
+
+Locked vector from a fresh RNG:
+
+```text
+createSeededRng('ice-slide:test')
+    .pick(['A', 'B', 'C', 'D', 'E'])
+= 'D'
+```
+
+### 7.6 Deterministic shuffle
+
+`shuffle()` returns a new array and leaves its input unchanged. It uses descending
+Fisher–Yates with one bounded draw per iteration:
+
+```ts
+function shuffle<T>(items: readonly T[]): T[] {
+    const result = [...items]
+    for (let index = result.length - 1; index > 0; index--) {
+        const swapIndex = nextInt(index + 1)
+        ;[result[index], result[swapIndex]] = [
+            result[swapIndex],
+            result[index],
+        ]
+    }
+    return result
+}
+```
+
+Locked vector from a fresh RNG:
+
+```text
+createSeededRng('ice-slide:test')
+    .shuffle(['A', 'B', 'C', 'D', 'E'])
+= ['C', 'A', 'E', 'B', 'D']
+```
+
+### 7.7 Labeled forks
+
+A fork is derived from the immutable seed path, not from the parent's draw position:
+
+```text
+child path = parent path + U+001F + label
+```
+
+`fork(label)` rejects empty labels and labels containing U+001F, then calls the internal
+`createSeededRngFromPath(childPath)` helper. It does not call the public top-level
+seed validator on the combined path.
+
+Consequences:
+
+- Calling `fork('stage:1')` before or after parent draws produces the same stream.
+- A new choice inside `stage:1` does not perturb `stage:2`.
+- Nested labels form stable paths.
+- Separate child instances do not share mutable state.
+
+Locked first outputs from separate fresh parents:
+
+```text
+createSeededRng('ice-slide:test').fork('stage:1').nextUint32()
+= 694760629
+
+createSeededRng('ice-slide:test').fork('stage:2').nextUint32()
+= 2216382472
+```
+
+### 7.8 Existing platform rotation remains isolated
+
+`src/lib/challenges.ts` currently uses its own date hash and `Math.sin` helper. HPA-485
+does not import, replace, or refactor it. Its output remains byte-for-byte compatible.
+
+## 8. Board transforms
+
+Create `src/lib/games/ice-slide/transforms.ts`. All row transformations are defined by
+one coordinate mapping rather than eight independent row-manipulation implementations.
+This keeps row and named-coordinate behavior aligned.
+
+### 8.1 Transform order
+
+```ts
+export const BOARD_TRANSFORMS = [
+    'identity',
+    'rotate_90',
+    'rotate_180',
+    'rotate_270',
+    'reflect_horizontal',
+    'reflect_vertical',
+    'reflect_main_diagonal',
+    'reflect_anti_diagonal',
+] as const
+```
+
+This order is generator behavior and is golden-tested.
+
+### 8.2 Naming
+
+- `reflect_horizontal`: reflect across the horizontal axis; swap top/bottom rows.
+- `reflect_vertical`: reflect across the vertical axis; swap left/right columns.
+- `reflect_main_diagonal`: top-left to bottom-right diagonal.
+- `reflect_anti_diagonal`: top-right to bottom-left diagonal.
+
+### 8.3 Coordinate mappings
+
+For input dimensions `R × C`:
+
+| Transform | Output dimensions | Input `(row, col)` maps to |
+| --- | --- | --- |
+| `identity` | `R × C` | `(row, col)` |
+| `rotate_90` | `C × R` | `(col, R - 1 - row)` |
+| `rotate_180` | `R × C` | `(R - 1 - row, C - 1 - col)` |
+| `rotate_270` | `C × R` | `(C - 1 - col, row)` |
+| `reflect_horizontal` | `R × C` | `(R - 1 - row, col)` |
+| `reflect_vertical` | `R × C` | `(row, C - 1 - col)` |
+| `reflect_main_diagonal` | `C × R` | `(col, row)` |
+| `reflect_anti_diagonal` | `C × R` | `(C - 1 - col, R - 1 - row)` |
+
+For:
+
+```text
+ABC
+DEF
+```
+
+expected rows are:
+
+| Transform | Rows |
+| --- | --- |
+| `identity` | `ABC`, `DEF` |
+| `rotate_90` | `DA`, `EB`, `FC` |
+| `rotate_180` | `FED`, `CBA` |
+| `rotate_270` | `CF`, `BE`, `AD` |
+| `reflect_horizontal` | `DEF`, `ABC` |
+| `reflect_vertical` | `CBA`, `FED` |
+| `reflect_main_diagonal` | `AD`, `BE`, `CF` |
+| `reflect_anti_diagonal` | `FC`, `EB`, `DA` |
+
+### 8.4 APIs and inverses
+
+```ts
+export function transformRows(
+    rows: readonly string[],
+    transform: BoardTransform
+): string[]
+
+export function transformPosition(
+    position: GridPosition,
+    inputRows: number,
+    inputCols: number,
+    transform: BoardTransform
+): GridPosition
+
+export function inverseBoardTransform(
+    transform: BoardTransform
+): BoardTransform
+```
+
+- `rotate_90` and `rotate_270` are inverses.
+- Every other transform is self-inverse, including `rotate_180` and both diagonal
+  reflections.
+- Transform plus inverse restores rows and named coordinates.
+
+## 9. Canonical rows and symmetric deduplication
+
+### 9.1 Shared rectangular-row validation
+
+`transformRows()` and `serializeBoardRows()` use one pure rectangular-row validator.
+It rejects:
+
+- an empty row list;
+- a zero-column first row;
+- any jagged row.
+
+This prevents malformed rows from receiving an ambiguous or incorrect canonical key.
+Glyph validation remains a separate concern owned by run parsing/validation.
+
+### 9.2 Serialization
+
+Canonical serialization is:
+
+```text
+<rowCount>x<columnCount> U+001F <row0> U+001E <row1> ...
+```
+
+Example:
+
+```text
+['AB', 'CD'] -> 2x2\u001fAB\u001eCD
+```
+
+```ts
+export function serializeBoardRows(rows: readonly string[]): string
+export function hashBoardRows(rows: readonly string[]): string
+```
+
+`hashBoardRows()` returns the lowercase eight-character FNV-1a hex hash of the exact
+serialization.
+
+### 9.3 Unique transformed variants
+
+```ts
+export interface TransformedBoardVariant {
+    transform: BoardTransform
+    rows: string[]
+    canonicalKey: string
+    hash: string
+}
+
+export function getUniqueBoardTransforms(
+    rows: readonly string[]
+): TransformedBoardVariant[]
+```
+
+Evaluate transforms in `BOARD_TRANSFORMS` order and retain the first transform producing
+each complete canonical serialization. Store `canonicalKey`, not the compact hash, in
+the deduplication set.
+
+## 10. Stage signatures and competitive identity
+
+A stage signature identifies materialized playable content. It does not by itself prove
+uniqueness or provide the ruleset interpretation.
+
+Competitive identity uses:
+
+```text
+mode + runKey + generatorVersion + rulesetVersion + ordered stageSignatures
+```
+
+Consumers must not compare or rank results by an individual signature or signature list
+alone.
+
+### 10.1 Included fields
+
+The signature includes:
+
+- final canonical rows;
+- `parMoves`;
+- sorted `objectiveIds`;
+- `scoreMultiplierBps`.
+
+It excludes display name, stage ID, template ID, transform label, and mutation IDs. Two
+generation paths producing the same playable content receive the same signature.
+
+### 10.2 Exact preimage and public format
+
+Use U+001D as the field separator. Canonical rows retain U+001F/U+001E:
+
+```ts
+const sortedObjectiveIds = [...objectiveIds].sort()
+const payload = [
+    'ice-slide-stage:v1',
+    `rows=${serializeBoardRows(rows)}`,
+    `parMoves=${parMoves}`,
+    `objectiveIds=${sortedObjectiveIds.join(',')}`,
+    `scoreMultiplierBps=${scoreMultiplierBps}`,
+].join('\u001d')
+
+const signature = `is1-${hashString32Hex(payload)}`
+```
+
+The labels, order, separators, empty-objective representation, decimal numeric
+representation, and sorting are observable generator behavior.
+
+For First Frost:
+
+```ts
+rows = ['#####', '#S..#', '#...#', '#G..#', '#####']
+parMoves = 1
+objectiveIds = []
+scoreMultiplierBps = 10000
+```
+
+Exact preimage:
+
+```text
+ice-slide-stage:v1\u001drows=5x5\u001f#####\u001e#S..#\u001e#...#\u001e#G..#\u001e#####\u001dparMoves=1\u001dobjectiveIds=\u001dscoreMultiplierBps=10000
+```
+
+Golden signature:
+
+```text
+is1-a387e186
+```
+
+## 11. Campaign materialization
+
+Create `src/lib/games/ice-slide/run.ts`. `levels.ts` remains the unchanged source of
+Campaign content.
+
+### 11.1 Campaign adapter
+
+```ts
+export function createCampaignRunDefinition(): IceSlideRunDefinition
+```
+
+The adapter returns a fresh defensive snapshot:
+
+```ts
+{
+    schemaVersion: ICE_SLIDE_RUN_SCHEMA_VERSION,
+    generatorVersion: ICE_SLIDE_CAMPAIGN_GENERATOR_VERSION,
+    rulesetVersion: ICE_SLIDE_RULESET_VERSION,
+    mode: 'campaign',
+    runKey: CAMPAIGN_RUN_KEY,
+    seed: null,
+    stages: [...],
+}
+```
+
+Stage mapping:
+
+| Existing level | Stage/template ID | Difficulty |
+| --- | --- | --- |
+| 1 | `campaign:1` | `tutorial` |
+| 2 | `campaign:2` | `easy` |
+| 3 | `campaign:3` | `easy` |
+| 4 | `campaign:4` | `medium` |
+| 5 | `campaign:5` | `medium` |
+| 6 | `campaign:6` | `medium` |
+| 7 | `campaign:7` | `hard` |
+| 8 | `campaign:8` | `hard` |
+
+Every stage preserves name, rows, and `parMoves`, with:
+
+```ts
+transform: 'identity'
+mutationIds: []
+objectiveIds: []
+scoreMultiplierBps: 10000
+```
+
+Difficulty is metadata only. HPA-487 Daily v1 uses the authored index pools from the
+parent design, not these difficulty tags.
+
+### 11.2 Structural validation and cloning
+
+```ts
+export function assertValidIceSlideRunDefinition(
+    run: IceSlideRunDefinition
+): void
+
+export function cloneIceSlideRunDefinition(
+    run: IceSlideRunDefinition
+): IceSlideRunDefinition
+```
+
+Validation covers:
+
+- schema version `1`;
+- positive signed-32-bit generator/ruleset versions;
+- mode-specific run-key format and cross-field version/seed relationships from §6.3;
+- `1..64` stages;
+- unique non-empty stage IDs;
+- recognized difficulty/transform labels;
+- non-empty rectangular rows;
+- every glyph is a key of `GLYPH_TO_CELL` in `types.ts`;
+- positive signed-32-bit `parMoves`;
+- integer `scoreMultiplierBps` in `1000..50000`;
+- unique non-empty mutation IDs;
+- unique recognized objective IDs;
+- signature exactly matching materialized stage fields.
+
+Both run validation and `physics.parseGrid()` use `GLYPH_TO_CELL`; neither maintains an
+independent glyph list.
+
+Structural validation deliberately stops before minimum-solution length, exact
+start/goal counts, objective feasibility, crystal reachability, and quality bands.
+HPA-486 owns those checks.
+
+Cloning includes rows, stage arrays, mutation IDs, objective IDs, and signatures. No
+caller-owned array remains reachable from the active game.
+
+HPA-489 owns authored mutation templates, seeded mutation choices, bounded generation,
+and `templateId`/`mutationIds` population.
+
+## 12. `IceSlideGame` integration
+
+### 12.1 Constructor and idle state
+
+The constructor creates a fresh Campaign definition and idle state but does **not** run
+the public structural assertion. The checked-in Campaign is guaranteed by exact adapter
+and validation tests. Therefore `new IceSlideGame()` introduces no new runtime throw
+path.
+
+Before first start:
+
+- `status === 'idle'`;
+- mode/key/versions match Campaign constants;
+- `stagesTotal === 8`;
+- `stageSignatures` contains all eight Campaign signatures in order;
+- score/move/crystal/clear/star/fall/reset/time counters are zero;
+- `getGameData().solved === false`.
+
+### 12.2 Start contract and error boundary
+
+```ts
+start(run?: IceSlideRunDefinition): void
+```
+
+Behavior:
+
+1. Stop any existing timer.
+2. If `run` is omitted, create a fresh known-good Campaign definition.
+3. If `run` is explicit, structurally validate and deep-clone it before mutating state.
+4. Store the active run.
+5. Create playing state and load stage zero.
+6. Start the timer and invoke callbacks in the existing order.
+
+An invalid **explicit** run throws synchronously before state mutation or timer start.
+The direct caller owns that exception boundary.
+
+HPA-485 leaves `init.ts` unchanged. Its current `game.start()` call is outside the
+renderer `try/catch`, but it only uses the no-argument checked-in Campaign path, so
+HPA-485 adds no user-supplied validation failure there. Existing checked-in level parse
+failures remain programmer errors as they are today.
+
+Before HPA-487 passes a generated Daily run through the UI handle, it must place
+`game.start(run)` inside `initializeIceSlide`'s `failRun` error boundary (or validate
+before changing button/UI state) so an invalid generated run restores controls and calls
+`onError`.
+
+Tests lock that construction/default start do not throw and invalid explicit starts
+throw without changing the prior state.
+
+### 12.3 Stage loading, state rebuilds, and progression
+
+`game.ts` no longer imports `getLevel()` or `ICE_SLIDE_LEVELS`. It loads:
+
+```ts
+this.activeRun.stages[index]
+```
+
+Legacy public names remain:
+
+- `levelIndex` is the stage index;
+- `levelName` is the stage name;
+- `onLevelClear(levelNumber)` remains one-based;
+- `levelsCleared` remains cumulative.
+
+Completion compares with `activeRun.stages.length`.
+
+Every state construction/rebuild—constructor, start, stage advance, manual Reset, and
+hazard reload—carries:
+
+```text
+mode
+runKey
+runSchemaVersion
+generatorVersion
+rulesetVersion
+stagesTotal
+starsEarned
+falls
+resets
+stageSignatures
+```
+
+`stageSignatures` is always the ordered list for the complete run, never only cleared
+stages.
+
+`starsEarned` means the cumulative number of stage stars earned in the active run.
+HPA-485 initializes and preserves it as zero because Campaign has no star evaluation.
+HPA-487 defines the Clear/Efficient/Bonus star rules and increments it. `falls` and
+`resets` are likewise initialized/preserved here and incremented by HPA-487.
+
+### 12.4 Scoring boundary
+
+HPA-485 does not expose Daily or Expedition. The game keeps existing `levelScore()` and
+`timeBonus()` behavior using stage position, par, moves, and crystals. It does not apply
+`scoreMultiplierBps`; every Campaign stage is `10000`.
+
+`scoring.ts` remains unchanged.
+
+### 12.5 State and game data
+
+Add to both `IceSlideState` and current-write `IceSlideGameData`:
+
+```ts
+mode: IceSlideMode
+runKey: string
+runSchemaVersion: 1
+generatorVersion: number
+rulesetVersion: number
+stagesTotal: number
+starsEarned: number
+falls: number
+resets: number
+stageSignatures: string[]
+```
+
+Existing fields remain unchanged:
+
+```ts
+levelsCleared
+totalMoves
+crystalsCollected
+elapsedSeconds
+solved
+perfectLevels
+```
+
+These new fields remain in HPA-485 because the issue explicitly requires additive
+state/game-data output. Their persistence behavior is narrower than the TypeScript
+shape:
+
+- Current Campaign submissions are unscoped and pass no score context, so the API uses
+  game data transiently for achievements but does not persist `gameDataJson`.
+- HPA-487 contextual Daily submissions persist game data with score context.
+- Historical persisted rows may lack these fields. Readers must treat them as optional
+  on read and normalize by schema/version; they are required on new writes from the
+  updated game.
+- The score API's 16 KiB game-data cap applies only when context is present. Daily has
+  five signatures and Expedition six; the structural maximum of 64 stages keeps the
+  signature list safely bounded for future contextual writes.
+
+`getState()` and `getGameData()` return copied signature arrays.
+
+`src/lib/games/shared/types.ts` re-exports the canonical Ice Slide type. Additive fields
+require no edit there; removal/renaming of existing fields would be breaking.
+
+### 12.6 Achievement compatibility
+
+HPA-485 exposes only Campaign, so existing achievements continue to receive their
+current fields and meanings.
+
+The existing `ice_slide_complete` condition (`solved && levelsCleared === 8`) is only
+semantically correct for Campaign. Before HPA-487 exposes other modes, legacy Ice Slide
+achievements that describe Campaign levels—including completion and any use of
+`perfectLevels`—must be explicitly gated with `mode === 'campaign'` or replaced with
+mode-specific achievements. An eight-stage non-Campaign run must not unlock “Clear all
+8 Ice Slide levels,” and a shorter Daily must not be permanently ineligible because of
+Campaign-specific counts.
+
+### 12.7 Reset, hazard, stop, and completion compatibility
+
+No Campaign semantics change:
+
+- blocked moves remain no-ops;
+- manual Reset clears attempt crystals and stage moves while preserving run score/time
+  and run metadata;
+- hazard reset keeps the failed move count and cannot farm crystals;
+- Campaign completion keeps the 360-second time bonus;
+- `stop()` changes playing to idle;
+- `init.ts` still submits a positive partial Campaign score on End;
+- existing achievement fields remain available.
+
+## 13. Physics parsing compatibility
+
+Narrow parsing to what it consumes:
+
+```ts
+interface IceSlideGridSource {
+    id: string | number
+    rows: readonly string[]
+}
+```
+
+`parseGrid()` preserves the same validation categories and error-message templates, and
+continues to use `GLYPH_TO_CELL`. Interpolated identifiers may now be strings, so the
+rendered message changes from e.g. `Level 3 ...` to `Level campaign:3 ...`; the spec
+does not require byte-identical rendered text for different input IDs.
+
+## 14. Test migration and coverage
+
+### 14.1 RNG tests
+
+Lock:
+
+- FNV numeric/hex vectors;
+- exact string-to-state mapping and five Mulberry32 outputs;
+- top-level empty/U+001F seed rejection;
+- parent/fork independence and label rejection;
+- `nextFloat()` range;
+- fresh-RNG `nextInt(1)` and `nextInt(7)` vectors;
+- upper bound/invalid bound behavior and no bitwise limit coercion;
+- exact `pick()` draw behavior, empty rejection, one-item draw, and `'D'` vector;
+- descending Fisher–Yates vector and immutability;
+- no `Math.random()` calls.
+
+### 14.2 Transform/canonicalization tests
+
+Cover:
+
+- all eight rectangular outputs;
+- coordinate/glyph alignment;
+- dimension swaps and inverse round trips;
+- empty/zero-column/jagged rejection in both transform and serialization APIs;
+- canonical boundary/dimension distinctions;
+- one/two/four/eight symmetry variants;
+- first-transform retention.
+
+### 14.3 Run construction tests
+
+Prove:
+
+- exact eight-stage Campaign content;
+- per-mode generator constants and stable Campaign key;
+- run-key transport pattern, length, prefixes, version suffixes, Daily seed/date
+  relationship, and Expedition seed hash;
+- exact First Frost signature/preimage;
+- signature order independence and semantic sensitivity;
+- defensive cloning;
+- stage-count and multiplier bounds;
+- shared `GLYPH_TO_CELL` acceptance;
+- structural invalid fixtures fail descriptively.
+
+### 14.4 Game integration tests
+
+Prove:
+
+- constructor and default start do not throw;
+- idle getters expose complete Campaign metadata and zero counters;
+- invalid explicit start throws before state mutation;
+- explicit run length/progression works;
+- caller mutation cannot affect active state;
+- every rebuild preserves complete run metadata/signatures/counters;
+- existing win/hazard/reset/crystal/timer/stop behavior remains green;
+- branch tests use explicit fixtures rather than `vi.mock('./levels')`;
+- renderer fixture supplies required additive fields.
+
+### 14.5 Future HPA-487 gates
+
+HPA-487 tests must additionally prove:
+
+- explicit generated start errors flow through `failRun` and restore controls;
+- legacy achievements are Campaign-gated;
+- contextual game-data writes fit the 16 KiB cap;
+- Daily run key and seed satisfy the HPA-485 validator.
+
+### 14.6 Repository verification
+
+```bash
+bunx vitest run \
+  src/lib/games/shared/seeded-rng.test.ts \
+  src/lib/games/ice-slide/transforms.test.ts \
+  src/lib/games/ice-slide/run.test.ts \
+  src/lib/games/ice-slide/physics.test.ts \
+  src/lib/games/ice-slide/game.test.ts \
+  src/lib/games/ice-slide/game.win.test.ts \
+  src/lib/games/ice-slide/game.hazard.test.ts \
+  src/lib/games/ice-slide/game.crystal-farm.test.ts \
+  src/lib/games/ice-slide/game.crystal-hazard-farm.test.ts \
+  src/lib/games/ice-slide/renderer.test.ts
+
+bun run test:run
+bun run typecheck
+bun run lint
+bun run format:check
+```
+
+## 15. File boundaries
+
+### New
+
+```text
+src/lib/games/shared/seeded-rng.ts
+src/lib/games/shared/seeded-rng.test.ts
+src/lib/games/ice-slide/transforms.ts
+src/lib/games/ice-slide/transforms.test.ts
+src/lib/games/ice-slide/run.ts
+src/lib/games/ice-slide/run.test.ts
+src/lib/games/ice-slide/test-fixtures.ts
+```
+
+### Modified
+
+```text
+src/lib/games/ice-slide/types.ts
+src/lib/games/ice-slide/physics.ts
+src/lib/games/ice-slide/physics.test.ts
+src/lib/games/ice-slide/game.ts
+src/lib/games/ice-slide/game.test.ts
+src/lib/games/ice-slide/game.win.test.ts
+src/lib/games/ice-slide/game.hazard.test.ts
+src/lib/games/ice-slide/game.crystal-farm.test.ts
+src/lib/games/ice-slide/game.crystal-hazard-farm.test.ts
+src/lib/games/ice-slide/renderer.test.ts
+```
+
+### Explicitly unchanged in HPA-485
+
+```text
+src/lib/challenges.ts
+src/lib/games/ice-slide/levels.ts
+src/lib/games/ice-slide/scoring.ts
+src/lib/games/ice-slide/init.ts
+src/lib/games/ice-slide/renderer.ts
+src/lib/games/shared/types.ts
+src/lib/achievements.ts
+DOM, database, network, and score-submission modules
+```
+
+`init.ts` and achievement changes described above are required gates for HPA-487, not
+HPA-485 production edits.
+
+## 16. Alternatives considered
+
+### 16.1 Replace the platform challenge RNG
+
+Rejected. It is already user-visible and explicitly protected by parent requirements.
+
+### 16.2 Pass only a seed into the game
+
+Rejected. Gameplay would become responsible for generation/version/retry semantics.
+
+### 16.3 Keep separate Campaign and generated progression paths
+
+Rejected. It would duplicate reset, score, completion, and game-data logic.
+
+### 16.4 Deduplicate by compact hash only
+
+Rejected. Complete canonical serialization is cheap and collision-safe.
+
+### 16.5 Include generation metadata in signatures
+
+Rejected. Signatures identify final playable content; stage metadata and mode-specific
+versions preserve provenance.
+
+### 16.6 Use a cryptographic hash
+
+Not required. FNV-1a is not used for security or sole equality.
+
+### 16.7 Use one global generator version
+
+Rejected. It would change fixed Campaign identity for unrelated Daily/Expedition
+algorithm changes. Generator versions belong to materializers/modes.
+
+### 16.8 Remove generator version from Campaign key
+
+Rejected. Campaign materialization still has a versioned adapter contract. A
+Campaign-specific generator version preserves that axis without coupling it to other
+modes.
+
+### 16.9 Defer all new game-data fields to HPA-487
+
+Rejected because HPA-485 explicitly requires the additive game-data contract. The spec
+instead distinguishes required current writes from optional historical reads and notes
+that unscoped Campaign game data is not persisted today.
+
+## 17. Risks and mitigations
+
+### Accidental Campaign drift
+
+Exact adapter comparisons and no-argument Campaign tests.
+
+### Seed-output drift
+
+Reference code and golden vectors lock hash, state mapping, stream, bounded integers,
+pick, shuffle, forks, transforms, canonicalization, and signatures.
+
+### Invalid explicit run escapes UI recovery
+
+HPA-485 exposes no explicit UI run. HPA-487 must move explicit start into `failRun`.
+
+### Campaign identity changes for unrelated generator work
+
+Use per-mode generator versions and a Campaign-specific version constant.
+
+### Run-key/version mismatch
+
+Pure structural validation checks transport shape, prefix, suffix versions, and
+mode-specific seed relationships.
+
+### State rebuild loses run context
+
+Explicit carry list and tests cover every rebuild path.
+
+### Historical game-data shape mismatch
+
+Current writes are required; persisted reads normalize absent fields by version.
+Campaign remains unpersisted without context.
+
+### Legacy achievements unlock in the wrong mode
+
+HPA-487 must gate Campaign achievements before exposing Daily/Expedition.
+
+### HPA-485 absorbs solver or mutation work
+
+Structural validation stops before quality checks; HPA-486 and HPA-489 retain ownership.
+
+## 18. Delivery and review boundaries
+
+Implement HPA-485 as one PR with four logical commits:
+
+1. `feat(games): add deterministic seeded rng`
+2. `feat(ice-slide): add board transforms and canonical variants`
+3. `feat(ice-slide): materialize versioned campaign runs`
+4. `refactor(ice-slide): consume explicit run definitions`
+
+Review focuses on:
+
+1. exact RNG, pick, shuffle, and fork contracts;
+2. rectangular transform semantics;
+3. canonicalization/signature preimage;
+4. mode-specific version/run-key invariants;
+5. Campaign behavior compatibility;
+6. idle/start/state-rebuild behavior;
+7. clean ownership boundaries for HPA-486/HPA-487/HPA-489.
+
+## 19. Acceptance-criteria traceability
+
+| HPA-485 criterion | Design section |
+| --- | --- |
+| Existing callers work through `start()` | §§11–12 |
+| Campaign content/scoring/completion/partial End unchanged | §§11–12, 14 |
+| Known seeds and independent forks are stable | §7 |
+| All row/coordinate transforms and inverse round trips work | §8 |
+| Symmetric boards produce unique canonical variants | §9 |
+| Runs contain final rows/stable signatures; gameplay makes no random/date choices | §§6, 10–12 |
+| Pure modules have no DOM/Pixi/database/network dependency | §§3–5, 15 |
+| Platform Daily rotation remains unchanged | §§4, 7.8, 15 |
+| Extended state/game data retains achievement fields | §§12.5–12.6 |
+
+## 20. Approval gate
+
+After approval, synchronize the existing HPA-485 implementation plan against this spec
+before code work. In particular, copy the exact Mulberry32 seed mapping, fresh-RNG
+vector semantics, `pick()` contract, per-mode version constants, run-key validation,
+explicit-start error boundary, game-data read/write distinction, and achievement gate.

--- a/docs/superpowers/specs/2026-08-02-deterministic-ice-slide-runs-design.md
+++ b/docs/superpowers/specs/2026-08-02-deterministic-ice-slide-runs-design.md
@@ -689,7 +689,7 @@ const payload = [
     `rows=${serializeBoardRows(rows)}`,
     `parMoves=${parMoves}`,
     `transform=${transform}`,
-    `mutationIds=${sortedMutationIds.join(',')}`,
+    `mutationIds=${JSON.stringify(sortedMutationIds)}`,
     `difficulty=${difficulty}`,
     `objectiveIds=${sortedObjectiveIds.join(',')}`,
     `scoreMultiplierBps=${scoreMultiplierBps}`,
@@ -716,13 +716,13 @@ scoreMultiplierBps = 10000
 Exact preimage:
 
 ```text
-ice-slide-stage:v2\u001drows=5x5\u001f#####\u001e#S..#\u001e#...#\u001e#G..#\u001e#####\u001dparMoves=1\u001dtransform=identity\u001dmutationIds=\u001ddifficulty=tutorial\u001dobjectiveIds=\u001dscoreMultiplierBps=10000
+ice-slide-stage:v2\u001drows=5x5\u001f#####\u001e#S..#\u001e#...#\u001e#G..#\u001e#####\u001dparMoves=1\u001dtransform=identity\u001dmutationIds=[]\u001ddifficulty=tutorial\u001dobjectiveIds=\u001dscoreMultiplierBps=10000
 ```
 
 Golden signature:
 
 ```text
-is2-68616e2d
+is2-d1feaba1
 ```
 
 ## 11. Campaign materialization

--- a/docs/superpowers/specs/2026-08-02-deterministic-ice-slide-runs-design.md
+++ b/docs/superpowers/specs/2026-08-02-deterministic-ice-slide-runs-design.md
@@ -267,6 +267,11 @@ ice-slide:expedition:<seedHash>:g<generatorVersion>:r<rulesetVersion>
 Additional relationships:
 
 - Campaign key must equal `CAMPAIGN_RUN_KEY` and `seed` must be `null`.
+- Daily `YYYY-MM-DD` must be a calendar-valid date, not merely lexical: the regex only
+  checks `\d{4}-\d{2}-\d{2}`, so the validator additionally round-trips the parsed
+  year/month/day through `new Date(Date.UTC(year, month - 1, day))` and requires the UTC
+  components to match, rejecting impossible dates such as `2026-02-30` or `2026-13-01`
+  before comparing generator/ruleset versions.
 - Daily `seed` must equal
   `ice-slide:daily:<generatorVersion>:<rulesetVersion>:YYYY-MM-DD`, using the same date
   captured in the run key.
@@ -663,37 +668,47 @@ The signature includes:
 
 - final canonical rows;
 - `parMoves`;
+- `transform` label;
+- sorted `mutationIds`;
+- `difficulty`;
 - sorted `objectiveIds`;
 - `scoreMultiplierBps`.
 
-It excludes display name, stage ID, template ID, transform label, and mutation IDs. Two
-generation paths producing the same playable content receive the same signature.
+It excludes display name, stage ID, and template ID. Two generation paths producing
+the same playable content receive the same signature.
 
 ### 10.2 Exact preimage and public format
 
 Use U+001D as the field separator. Canonical rows retain U+001F/U+001E:
 
 ```ts
+const sortedMutationIds = [...mutationIds].sort()
 const sortedObjectiveIds = [...objectiveIds].sort()
 const payload = [
-    'ice-slide-stage:v1',
+    'ice-slide-stage:v2',
     `rows=${serializeBoardRows(rows)}`,
     `parMoves=${parMoves}`,
+    `transform=${transform}`,
+    `mutationIds=${sortedMutationIds.join(',')}`,
+    `difficulty=${difficulty}`,
     `objectiveIds=${sortedObjectiveIds.join(',')}`,
     `scoreMultiplierBps=${scoreMultiplierBps}`,
 ].join('\u001d')
 
-const signature = `is1-${hashString32Hex(payload)}`
+const signature = `is2-${hashString32Hex(payload)}`
 ```
 
-The labels, order, separators, empty-objective representation, decimal numeric
-representation, and sorting are observable generator behavior.
+The labels, order, separators, empty-objective and empty-mutation representation,
+decimal numeric representation, and sorting are observable generator behavior.
 
 For First Frost:
 
 ```ts
 rows = ['#####', '#S..#', '#...#', '#G..#', '#####']
 parMoves = 1
+transform = 'identity'
+mutationIds = []
+difficulty = 'tutorial'
 objectiveIds = []
 scoreMultiplierBps = 10000
 ```
@@ -701,13 +716,13 @@ scoreMultiplierBps = 10000
 Exact preimage:
 
 ```text
-ice-slide-stage:v1\u001drows=5x5\u001f#####\u001e#S..#\u001e#...#\u001e#G..#\u001e#####\u001dparMoves=1\u001dobjectiveIds=\u001dscoreMultiplierBps=10000
+ice-slide-stage:v2\u001drows=5x5\u001f#####\u001e#S..#\u001e#...#\u001e#G..#\u001e#####\u001dparMoves=1\u001dtransform=identity\u001dmutationIds=\u001ddifficulty=tutorial\u001dobjectiveIds=\u001dscoreMultiplierBps=10000
 ```
 
 Golden signature:
 
 ```text
-is1-a387e186
+is2-68616e2d
 ```
 
 ## 11. Campaign materialization
@@ -827,14 +842,15 @@ start(run?: IceSlideRunDefinition): void
 
 Behavior:
 
-1. Stop any existing timer.
+1. If `run` is explicit, structurally validate and deep-clone it before stopping any timer or mutating state.
 2. If `run` is omitted, create a fresh known-good Campaign definition.
-3. If `run` is explicit, structurally validate and deep-clone it before mutating state.
+3. Stop any existing timer.
 4. Store the active run.
 5. Create playing state and load stage zero.
 6. Start the timer and invoke callbacks in the existing order.
 
-An invalid **explicit** run throws synchronously before state mutation or timer start.
+An invalid **explicit** run throws synchronously before the existing timer is stopped, before any
+state mutation, and before the new timer starts; prior state is left unchanged.
 The direct caller owns that exception boundary.
 
 HPA-485 leaves `init.ts` unchanged. Its current `game.start()` call is outside the
@@ -1075,6 +1091,20 @@ bun run typecheck
 bun run lint
 bun run format:check
 ```
+
+**Typecheck baseline (regression handling).** `bun run typecheck` is not expected to
+exit zero on `main` or on this branch. The repository carries a documented two-error
+baseline that predates this work and is out of scope:
+
+- `src/lib/games/ice-slide/init.test.ts:36` — ts(2556), a spread argument tuple-type error.
+- `src/lib/games/ice-slide/init.ts:178` — ts(2358), an `instanceof` left-hand-side error.
+
+Record the exact `bun run typecheck` error count before starting the branch and again
+after each verification step. The required outcome is a **zero delta**: the same two
+baseline errors and no others. Any new error in the files this branch touches
+(`run.ts`, `run.test.ts`, `test-fixtures.ts`, `transforms.ts`, `transforms.test.ts`,
+`seeded-rng.ts`, `seeded-rng.test.ts`, `game.ts`) is a regression and must be fixed
+before the branch can merge. Do not fix the two baseline errors here.
 
 ## 15. File boundaries
 

--- a/src/lib/games/ice-slide/game.crystal-farm.test.ts
+++ b/src/lib/games/ice-slide/game.crystal-farm.test.ts
@@ -1,32 +1,18 @@
 import { describe, expect, it } from 'vitest'
-
-vi.mock('./levels', () => {
-    const levels = [
-        {
-            id: 1,
-            name: 'Crystal Corridor',
-            parMoves: 3,
-            rows: ['######', '#S.C.#', '#....#', '#...G#', '######'],
-        },
-    ]
-    return {
-        ICE_SLIDE_LEVELS: levels,
-        getLevel: (index: number) => {
-            const level = levels[index]
-            if (!level) {
-                throw new Error(`Ice Slide level index out of range: ${index}`)
-            }
-            return level
-        },
-    }
-})
-
 import { IceSlideGame } from './game'
+import { createTestRun, createTestStage } from './test-fixtures'
 
 describe('IceSlideGame crystal farming guard', () => {
     it('does not farm crystals across collect → reset → recollect', () => {
+        const run = createTestRun([
+            createTestStage({
+                name: 'Crystal Corridor',
+                parMoves: 3,
+                rows: ['######', '#S.C.#', '#....#', '#...G#', '######'],
+            }),
+        ])
         const game = new IceSlideGame()
-        game.start()
+        game.start(run)
 
         game.move('E')
         expect(game.getState().crystalsCollected).toBe(1)

--- a/src/lib/games/ice-slide/game.crystal-hazard-farm.test.ts
+++ b/src/lib/games/ice-slide/game.crystal-hazard-farm.test.ts
@@ -1,33 +1,19 @@
 import { describe, expect, it, vi } from 'vitest'
-
-vi.mock('./levels', () => {
-    const levels = [
-        {
-            id: 1,
-            name: 'Crystal Hazard',
-            parMoves: 2,
-            rows: ['######', '#S.C.#', '#...H#', '######'],
-        },
-    ]
-    return {
-        ICE_SLIDE_LEVELS: levels,
-        getLevel: (index: number) => {
-            const level = levels[index]
-            if (!level) {
-                throw new Error(`Ice Slide level index out of range: ${index}`)
-            }
-            return level
-        },
-    }
-})
-
 import { IceSlideGame } from './game'
+import { createTestRun, createTestStage } from './test-fixtures'
 
 describe('IceSlideGame crystal farming via hazard', () => {
     it('subtracts attempt crystals after falling in a hole', () => {
         const onHazard = vi.fn()
+        const run = createTestRun([
+            createTestStage({
+                name: 'Crystal Hazard',
+                parMoves: 2,
+                rows: ['######', '#S.C.#', '#...H#', '######'],
+            }),
+        ])
         const game = new IceSlideGame({ onHazard })
-        game.start()
+        game.start(run)
 
         game.move('E') // collect crystal, stop at (1,4)
         expect(game.getState().crystalsCollected).toBe(1)

--- a/src/lib/games/ice-slide/game.hazard.test.ts
+++ b/src/lib/games/ice-slide/game.hazard.test.ts
@@ -1,34 +1,20 @@
-import { beforeEach, describe, expect, it, vi } from 'vitest'
-
-vi.mock('./levels', () => {
-    const levels = [
-        {
-            id: 1,
-            name: 'Hazard Lane',
-            parMoves: 1,
-            rows: ['#####', '#S.H#', '#G..#', '#####'],
-        },
-    ]
-    return {
-        ICE_SLIDE_LEVELS: levels,
-        getLevel: (index: number) => {
-            const level = levels[index]
-            if (!level) {
-                throw new Error(`Ice Slide level index out of range: ${index}`)
-            }
-            return level
-        },
-    }
-})
-
+import { describe, expect, it, vi } from 'vitest'
 import { IceSlideGame } from './game'
+import { createTestRun, createTestStage } from './test-fixtures'
 
-describe('IceSlideGame hazard branch (mocked levels)', () => {
+describe('IceSlideGame hazard branch (explicit run)', () => {
     it('reloads the level after sliding into a hazard', () => {
         const onHazard = vi.fn()
         const onMove = vi.fn()
+        const run = createTestRun([
+            createTestStage({
+                name: 'Hazard Lane',
+                rows: ['#####', '#S.H#', '#G..#', '#####'],
+                parMoves: 1,
+            }),
+        ])
         const game = new IceSlideGame({ onHazard, onMove })
-        game.start()
+        game.start(run)
 
         game.move('E')
         expect(onHazard).toHaveBeenCalled()
@@ -41,8 +27,15 @@ describe('IceSlideGame hazard branch (mocked levels)', () => {
     })
 
     it('does not award perfectLevels after a hazard then at-par solve', () => {
+        const run = createTestRun([
+            createTestStage({
+                name: 'Hazard Lane',
+                rows: ['#####', '#S.H#', '#G..#', '#####'],
+                parMoves: 1,
+            }),
+        ])
         const game = new IceSlideGame()
-        game.start()
+        game.start(run)
 
         game.move('E') // hazard; levelMoves retained at 1
         expect(game.getState().levelMoves).toBe(1)
@@ -65,8 +58,15 @@ describe('IceSlideGame hazard branch (mocked levels)', () => {
 
     it('stop leaves the run idle without winning', () => {
         const onWin = vi.fn()
+        const run = createTestRun([
+            createTestStage({
+                name: 'Hazard Lane',
+                rows: ['#####', '#S.H#', '#G..#', '#####'],
+                parMoves: 1,
+            }),
+        ])
         const game = new IceSlideGame({ onWin })
-        game.start()
+        game.start(run)
         game.stop()
         expect(game.getState().status).toBe('idle')
         expect(onWin).not.toHaveBeenCalled()

--- a/src/lib/games/ice-slide/game.test.ts
+++ b/src/lib/games/ice-slide/game.test.ts
@@ -1,9 +1,176 @@
 import { afterEach, describe, expect, it, vi } from 'vitest'
 import { IceSlideGame } from './game'
+import { CAMPAIGN_RUN_KEY } from './run'
+import { createTestRun, createTestStage } from './test-fixtures'
+
+function expectRunMetadataPreserved(
+    before: ReturnType<IceSlideGame['getState']>,
+    after: ReturnType<IceSlideGame['getState']>
+): void {
+    expect(after).toMatchObject({
+        mode: before.mode,
+        runKey: before.runKey,
+        runSchemaVersion: before.runSchemaVersion,
+        generatorVersion: before.generatorVersion,
+        rulesetVersion: before.rulesetVersion,
+        stagesTotal: before.stagesTotal,
+        starsEarned: before.starsEarned,
+        falls: before.falls,
+        resets: before.resets,
+    })
+    expect(after.stageSignatures).toEqual(before.stageSignatures)
+}
 
 describe('IceSlideGame', () => {
     afterEach(() => {
         vi.useRealTimers()
+    })
+
+    it('exposes complete Campaign metadata while idle', () => {
+        const game = new IceSlideGame()
+        const state = game.getState()
+        const data = game.getGameData()
+
+        expect(state).toMatchObject({
+            status: 'idle',
+            mode: 'campaign',
+            runKey: CAMPAIGN_RUN_KEY,
+            runSchemaVersion: 1,
+            generatorVersion: 1,
+            rulesetVersion: 1,
+            stagesTotal: 8,
+            starsEarned: 0,
+            falls: 0,
+            resets: 0,
+        })
+        expect(state.stageSignatures).toHaveLength(8)
+        expect(data).toMatchObject({
+            solved: false,
+            stagesTotal: 8,
+            starsEarned: 0,
+            falls: 0,
+            resets: 0,
+        })
+        expect(data.stageSignatures).toEqual(state.stageSignatures)
+        expect(data.stageSignatures).not.toBe(state.stageSignatures)
+        game.destroy()
+    })
+
+    it('constructs and starts the default Campaign without throwing', () => {
+        const game = new IceSlideGame()
+        expect(() => game.start()).not.toThrow()
+        expect(game.getState().levelName).toBe('First Frost')
+        game.destroy()
+    })
+
+    it('plays an explicit run according to its own stage count', () => {
+        const stages = [
+            createTestStage({
+                id: 'test:1',
+                name: 'First Test',
+                rows: ['#####', '#S.G#', '#####'],
+            }),
+            createTestStage({
+                id: 'test:2',
+                name: 'Second Test',
+                rows: ['#####', '#S.G#', '#####'],
+            }),
+        ]
+        const game = new IceSlideGame()
+        game.start(createTestRun(stages))
+
+        expect(game.getState().levelName).toBe('First Test')
+        game.move('E')
+        expect(game.getState().levelName).toBe('Second Test')
+        game.move('E')
+        expect(game.getState().status).toBe('won')
+        expect(game.getState().levelsCleared).toBe(2)
+        game.destroy()
+    })
+
+    it('rejects an invalid explicit run before mutating prior state', () => {
+        const game = new IceSlideGame()
+        const before = game.getState()
+        const invalid = createTestRun()
+        invalid.runKey = 'invalid key'
+
+        expect(() => game.start(invalid)).toThrow()
+        expect(game.getState()).toEqual(before)
+        game.destroy()
+    })
+
+    it('isolates the active run from caller mutation', () => {
+        const run = createTestRun()
+        const game = new IceSlideGame()
+        game.start(run)
+
+        run.stages[0].rows[1] = '#...#'
+        run.stages[0].name = 'Mutated'
+        run.stages[0].objectiveIds.push('no_reset')
+
+        expect(game.getState().levelName).toBe('Test Stage')
+        expect(game.getState().rows).toBe(3)
+        game.destroy()
+    })
+
+    it('preserves run metadata across a normal stage advance', () => {
+        const stages = [
+            createTestStage({
+                id: 'test:1',
+                name: 'First Test',
+                rows: ['#####', '#S.G#', '#####'],
+            }),
+            createTestStage({
+                id: 'test:2',
+                name: 'Second Test',
+                rows: ['#####', '#S.G#', '#####'],
+            }),
+        ]
+        const game = new IceSlideGame()
+        game.start(createTestRun(stages))
+        const before = game.getState()
+        game.move('E')
+        expect(game.getState().levelName).toBe('Second Test')
+        expectRunMetadataPreserved(before, game.getState())
+        game.destroy()
+    })
+
+    it('preserves run metadata across a manual resetLevel', () => {
+        const game = new IceSlideGame()
+        game.start(
+            createTestRun([
+                createTestStage({
+                    id: 'reset:1',
+                    name: 'Reset Test',
+                    rows: ['#####', '#S..#', '#G..#', '#####'],
+                }),
+            ])
+        )
+        game.move('E')
+        expect(game.getState().levelMoves).toBe(1)
+        const before = game.getState()
+        game.resetLevel()
+        expectRunMetadataPreserved(before, game.getState())
+        game.destroy()
+    })
+
+    it('preserves run metadata across a hazard reload', () => {
+        const onHazard = vi.fn()
+        const game = new IceSlideGame({ onHazard })
+        game.start(
+            createTestRun([
+                createTestStage({
+                    id: 'hazard:1',
+                    name: 'Hazard Test',
+                    rows: ['#####', '#S.H#', '#####'],
+                }),
+            ])
+        )
+        const before = game.getState()
+        game.move('E')
+        expect(onHazard).toHaveBeenCalled()
+        expectRunMetadataPreserved(before, game.getState())
+        game.destroy()
     })
 
     it('starts on level 1 and clears First Frost in one move', () => {

--- a/src/lib/games/ice-slide/game.ts
+++ b/src/lib/games/ice-slide/game.ts
@@ -3,20 +3,59 @@ import {
     type Direction,
     type IceSlideCallbacks,
     type IceSlideGameData,
+    type IceSlideRunDefinition,
+    type IceSlideStageDefinition,
     type IceSlideState,
 } from './types'
 import { cloneGrid, findStart, parseGrid, slide } from './physics'
-import { getLevel, ICE_SLIDE_LEVELS } from './levels'
+import {
+    assertValidIceSlideRunDefinition,
+    cloneIceSlideRunDefinition,
+    createCampaignRunDefinition,
+} from './run'
 import { levelScore, timeBonus } from './scoring'
 
 export class IceSlideGame {
     private state: IceSlideState
+    private activeRun: IceSlideRunDefinition
     private elapsedTimer: ReturnType<typeof setInterval> | null = null
     private callbacks: Partial<IceSlideCallbacks>
 
     constructor(callbacks: Partial<IceSlideCallbacks> = {}) {
         this.callbacks = callbacks
+        this.activeRun = createCampaignRunDefinition()
         this.state = this.createIdleState()
+    }
+
+    private runMetadata(): Pick<
+        IceSlideState,
+        | 'mode'
+        | 'runKey'
+        | 'runSchemaVersion'
+        | 'generatorVersion'
+        | 'rulesetVersion'
+        | 'stagesTotal'
+        | 'stageSignatures'
+    > {
+        return {
+            mode: this.activeRun.mode,
+            runKey: this.activeRun.runKey,
+            runSchemaVersion: this.activeRun.schemaVersion,
+            generatorVersion: this.activeRun.generatorVersion,
+            rulesetVersion: this.activeRun.rulesetVersion,
+            stagesTotal: this.activeRun.stages.length,
+            stageSignatures: this.activeRun.stages.map(
+                stage => stage.signature
+            ),
+        }
+    }
+
+    private getStage(index: number): IceSlideStageDefinition {
+        const stage = this.activeRun.stages[index]
+        if (!stage) {
+            throw new Error(`Ice Slide stage index out of range: ${index}`)
+        }
+        return stage
     }
 
     private createIdleState(): IceSlideState {
@@ -38,6 +77,10 @@ export class IceSlideGame {
             perfectLevels: 0,
             levelsCleared: 0,
             lastSlidePath: [],
+            ...this.runMetadata(),
+            starsEarned: 0,
+            falls: 0,
+            resets: 0,
         }
     }
 
@@ -48,6 +91,7 @@ export class IceSlideGame {
             player: { ...this.state.player },
             start: { ...this.state.start },
             lastSlidePath: this.state.lastSlidePath.map(p => ({ ...p })),
+            stageSignatures: [...this.state.stageSignatures],
         }
     }
 
@@ -59,11 +103,29 @@ export class IceSlideGame {
             elapsedSeconds: this.state.elapsedSeconds,
             solved: this.state.status === 'won',
             perfectLevels: this.state.perfectLevels,
+            mode: this.state.mode,
+            runKey: this.state.runKey,
+            runSchemaVersion: this.state.runSchemaVersion,
+            generatorVersion: this.state.generatorVersion,
+            rulesetVersion: this.state.rulesetVersion,
+            stagesTotal: this.state.stagesTotal,
+            starsEarned: this.state.starsEarned,
+            falls: this.state.falls,
+            resets: this.state.resets,
+            stageSignatures: [...this.state.stageSignatures],
         }
     }
 
-    start(): void {
+    start(run?: IceSlideRunDefinition): void {
+        const nextRun = run
+            ? (() => {
+                  assertValidIceSlideRunDefinition(run)
+                  return cloneIceSlideRunDefinition(run)
+              })()
+            : createCampaignRunDefinition()
+
         this.stopTimer()
+        this.activeRun = nextRun
         this.state = this.createIdleState()
         this.state.status = 'playing'
         this.loadLevel(0)
@@ -144,22 +206,22 @@ export class IceSlideGame {
     }
 
     private clearLevel(): void {
-        const level = getLevel(this.state.levelIndex)
+        const stage = this.getStage(this.state.levelIndex)
         const levelNumber = this.state.levelIndex + 1
         const gained = levelScore({
             levelNumber,
-            parMoves: level.parMoves,
+            parMoves: stage.parMoves,
             movesUsed: this.state.levelMoves,
             crystalsCollected: this.state.levelCrystalsCollected,
         })
         this.state.score += gained
         this.state.levelsCleared += 1
-        if (this.state.levelMoves <= level.parMoves) {
+        if (this.state.levelMoves <= stage.parMoves) {
             this.state.perfectLevels += 1
         }
         this.callbacks.onScoreUpdate?.(this.state.score)
 
-        if (this.state.levelIndex >= ICE_SLIDE_LEVELS.length - 1) {
+        if (this.state.levelIndex >= this.activeRun.stages.length - 1) {
             this.state.score += timeBonus(this.state.elapsedSeconds)
             this.state.status = 'won'
             this.stopTimer()
@@ -180,8 +242,8 @@ export class IceSlideGame {
             preserveLevelMoves?: boolean
         } = {}
     ): void {
-        const level = getLevel(index)
-        const grid = cloneGrid(parseGrid(level))
+        const stage = this.getStage(index)
+        const grid = cloneGrid(parseGrid(stage))
         const start = findStart(grid)
         // Start tile behaves as ice after spawn.
         grid[start.row][start.col] = 'ice'
@@ -194,13 +256,16 @@ export class IceSlideGame {
                   elapsedSeconds: this.state.elapsedSeconds,
                   perfectLevels: this.state.perfectLevels,
                   levelsCleared: this.state.levelsCleared,
+                  starsEarned: this.state.starsEarned,
+                  falls: this.state.falls,
+                  resets: this.state.resets,
                   status: this.state.status,
               }
             : null
 
         this.state = {
             levelIndex: index,
-            levelName: level.name,
+            levelName: stage.name,
             rows: grid.length,
             cols: grid[0].length,
             grid,
@@ -216,6 +281,10 @@ export class IceSlideGame {
             perfectLevels: preserved?.perfectLevels ?? 0,
             levelsCleared: preserved?.levelsCleared ?? 0,
             lastSlidePath: [],
+            ...this.runMetadata(),
+            starsEarned: preserved?.starsEarned ?? 0,
+            falls: preserved?.falls ?? 0,
+            resets: preserved?.resets ?? 0,
         }
     }
 

--- a/src/lib/games/ice-slide/game.win.test.ts
+++ b/src/lib/games/ice-slide/game.win.test.ts
@@ -1,35 +1,21 @@
 import { describe, expect, it, vi } from 'vitest'
-
-vi.mock('./levels', () => {
-    const levels = [
-        {
-            id: 1,
-            name: 'Crystal Dash',
-            parMoves: 1,
-            rows: ['######', '#SC.G#', '######'],
-        },
-    ]
-    return {
-        ICE_SLIDE_LEVELS: levels,
-        getLevel: (index: number) => {
-            const level = levels[index]
-            if (!level) {
-                throw new Error(`Ice Slide level index out of range: ${index}`)
-            }
-            return level
-        },
-    }
-})
-
 import { IceSlideGame } from './game'
+import { createTestRun, createTestStage } from './test-fixtures'
 
-describe('IceSlideGame win + crystal branch (mocked levels)', () => {
+describe('IceSlideGame win + crystal branch (explicit run)', () => {
     it('collects crystals and wins the single-level mission', () => {
         const onCrystal = vi.fn()
         const onWin = vi.fn()
         const onLevelClear = vi.fn()
+        const run = createTestRun([
+            createTestStage({
+                name: 'Crystal Dash',
+                rows: ['######', '#SC.G#', '######'],
+                parMoves: 1,
+            }),
+        ])
         const game = new IceSlideGame({ onCrystal, onWin, onLevelClear })
-        game.start()
+        game.start(run)
 
         game.move('E')
         expect(onCrystal).toHaveBeenCalledWith(1)

--- a/src/lib/games/ice-slide/physics.test.ts
+++ b/src/lib/games/ice-slide/physics.test.ts
@@ -20,8 +20,6 @@ describe('ice-slide physics', () => {
     it('parses glyphs and finds start', () => {
         const grid = parseGrid({
             id: 99,
-            name: 't',
-            parMoves: 1,
             rows: ['####', '#SG#', '####'],
         })
         expect(grid[1][1]).toBe('start')
@@ -30,22 +28,16 @@ describe('ice-slide physics', () => {
     })
 
     it('rejects empty, jagged, and unknown glyphs', () => {
-        expect(() =>
-            parseGrid({ id: 1, name: 't', parMoves: 1, rows: [] })
-        ).toThrow(/no rows/)
+        expect(() => parseGrid({ id: 1, rows: [] })).toThrow(/no rows/)
         expect(() =>
             parseGrid({
                 id: 2,
-                name: 't',
-                parMoves: 1,
                 rows: ['###', '##'],
             })
         ).toThrow(/length/)
         expect(() =>
             parseGrid({
                 id: 3,
-                name: 't',
-                parMoves: 1,
                 rows: ['###', '#X#', '###'],
             })
         ).toThrow(/unknown glyph/)
@@ -54,8 +46,6 @@ describe('ice-slide physics', () => {
     it('throws when start is missing', () => {
         const grid = parseGrid({
             id: 99,
-            name: 't',
-            parMoves: 1,
             rows: ['###', '#.#', '###'],
         })
         expect(() => findStart(grid)).toThrow(/missing a start/)
@@ -64,8 +54,6 @@ describe('ice-slide physics', () => {
     it('slides until a wall and stops before it', () => {
         const grid = parseGrid({
             id: 99,
-            name: 't',
-            parMoves: 1,
             rows: ['#####', '#S..#', '#####'],
         })
         const start = findStart(grid)
@@ -94,8 +82,6 @@ describe('ice-slide physics', () => {
     it('stops before a rock', () => {
         const grid = parseGrid({
             id: 99,
-            name: 't',
-            parMoves: 1,
             rows: ['#####', '#S.O#', '#####'],
         })
         const start = findStart(grid)
@@ -110,8 +96,6 @@ describe('ice-slide physics', () => {
     it('stops on the goal', () => {
         const grid = parseGrid({
             id: 99,
-            name: 't',
-            parMoves: 1,
             rows: ['#####', '#S.G#', '#####'],
         })
         const start = findStart(grid)
@@ -127,8 +111,6 @@ describe('ice-slide physics', () => {
     it('collects crystals while sliding', () => {
         const grid = parseGrid({
             id: 99,
-            name: 't',
-            parMoves: 1,
             rows: ['######', '#S.C.#', '######'],
         })
         const start = findStart(grid)
@@ -145,8 +127,6 @@ describe('ice-slide physics', () => {
     it('reports hazard when entering a hole', () => {
         const grid = parseGrid({
             id: 99,
-            name: 't',
-            parMoves: 1,
             rows: ['#####', '#S.H#', '#####'],
         })
         const start = findStart(grid)
@@ -158,8 +138,6 @@ describe('ice-slide physics', () => {
     it('no-ops when the adjacent cell is blocked', () => {
         const grid = parseGrid({
             id: 99,
-            name: 't',
-            parMoves: 1,
             rows: ['###', '#S#', '###'],
         })
         const start = findStart(grid)
@@ -377,4 +355,13 @@ describe('ice-slide levels', () => {
         expect(() => getLevel(-1)).toThrow(/out of range/)
         expect(() => getLevel(ICE_SLIDE_LEVELS.length)).toThrow(/out of range/)
     })
+})
+
+it('parses materialized stage rows with a string id', () => {
+    const grid = parseGrid({
+        id: 'campaign:1',
+        rows: ['#####', '#S.G#', '#####'],
+    })
+    expect(grid[1][1]).toBe('start')
+    expect(grid[1][3]).toBe('goal')
 })

--- a/src/lib/games/ice-slide/physics.ts
+++ b/src/lib/games/ice-slide/physics.ts
@@ -1,26 +1,26 @@
-import {
-    GLYPH_TO_CELL,
-    type CellType,
-    type GridPosition,
-    type IceSlideLevel,
-} from './types'
+import { GLYPH_TO_CELL, type CellType, type GridPosition } from './types'
 
-export function parseGrid(level: IceSlideLevel): CellType[][] {
-    if (level.rows.length === 0) {
-        throw new Error(`Level ${level.id} has no rows`)
+export interface IceSlideGridSource {
+    id: string | number
+    rows: readonly string[]
+}
+
+export function parseGrid(source: IceSlideGridSource): CellType[][] {
+    if (source.rows.length === 0) {
+        throw new Error(`Level ${source.id} has no rows`)
     }
-    const cols = level.rows[0].length
-    return level.rows.map((row, rowIndex) => {
+    const cols = source.rows[0].length
+    return source.rows.map((row, rowIndex) => {
         if (row.length !== cols) {
             throw new Error(
-                `Level ${level.id} row ${rowIndex} length ${row.length} != ${cols}`
+                `Level ${source.id} row ${rowIndex} length ${row.length} != ${cols}`
             )
         }
         return [...row].map(glyph => {
             const cell = GLYPH_TO_CELL[glyph]
             if (!cell) {
                 throw new Error(
-                    `Level ${level.id} unknown glyph "${glyph}" at row ${rowIndex}`
+                    `Level ${source.id} unknown glyph "${glyph}" at row ${rowIndex}`
                 )
             }
             return cell

--- a/src/lib/games/ice-slide/renderer.test.ts
+++ b/src/lib/games/ice-slide/renderer.test.ts
@@ -75,6 +75,16 @@ function makeState(
         perfectLevels: 0,
         levelsCleared: 0,
         lastSlidePath: [],
+        mode: 'campaign',
+        runKey: 'ice-slide:campaign:g1:r1',
+        runSchemaVersion: 1,
+        generatorVersion: 1,
+        rulesetVersion: 1,
+        stagesTotal: 8,
+        starsEarned: 0,
+        falls: 0,
+        resets: 0,
+        stageSignatures: [],
         ...overrides,
     }
 }

--- a/src/lib/games/ice-slide/run.test.ts
+++ b/src/lib/games/ice-slide/run.test.ts
@@ -169,3 +169,238 @@ it('deep-clones every mutable run array', () => {
     expect(source.stages[0].mutationIds).toEqual([])
     expect(source.stages[0].objectiveIds).toEqual([])
 })
+
+function cloneDailyRun(): ReturnType<typeof createCampaignRunDefinition> {
+    const run = cloneRun()
+    run.mode = 'daily'
+    run.generatorVersion = 3
+    run.rulesetVersion = 2
+    run.runKey = 'ice-slide:daily:2026-08-02:g3:r2'
+    run.seed = 'ice-slide:daily:3:2:2026-08-02'
+    return run
+}
+
+function cloneExpeditionRun(
+    seed = 'ice-slide:expedition:sample-seed'
+): ReturnType<typeof createCampaignRunDefinition> {
+    const run = cloneRun()
+    run.mode = 'expedition'
+    run.generatorVersion = 4
+    run.rulesetVersion = 2
+    run.seed = seed
+    run.runKey = `ice-slide:expedition:${hashString32Hex(seed)}:g4:r2`
+    return run
+}
+
+describe('assertValidIceSlideRunDefinition rejections', () => {
+    it.each([
+        [
+            'schemaVersion mismatch',
+            (run: ReturnType<typeof cloneRun>) => {
+                run.schemaVersion = 2 as 1
+            },
+        ],
+        [
+            'generatorVersion not a positive int',
+            (run: ReturnType<typeof cloneRun>) => {
+                run.generatorVersion = 0
+            },
+        ],
+        [
+            'rulesetVersion not a positive int',
+            (run: ReturnType<typeof cloneRun>) => {
+                run.rulesetVersion = -1
+            },
+        ],
+        [
+            'generatorVersion non-integer',
+            (run: ReturnType<typeof cloneRun>) => {
+                run.generatorVersion = 1.5
+            },
+        ],
+        [
+            'unknown run mode',
+            (run: ReturnType<typeof cloneRun>) => {
+                run.mode = 'arcade' as 'campaign'
+            },
+        ],
+        [
+            'campaign generatorVersion mismatch',
+            (run: ReturnType<typeof cloneRun>) => {
+                run.generatorVersion = 2
+            },
+        ],
+        [
+            'campaign rulesetVersion mismatch',
+            (run: ReturnType<typeof cloneRun>) => {
+                run.rulesetVersion = 2
+            },
+        ],
+        [
+            'duplicate stage ids',
+            (run: ReturnType<typeof cloneRun>) => {
+                run.stages[1].id = run.stages[0].id
+            },
+        ],
+        [
+            'empty stage id',
+            (run: ReturnType<typeof cloneRun>) => {
+                run.stages[0].id = ''
+            },
+        ],
+        [
+            'unknown stage difficulty',
+            (run: ReturnType<typeof cloneRun>) => {
+                run.stages[0].difficulty = 'impossible' as 'easy'
+            },
+        ],
+        [
+            'unknown stage transform',
+            (run: ReturnType<typeof cloneRun>) => {
+                run.stages[0].transform = 'flip' as 'identity'
+            },
+        ],
+        [
+            'empty stage rows',
+            (run: ReturnType<typeof cloneRun>) => {
+                run.stages[0].rows = []
+            },
+        ],
+        [
+            'non-rectangular stage rows',
+            (run: ReturnType<typeof cloneRun>) => {
+                run.stages[0].rows = ['###', '##']
+            },
+        ],
+        [
+            'unknown stage glyph',
+            (run: ReturnType<typeof cloneRun>) => {
+                run.stages[0].rows = ['###', '#X#', '###']
+            },
+        ],
+        [
+            'parMoves not a positive int',
+            (run: ReturnType<typeof cloneRun>) => {
+                run.stages[0].parMoves = 0
+            },
+        ],
+        [
+            'duplicate mutation ids',
+            (run: ReturnType<typeof cloneRun>) => {
+                run.stages[0].mutationIds = ['m:a', 'm:a']
+            },
+        ],
+        [
+            'empty mutation id',
+            (run: ReturnType<typeof cloneRun>) => {
+                run.stages[0].mutationIds = ['m:a', '']
+            },
+        ],
+        [
+            'duplicate objective ids',
+            (run: ReturnType<typeof cloneRun>) => {
+                run.stages[0].objectiveIds = ['no_falls', 'no_falls']
+            },
+        ],
+        [
+            'unknown objective id',
+            (run: ReturnType<typeof cloneRun>) => {
+                run.stages[0].objectiveIds = ['no_falls', 'bogus' as 'no_falls']
+            },
+        ],
+        [
+            'stage signature mismatch',
+            (run: ReturnType<typeof cloneRun>) => {
+                run.stages[0].parMoves = 999
+            },
+        ],
+    ] as const)('rejects %s', (_name, mutate) => {
+        const run = cloneRun()
+        mutate(run)
+        expect(() => assertValidIceSlideRunDefinition(run)).toThrow(RangeError)
+    })
+})
+
+describe('Daily run key validation', () => {
+    it.each([
+        [
+            'malformed daily key',
+            (run: ReturnType<typeof cloneDailyRun>) => {
+                run.runKey = 'ice-slide:daily:bad'
+            },
+        ],
+        [
+            'daily generatorVersion mismatch',
+            (run: ReturnType<typeof cloneDailyRun>) => {
+                run.generatorVersion = 5
+            },
+        ],
+        [
+            'daily rulesetVersion mismatch',
+            (run: ReturnType<typeof cloneDailyRun>) => {
+                run.rulesetVersion = 5
+            },
+        ],
+        [
+            'daily seed mismatch',
+            (run: ReturnType<typeof cloneDailyRun>) => {
+                run.seed = 'ice-slide:daily:3:2:2026-08-99'
+            },
+        ],
+    ] as const)('rejects %s', (_name, mutate) => {
+        const run = cloneDailyRun()
+        mutate(run)
+        expect(() => assertValidIceSlideRunDefinition(run)).toThrow(RangeError)
+    })
+})
+
+describe('Expedition run key validation', () => {
+    it.each([
+        [
+            'malformed expedition key',
+            (run: ReturnType<typeof cloneExpeditionRun>) => {
+                run.runKey = 'ice-slide:expedition:bad'
+            },
+        ],
+        [
+            'expedition generatorVersion mismatch',
+            (run: ReturnType<typeof cloneExpeditionRun>) => {
+                run.generatorVersion = 99
+            },
+        ],
+        [
+            'expedition rulesetVersion mismatch',
+            (run: ReturnType<typeof cloneExpeditionRun>) => {
+                run.rulesetVersion = 99
+            },
+        ],
+        [
+            'null expedition seed',
+            (run: ReturnType<typeof cloneExpeditionRun>) => {
+                run.seed = null
+            },
+        ],
+        [
+            'empty expedition seed',
+            (run: ReturnType<typeof cloneExpeditionRun>) => {
+                run.seed = ''
+            },
+        ],
+        [
+            'expedition seed with U+001F',
+            (run: ReturnType<typeof cloneExpeditionRun>) => {
+                run.seed = 'a\u001fb'
+            },
+        ],
+        [
+            'expedition hash mismatch',
+            (run: ReturnType<typeof cloneExpeditionRun>) => {
+                run.seed = 'different-seed'
+            },
+        ],
+    ] as const)('rejects %s', (_name, mutate) => {
+        const run = cloneExpeditionRun()
+        mutate(run)
+        expect(() => assertValidIceSlideRunDefinition(run)).toThrow(RangeError)
+    })
+})

--- a/src/lib/games/ice-slide/run.test.ts
+++ b/src/lib/games/ice-slide/run.test.ts
@@ -11,6 +11,7 @@ import {
     createCampaignRunDefinition,
     createIceSlideStageSignature,
 } from './run'
+import type { IceSlideObjectiveId } from './types'
 
 describe('Ice Slide run versions and signatures', () => {
     it('derives the Campaign key from mode-specific versions', () => {
@@ -31,7 +32,27 @@ describe('Ice Slide run versions and signatures', () => {
                 objectiveIds: [],
                 scoreMultiplierBps: 10000,
             })
-        ).toBe('is2-68616e2d')
+        ).toBe('is2-d1feaba1')
+    })
+
+    it('distinguishes mutation id lists that share a comma-joined form', () => {
+        const common = {
+            rows: ICE_SLIDE_LEVELS[0].rows,
+            parMoves: 1,
+            transform: 'identity' as const,
+            difficulty: 'tutorial' as const,
+            objectiveIds: [] as IceSlideObjectiveId[],
+            scoreMultiplierBps: 10000,
+        }
+        const commaFirst = createIceSlideStageSignature({
+            ...common,
+            mutationIds: ['a,b', 'c'],
+        })
+        const commaSecond = createIceSlideStageSignature({
+            ...common,
+            mutationIds: ['a', 'b,c'],
+        })
+        expect(commaFirst).not.toBe(commaSecond)
     })
 })
 

--- a/src/lib/games/ice-slide/run.test.ts
+++ b/src/lib/games/ice-slide/run.test.ts
@@ -11,7 +11,7 @@ import {
     createCampaignRunDefinition,
     createIceSlideStageSignature,
 } from './run'
-import type { IceSlideObjectiveId } from './types'
+import type { IceSlideObjectiveId, IceSlideRunDefinition } from './types'
 
 describe('Ice Slide run versions and signatures', () => {
     it('derives the Campaign key from mode-specific versions', () => {
@@ -266,7 +266,7 @@ it('deep-clones every mutable run array', () => {
     expect(source.stages[0].objectiveIds).toEqual([])
 })
 
-function cloneDailyRun(): ReturnType<typeof createCampaignRunDefinition> {
+function makeDailyRun(): IceSlideRunDefinition {
     const run = cloneRun()
     run.mode = 'daily'
     run.generatorVersion = 3
@@ -276,9 +276,9 @@ function cloneDailyRun(): ReturnType<typeof createCampaignRunDefinition> {
     return run
 }
 
-function cloneExpeditionRun(
+function makeExpeditionRun(
     seed = 'ice-slide:expedition:sample-seed'
-): ReturnType<typeof createCampaignRunDefinition> {
+): IceSlideRunDefinition {
     const run = cloneRun()
     run.mode = 'expedition'
     run.generatorVersion = 4
@@ -295,125 +295,145 @@ describe('assertValidIceSlideRunDefinition rejections', () => {
             (run: ReturnType<typeof cloneRun>) => {
                 run.schemaVersion = 2 as 1
             },
+            'schemaVersion must be 1',
         ],
         [
             'generatorVersion not a positive int',
             (run: ReturnType<typeof cloneRun>) => {
                 run.generatorVersion = 0
             },
+            'generatorVersion must be a positive signed integer',
         ],
         [
             'rulesetVersion not a positive int',
             (run: ReturnType<typeof cloneRun>) => {
                 run.rulesetVersion = -1
             },
+            'rulesetVersion must be a positive signed integer',
         ],
         [
             'generatorVersion non-integer',
             (run: ReturnType<typeof cloneRun>) => {
                 run.generatorVersion = 1.5
             },
+            'generatorVersion must be a positive signed integer',
         ],
         [
             'unknown run mode',
             (run: ReturnType<typeof cloneRun>) => {
                 run.mode = 'arcade' as 'campaign'
             },
+            'unknown run mode "arcade"',
         ],
         [
             'campaign generatorVersion mismatch',
             (run: ReturnType<typeof cloneRun>) => {
                 run.generatorVersion = 2
             },
+            'campaign versions must match the campaign runKey',
         ],
         [
             'campaign rulesetVersion mismatch',
             (run: ReturnType<typeof cloneRun>) => {
                 run.rulesetVersion = 2
             },
+            'campaign versions must match the campaign runKey',
         ],
         [
             'duplicate stage ids',
             (run: ReturnType<typeof cloneRun>) => {
                 run.stages[1].id = run.stages[0].id
             },
+            'stage ids must contain unique non-empty values',
         ],
         [
             'empty stage id',
             (run: ReturnType<typeof cloneRun>) => {
                 run.stages[0].id = ''
             },
+            'stage ids must contain unique non-empty values',
         ],
         [
             'unknown stage difficulty',
             (run: ReturnType<typeof cloneRun>) => {
                 run.stages[0].difficulty = 'impossible' as 'easy'
             },
+            'unknown stage difficulty "impossible"',
         ],
         [
             'unknown stage transform',
             (run: ReturnType<typeof cloneRun>) => {
                 run.stages[0].transform = 'flip' as 'identity'
             },
+            'unknown stage transform "flip"',
         ],
         [
             'empty stage rows',
             (run: ReturnType<typeof cloneRun>) => {
                 run.stages[0].rows = []
             },
+            'stage rows must not be empty',
         ],
         [
             'non-rectangular stage rows',
             (run: ReturnType<typeof cloneRun>) => {
                 run.stages[0].rows = ['###', '##']
             },
+            'stage rows must be rectangular',
         ],
         [
             'unknown stage glyph',
             (run: ReturnType<typeof cloneRun>) => {
                 run.stages[0].rows = ['###', '#X#', '###']
             },
+            'unknown stage glyph "X"',
         ],
         [
             'parMoves not a positive int',
             (run: ReturnType<typeof cloneRun>) => {
                 run.stages[0].parMoves = 0
             },
+            'parMoves must be a positive signed integer',
         ],
         [
             'duplicate mutation ids',
             (run: ReturnType<typeof cloneRun>) => {
                 run.stages[0].mutationIds = ['m:a', 'm:a']
             },
+            'mutation ids must contain unique non-empty values',
         ],
         [
             'empty mutation id',
             (run: ReturnType<typeof cloneRun>) => {
                 run.stages[0].mutationIds = ['m:a', '']
             },
+            'mutation ids must contain unique non-empty values',
         ],
         [
             'duplicate objective ids',
             (run: ReturnType<typeof cloneRun>) => {
                 run.stages[0].objectiveIds = ['no_falls', 'no_falls']
             },
+            'objective ids must contain unique non-empty values',
         ],
         [
             'unknown objective id',
             (run: ReturnType<typeof cloneRun>) => {
                 run.stages[0].objectiveIds = ['no_falls', 'bogus' as 'no_falls']
             },
+            'unknown objective "bogus"',
         ],
         [
             'stage signature mismatch',
             (run: ReturnType<typeof cloneRun>) => {
                 run.stages[0].parMoves = 999
             },
+            'stage signature does not match its definition',
         ],
-    ] as const)('rejects %s', (_name, mutate) => {
+    ] as const)('rejects %s', (_name, mutate, message) => {
         const run = cloneRun()
         mutate(run)
-        expect(() => assertValidIceSlideRunDefinition(run)).toThrow(RangeError)
+        expect(() => assertValidIceSlideRunDefinition(run)).toThrow(message)
     })
 })
 
@@ -421,32 +441,44 @@ describe('Daily run key validation', () => {
     it.each([
         [
             'malformed daily key',
-            (run: ReturnType<typeof cloneDailyRun>) => {
+            (run: ReturnType<typeof makeDailyRun>) => {
                 run.runKey = 'ice-slide:daily:bad'
             },
+            'daily runKey must match the daily key format',
         ],
         [
             'daily generatorVersion mismatch',
-            (run: ReturnType<typeof cloneDailyRun>) => {
+            (run: ReturnType<typeof makeDailyRun>) => {
                 run.generatorVersion = 5
             },
+            'daily generatorVersion must match the runKey',
         ],
         [
             'daily rulesetVersion mismatch',
-            (run: ReturnType<typeof cloneDailyRun>) => {
+            (run: ReturnType<typeof makeDailyRun>) => {
                 run.rulesetVersion = 5
             },
+            'daily rulesetVersion must match the runKey',
         ],
         [
             'daily seed mismatch',
-            (run: ReturnType<typeof cloneDailyRun>) => {
+            (run: ReturnType<typeof makeDailyRun>) => {
                 run.seed = 'ice-slide:daily:3:2:2026-08-99'
             },
+            'daily seed must match the runKey date and versions',
         ],
-    ] as const)('rejects %s', (_name, mutate) => {
-        const run = cloneDailyRun()
+        [
+            'daily calendar-invalid date',
+            (run: ReturnType<typeof makeDailyRun>) => {
+                run.runKey = 'ice-slide:daily:2026-02-30:g3:r2'
+                run.seed = 'ice-slide:daily:3:2:2026-02-30'
+            },
+            'daily runKey date must be a calendar-valid YYYY-MM-DD date',
+        ],
+    ] as const)('rejects %s', (_name, mutate, message) => {
+        const run = makeDailyRun()
         mutate(run)
-        expect(() => assertValidIceSlideRunDefinition(run)).toThrow(RangeError)
+        expect(() => assertValidIceSlideRunDefinition(run)).toThrow(message)
     })
 })
 
@@ -454,49 +486,56 @@ describe('Expedition run key validation', () => {
     it.each([
         [
             'malformed expedition key',
-            (run: ReturnType<typeof cloneExpeditionRun>) => {
+            (run: ReturnType<typeof makeExpeditionRun>) => {
                 run.runKey = 'ice-slide:expedition:bad'
             },
+            'expedition runKey must match the expedition key format',
         ],
         [
             'expedition generatorVersion mismatch',
-            (run: ReturnType<typeof cloneExpeditionRun>) => {
+            (run: ReturnType<typeof makeExpeditionRun>) => {
                 run.generatorVersion = 99
             },
+            'expedition generatorVersion must match the runKey',
         ],
         [
             'expedition rulesetVersion mismatch',
-            (run: ReturnType<typeof cloneExpeditionRun>) => {
+            (run: ReturnType<typeof makeExpeditionRun>) => {
                 run.rulesetVersion = 99
             },
+            'expedition rulesetVersion must match the runKey',
         ],
         [
             'null expedition seed',
-            (run: ReturnType<typeof cloneExpeditionRun>) => {
+            (run: ReturnType<typeof makeExpeditionRun>) => {
                 run.seed = null
             },
+            'expedition seed must be non-empty without U+001F',
         ],
         [
             'empty expedition seed',
-            (run: ReturnType<typeof cloneExpeditionRun>) => {
+            (run: ReturnType<typeof makeExpeditionRun>) => {
                 run.seed = ''
             },
+            'expedition seed must be non-empty without U+001F',
         ],
         [
             'expedition seed with U+001F',
-            (run: ReturnType<typeof cloneExpeditionRun>) => {
+            (run: ReturnType<typeof makeExpeditionRun>) => {
                 run.seed = 'a\u001fb'
             },
+            'expedition seed must be non-empty without U+001F',
         ],
         [
             'expedition hash mismatch',
-            (run: ReturnType<typeof cloneExpeditionRun>) => {
+            (run: ReturnType<typeof makeExpeditionRun>) => {
                 run.seed = 'different-seed'
             },
+            'expedition runKey hash must equal hashString32Hex(seed)',
         ],
-    ] as const)('rejects %s', (_name, mutate) => {
-        const run = cloneExpeditionRun()
+    ] as const)('rejects %s', (_name, mutate, message) => {
+        const run = makeExpeditionRun()
         mutate(run)
-        expect(() => assertValidIceSlideRunDefinition(run)).toThrow(RangeError)
+        expect(() => assertValidIceSlideRunDefinition(run)).toThrow(message)
     })
 })

--- a/src/lib/games/ice-slide/run.test.ts
+++ b/src/lib/games/ice-slide/run.test.ts
@@ -1,0 +1,171 @@
+import { describe, expect, it } from 'vitest'
+import { hashString32Hex } from '../shared/seeded-rng'
+import { ICE_SLIDE_LEVELS } from './levels'
+import {
+    CAMPAIGN_RUN_KEY,
+    ICE_SLIDE_CAMPAIGN_GENERATOR_VERSION,
+    ICE_SLIDE_RULESET_VERSION,
+    ICE_SLIDE_RUN_SCHEMA_VERSION,
+    assertValidIceSlideRunDefinition,
+    cloneIceSlideRunDefinition,
+    createCampaignRunDefinition,
+    createIceSlideStageSignature,
+} from './run'
+
+describe('Ice Slide run versions and signatures', () => {
+    it('derives the Campaign key from mode-specific versions', () => {
+        expect(ICE_SLIDE_RUN_SCHEMA_VERSION).toBe(1)
+        expect(ICE_SLIDE_CAMPAIGN_GENERATOR_VERSION).toBe(1)
+        expect(ICE_SLIDE_RULESET_VERSION).toBe(1)
+        expect(CAMPAIGN_RUN_KEY).toBe('ice-slide:campaign:g1:r1')
+    })
+
+    it('locks the First Frost signature preimage', () => {
+        expect(
+            createIceSlideStageSignature({
+                rows: ICE_SLIDE_LEVELS[0].rows,
+                parMoves: 1,
+                objectiveIds: [],
+                scoreMultiplierBps: 10000,
+            })
+        ).toBe('is1-a387e186')
+    })
+})
+
+describe('Campaign run materialization', () => {
+    it('materializes exactly the authored eight levels', () => {
+        const run = createCampaignRunDefinition()
+
+        expect(run).toMatchObject({
+            schemaVersion: 1,
+            generatorVersion: 1,
+            rulesetVersion: 1,
+            mode: 'campaign',
+            runKey: 'ice-slide:campaign:g1:r1',
+            seed: null,
+        })
+        expect(run.stages).toHaveLength(8)
+
+        for (let index = 0; index < ICE_SLIDE_LEVELS.length; index++) {
+            const level = ICE_SLIDE_LEVELS[index]
+            const stage = run.stages[index]
+
+            expect(stage.id).toBe(`campaign:${level.id}`)
+            expect(stage.templateId).toBe(`campaign:${level.id}`)
+            expect(stage.name).toBe(level.name)
+            expect(stage.rows).toEqual(level.rows)
+            expect(stage.rows).not.toBe(level.rows)
+            expect(stage.parMoves).toBe(level.parMoves)
+            expect(stage.transform).toBe('identity')
+            expect(stage.mutationIds).toEqual([])
+            expect(stage.objectiveIds).toEqual([])
+            expect(stage.scoreMultiplierBps).toBe(10000)
+            expect(stage.signature).toMatch(/^is1-[0-9a-f]{8}$/)
+        }
+    })
+
+    it('returns fresh snapshots on every call', () => {
+        const first = createCampaignRunDefinition()
+        const second = createCampaignRunDefinition()
+
+        first.stages[0].rows[0] = 'xxxxx'
+        first.stages[0].objectiveIds.push('no_reset')
+
+        expect(second.stages[0].rows[0]).toBe('#####')
+        expect(second.stages[0].objectiveIds).toEqual([])
+    })
+})
+
+function cloneRun(
+    run = createCampaignRunDefinition()
+): ReturnType<typeof createCampaignRunDefinition> {
+    return structuredClone(run)
+}
+
+it('accepts the Campaign run', () => {
+    expect(() =>
+        assertValidIceSlideRunDefinition(createCampaignRunDefinition())
+    ).not.toThrow()
+})
+
+it.each([
+    [
+        'bad key characters',
+        (run: ReturnType<typeof createCampaignRunDefinition>) => {
+            run.runKey = 'ice slide'
+        },
+    ],
+    [
+        'version mismatch',
+        (run: ReturnType<typeof createCampaignRunDefinition>) => {
+            run.runKey = 'ice-slide:campaign:g2:r1'
+        },
+    ],
+    [
+        'Campaign seed',
+        (run: ReturnType<typeof createCampaignRunDefinition>) => {
+            run.seed = 'not-null'
+        },
+    ],
+    [
+        'too many stages',
+        (run: ReturnType<typeof createCampaignRunDefinition>) => {
+            run.stages = Array.from({ length: 65 }, (_, index) => ({
+                ...structuredClone(run.stages[0]),
+                id: `campaign:${index + 1}`,
+            }))
+        },
+    ],
+    [
+        'multiplier below band',
+        (run: ReturnType<typeof createCampaignRunDefinition>) => {
+            run.stages[0].scoreMultiplierBps = 999
+        },
+    ],
+    [
+        'multiplier above band',
+        (run: ReturnType<typeof createCampaignRunDefinition>) => {
+            run.stages[0].scoreMultiplierBps = 50001
+        },
+    ],
+] as const)('rejects %s', (_name, mutate) => {
+    const run = cloneRun()
+    mutate(run)
+    expect(() => assertValidIceSlideRunDefinition(run)).toThrow()
+})
+
+it('validates a Daily key/date/seed relationship', () => {
+    const run = cloneRun()
+    run.mode = 'daily'
+    run.generatorVersion = 3
+    run.rulesetVersion = 2
+    run.runKey = 'ice-slide:daily:2026-08-02:g3:r2'
+    run.seed = 'ice-slide:daily:3:2:2026-08-02'
+    expect(() => assertValidIceSlideRunDefinition(run)).not.toThrow()
+})
+
+it('validates an Expedition key against the seed hash', () => {
+    const run = cloneRun()
+    run.mode = 'expedition'
+    run.generatorVersion = 4
+    run.rulesetVersion = 2
+    run.seed = 'ice-slide:expedition:sample-seed'
+    run.runKey = `ice-slide:expedition:${hashString32Hex(run.seed)}:` + 'g4:r2'
+
+    expect(() => assertValidIceSlideRunDefinition(run)).not.toThrow()
+})
+
+it('deep-clones every mutable run array', () => {
+    const source = createCampaignRunDefinition()
+    const clone = cloneIceSlideRunDefinition(source)
+
+    clone.stages[0].rows[0] = 'xxxxx'
+    clone.stages[0].mutationIds.push('mutation:a')
+    clone.stages[0].objectiveIds.push('no_reset')
+    clone.stages.push(structuredClone(clone.stages[0]))
+
+    expect(source.stages).toHaveLength(8)
+    expect(source.stages[0].rows[0]).toBe('#####')
+    expect(source.stages[0].mutationIds).toEqual([])
+    expect(source.stages[0].objectiveIds).toEqual([])
+})

--- a/src/lib/games/ice-slide/run.test.ts
+++ b/src/lib/games/ice-slide/run.test.ts
@@ -25,10 +25,13 @@ describe('Ice Slide run versions and signatures', () => {
             createIceSlideStageSignature({
                 rows: ICE_SLIDE_LEVELS[0].rows,
                 parMoves: 1,
+                transform: 'identity',
+                mutationIds: [],
+                difficulty: 'tutorial',
                 objectiveIds: [],
                 scoreMultiplierBps: 10000,
             })
-        ).toBe('is1-a387e186')
+        ).toBe('is2-68616e2d')
     })
 })
 
@@ -60,7 +63,7 @@ describe('Campaign run materialization', () => {
             expect(stage.mutationIds).toEqual([])
             expect(stage.objectiveIds).toEqual([])
             expect(stage.scoreMultiplierBps).toBe(10000)
-            expect(stage.signature).toMatch(/^is1-[0-9a-f]{8}$/)
+            expect(stage.signature).toMatch(/^is2-[0-9a-f]{8}$/)
         }
     })
 
@@ -94,18 +97,21 @@ it.each([
         (run: ReturnType<typeof createCampaignRunDefinition>) => {
             run.runKey = 'ice slide'
         },
+        'runKey must be transport-safe',
     ],
     [
         'version mismatch',
         (run: ReturnType<typeof createCampaignRunDefinition>) => {
-            run.runKey = 'ice-slide:campaign:g2:r1'
+            run.generatorVersion = 2
         },
+        'campaign versions must match the campaign runKey',
     ],
     [
         'Campaign seed',
         (run: ReturnType<typeof createCampaignRunDefinition>) => {
             run.seed = 'not-null'
         },
+        'campaign seed must be null',
     ],
     [
         'too many stages',
@@ -115,23 +121,92 @@ it.each([
                 id: `campaign:${index + 1}`,
             }))
         },
+        'run must contain between 1 and 64 stages',
     ],
     [
         'multiplier below band',
         (run: ReturnType<typeof createCampaignRunDefinition>) => {
             run.stages[0].scoreMultiplierBps = 999
         },
+        'scoreMultiplierBps must be an integer from 1000 through 50000',
     ],
     [
         'multiplier above band',
         (run: ReturnType<typeof createCampaignRunDefinition>) => {
             run.stages[0].scoreMultiplierBps = 50001
         },
+        'scoreMultiplierBps must be an integer from 1000 through 50000',
     ],
-] as const)('rejects %s', (_name, mutate) => {
+    [
+        'fractional multiplier',
+        (run: ReturnType<typeof createCampaignRunDefinition>) => {
+            run.stages[0].scoreMultiplierBps = 10000.5
+        },
+        'scoreMultiplierBps must be an integer from 1000 through 50000',
+    ],
+    [
+        'unknown glyph',
+        (run: ReturnType<typeof createCampaignRunDefinition>) => {
+            run.stages[0].rows = ['#####', '#S..#', '#Z..#', '#G..#', '#####']
+            run.stages[0].signature = createIceSlideStageSignature(
+                run.stages[0]
+            )
+        },
+        'unknown stage glyph',
+    ],
+    [
+        'non-rectangular rows',
+        (run: ReturnType<typeof createCampaignRunDefinition>) => {
+            run.stages[0].rows = ['#####', '#S..#', '###', '#G..#', '#####']
+        },
+        'stage rows must be rectangular',
+    ],
+    [
+        'signature mismatch',
+        (run: ReturnType<typeof createCampaignRunDefinition>) => {
+            run.stages[0].signature = 'is2-deadbeef'
+        },
+        'stage signature does not match its definition',
+    ],
+    [
+        'duplicate stage IDs',
+        (run: ReturnType<typeof createCampaignRunDefinition>) => {
+            run.stages[1] = structuredClone(run.stages[0])
+        },
+        'stage ids must contain unique non-empty values',
+    ],
+    [
+        'unknown objective',
+        (run: ReturnType<typeof createCampaignRunDefinition>) => {
+            run.stages[0].objectiveIds = ['no_falls', 'unknown' as never]
+            run.stages[0].signature = createIceSlideStageSignature(
+                run.stages[0]
+            )
+        },
+        'unknown objective "unknown"',
+    ],
+    [
+        'daily seed mismatch',
+        (run: ReturnType<typeof createCampaignRunDefinition>) => {
+            run.mode = 'daily'
+            run.runKey = 'ice-slide:daily:2026-08-03:g1:r1'
+            run.seed = 'ice-slide:daily:1:1:2026-08-04'
+        },
+        'daily seed must match the runKey date and versions',
+    ],
+    [
+        'expedition hash mismatch',
+        (run: ReturnType<typeof createCampaignRunDefinition>) => {
+            run.mode = 'expedition'
+            run.runKey = 'ice-slide:expedition:deadbeef:g1:r1'
+            run.seed = 'test-seed'
+        },
+        'expedition runKey hash must equal hashString32Hex(seed)',
+    ],
+] as const)('rejects %s', (_name, mutate, message) => {
     const run = cloneRun()
     mutate(run)
-    expect(() => assertValidIceSlideRunDefinition(run)).toThrow()
+    expect(() => assertValidIceSlideRunDefinition(run)).toThrow(message)
 })
 
 it('validates a Daily key/date/seed relationship', () => {

--- a/src/lib/games/ice-slide/run.ts
+++ b/src/lib/games/ice-slide/run.ts
@@ -1,0 +1,294 @@
+import { hashString32Hex } from '../shared/seeded-rng'
+import { ICE_SLIDE_LEVELS } from './levels'
+import { BOARD_TRANSFORMS, serializeBoardRows } from './transforms'
+import {
+    GLYPH_TO_CELL,
+    type BoardTransform,
+    type IceSlideDifficulty,
+    type IceSlideMode,
+    type IceSlideObjectiveId,
+    type IceSlideRunDefinition,
+} from './types'
+
+export const ICE_SLIDE_RUN_SCHEMA_VERSION = 1 as const
+export const ICE_SLIDE_CAMPAIGN_GENERATOR_VERSION = 1
+export const ICE_SLIDE_RULESET_VERSION = 1
+
+export const CAMPAIGN_RUN_KEY =
+    `ice-slide:campaign:` +
+    `g${ICE_SLIDE_CAMPAIGN_GENERATOR_VERSION}:` +
+    `r${ICE_SLIDE_RULESET_VERSION}`
+
+export function createIceSlideStageSignature(input: {
+    rows: readonly string[]
+    parMoves: number
+    objectiveIds: readonly IceSlideObjectiveId[]
+    scoreMultiplierBps: number
+}): string {
+    const sortedObjectiveIds = [...input.objectiveIds].sort()
+    const payload = [
+        'ice-slide-stage:v1',
+        `rows=${serializeBoardRows(input.rows)}`,
+        `parMoves=${input.parMoves}`,
+        `objectiveIds=${sortedObjectiveIds.join(',')}`,
+        `scoreMultiplierBps=${input.scoreMultiplierBps}`,
+    ].join('\u001d')
+
+    return `is1-${hashString32Hex(payload)}`
+}
+
+const CAMPAIGN_DIFFICULTIES: readonly IceSlideDifficulty[] = [
+    'tutorial',
+    'easy',
+    'easy',
+    'medium',
+    'medium',
+    'medium',
+    'hard',
+    'hard',
+]
+
+export function createCampaignRunDefinition(): IceSlideRunDefinition {
+    return {
+        schemaVersion: ICE_SLIDE_RUN_SCHEMA_VERSION,
+        generatorVersion: ICE_SLIDE_CAMPAIGN_GENERATOR_VERSION,
+        rulesetVersion: ICE_SLIDE_RULESET_VERSION,
+        mode: 'campaign',
+        runKey: CAMPAIGN_RUN_KEY,
+        seed: null,
+        stages: ICE_SLIDE_LEVELS.map((level, index) => {
+            const rows = [...level.rows]
+            const stage = {
+                id: `campaign:${level.id}`,
+                name: level.name,
+                templateId: `campaign:${level.id}`,
+                difficulty: CAMPAIGN_DIFFICULTIES[index],
+                rows,
+                parMoves: level.parMoves,
+                transform: 'identity' as const,
+                mutationIds: [],
+                objectiveIds: [],
+                scoreMultiplierBps: 10000,
+                signature: '',
+            }
+            stage.signature = createIceSlideStageSignature(stage)
+            return stage
+        }),
+    }
+}
+
+const RUN_KEY_PATTERN = /^[A-Za-z0-9:._-]+$/
+const RUN_KEY_MAX_LENGTH = 128
+const DAILY_KEY_PATTERN =
+    /^ice-slide:daily:(\d{4}-\d{2}-\d{2}):g([1-9]\d*):r([1-9]\d*)$/
+const EXPEDITION_KEY_PATTERN =
+    /^ice-slide:expedition:([0-9a-f]{8}):g([1-9]\d*):r([1-9]\d*)$/
+
+const MODES = new Set<IceSlideMode>(['campaign', 'daily', 'expedition'])
+const DIFFICULTIES = new Set<IceSlideDifficulty>([
+    'tutorial',
+    'easy',
+    'medium',
+    'hard',
+])
+const OBJECTIVES = new Set<IceSlideObjectiveId>([
+    'collect_all_crystals',
+    'no_falls',
+    'no_reset',
+])
+const TRANSFORMS = new Set<BoardTransform>(BOARD_TRANSFORMS)
+
+function assertPositiveInt(value: number, field: string): void {
+    if (!Number.isInteger(value) || value < 1 || value > 0x7fffffff) {
+        throw new RangeError(`${field} must be a positive signed integer`)
+    }
+}
+
+function assertUniqueNonEmpty(values: readonly string[], field: string): void {
+    const seen = new Set<string>()
+    for (const value of values) {
+        if (value.length === 0 || seen.has(value)) {
+            throw new RangeError(
+                `${field} must contain unique non-empty values`
+            )
+        }
+        seen.add(value)
+    }
+}
+
+export function assertValidIceSlideRunDefinition(
+    run: IceSlideRunDefinition
+): void {
+    if (run.schemaVersion !== ICE_SLIDE_RUN_SCHEMA_VERSION) {
+        throw new RangeError(
+            `schemaVersion must be ${ICE_SLIDE_RUN_SCHEMA_VERSION}`
+        )
+    }
+    assertPositiveInt(run.generatorVersion, 'generatorVersion')
+    assertPositiveInt(run.rulesetVersion, 'rulesetVersion')
+    if (!MODES.has(run.mode)) {
+        throw new RangeError(`unknown run mode "${run.mode}"`)
+    }
+
+    if (
+        run.runKey.length > RUN_KEY_MAX_LENGTH ||
+        !RUN_KEY_PATTERN.test(run.runKey)
+    ) {
+        throw new RangeError(
+            `runKey must be transport-safe and at most ${RUN_KEY_MAX_LENGTH} characters`
+        )
+    }
+
+    if (run.mode === 'campaign') {
+        if (run.runKey !== CAMPAIGN_RUN_KEY) {
+            throw new RangeError(`campaign runKey must be ${CAMPAIGN_RUN_KEY}`)
+        }
+        if (
+            run.generatorVersion !== ICE_SLIDE_CAMPAIGN_GENERATOR_VERSION ||
+            run.rulesetVersion !== ICE_SLIDE_RULESET_VERSION
+        ) {
+            throw new RangeError(
+                'campaign versions must match the campaign runKey'
+            )
+        }
+        if (run.seed !== null) {
+            throw new RangeError('campaign seed must be null')
+        }
+    } else if (run.mode === 'daily') {
+        const match = DAILY_KEY_PATTERN.exec(run.runKey)
+        if (!match) {
+            throw new RangeError('daily runKey must match the daily key format')
+        }
+        const generatorVersion = Number(match[2])
+        const rulesetVersion = Number(match[3])
+        if (run.generatorVersion !== generatorVersion) {
+            throw new RangeError('daily generatorVersion must match the runKey')
+        }
+        if (run.rulesetVersion !== rulesetVersion) {
+            throw new RangeError('daily rulesetVersion must match the runKey')
+        }
+        const expectedSeed =
+            `ice-slide:daily:${generatorVersion}:` +
+            `${rulesetVersion}:${match[1]}`
+        if (run.seed !== expectedSeed) {
+            throw new RangeError(
+                'daily seed must match the runKey date and versions'
+            )
+        }
+    } else {
+        const match = EXPEDITION_KEY_PATTERN.exec(run.runKey)
+        if (!match) {
+            throw new RangeError(
+                'expedition runKey must match the expedition key format'
+            )
+        }
+        const keyHash = match[1]
+        const generatorVersion = Number(match[2])
+        const rulesetVersion = Number(match[3])
+        if (run.generatorVersion !== generatorVersion) {
+            throw new RangeError(
+                'expedition generatorVersion must match the runKey'
+            )
+        }
+        if (run.rulesetVersion !== rulesetVersion) {
+            throw new RangeError(
+                'expedition rulesetVersion must match the runKey'
+            )
+        }
+        if (
+            run.seed === null ||
+            run.seed.length === 0 ||
+            run.seed.includes('\u001f')
+        ) {
+            throw new RangeError(
+                'expedition seed must be non-empty without U+001F'
+            )
+        }
+        if (hashString32Hex(run.seed) !== keyHash) {
+            throw new RangeError(
+                'expedition runKey hash must equal hashString32Hex(seed)'
+            )
+        }
+    }
+
+    if (
+        !Number.isInteger(run.stages.length) ||
+        run.stages.length < 1 ||
+        run.stages.length > 64
+    ) {
+        throw new RangeError('run must contain between 1 and 64 stages')
+    }
+    assertUniqueNonEmpty(
+        run.stages.map(stage => stage.id),
+        'stage ids'
+    )
+
+    for (const stage of run.stages) {
+        if (!DIFFICULTIES.has(stage.difficulty)) {
+            throw new RangeError(
+                `unknown stage difficulty "${stage.difficulty}"`
+            )
+        }
+        if (!TRANSFORMS.has(stage.transform)) {
+            throw new RangeError(`unknown stage transform "${stage.transform}"`)
+        }
+        if (stage.rows.length === 0) {
+            throw new RangeError('stage rows must not be empty')
+        }
+        const cols = stage.rows[0].length
+        for (const row of stage.rows) {
+            if (row.length !== cols) {
+                throw new RangeError('stage rows must be rectangular')
+            }
+        }
+        for (const row of stage.rows) {
+            for (const glyph of row) {
+                if (!GLYPH_TO_CELL[glyph]) {
+                    throw new RangeError(`unknown stage glyph "${glyph}"`)
+                }
+            }
+        }
+        assertPositiveInt(stage.parMoves, 'parMoves')
+        if (
+            !Number.isInteger(stage.scoreMultiplierBps) ||
+            stage.scoreMultiplierBps < 1000 ||
+            stage.scoreMultiplierBps > 50000
+        ) {
+            throw new RangeError(
+                'scoreMultiplierBps must be an integer from 1000 through 50000'
+            )
+        }
+        assertUniqueNonEmpty(stage.mutationIds, 'mutation ids')
+        assertUniqueNonEmpty(stage.objectiveIds, 'objective ids')
+        for (const objectiveId of stage.objectiveIds) {
+            if (!OBJECTIVES.has(objectiveId)) {
+                throw new RangeError(`unknown objective "${objectiveId}"`)
+            }
+        }
+        const expectedSignature = createIceSlideStageSignature({
+            rows: stage.rows,
+            parMoves: stage.parMoves,
+            objectiveIds: stage.objectiveIds,
+            scoreMultiplierBps: stage.scoreMultiplierBps,
+        })
+        if (stage.signature !== expectedSignature) {
+            throw new RangeError(
+                'stage signature does not match its definition'
+            )
+        }
+    }
+}
+
+export function cloneIceSlideRunDefinition(
+    run: IceSlideRunDefinition
+): IceSlideRunDefinition {
+    return {
+        ...run,
+        stages: run.stages.map(stage => ({
+            ...stage,
+            rows: [...stage.rows],
+            mutationIds: [...stage.mutationIds],
+            objectiveIds: [...stage.objectiveIds],
+        })),
+    }
+}

--- a/src/lib/games/ice-slide/run.ts
+++ b/src/lib/games/ice-slide/run.ts
@@ -35,7 +35,7 @@ export function createIceSlideStageSignature(input: {
         `rows=${serializeBoardRows(input.rows)}`,
         `parMoves=${input.parMoves}`,
         `transform=${input.transform}`,
-        `mutationIds=${sortedMutationIds.join(',')}`,
+        `mutationIds=${JSON.stringify(sortedMutationIds)}`,
         `difficulty=${input.difficulty}`,
         `objectiveIds=${sortedObjectiveIds.join(',')}`,
         `scoreMultiplierBps=${input.scoreMultiplierBps}`,
@@ -96,26 +96,30 @@ const DAILY_KEY_PATTERN =
 const EXPEDITION_KEY_PATTERN =
     /^ice-slide:expedition:([0-9a-f]{8}):g([1-9]\d*):r([1-9]\d*)$/
 
-const MODE_TUPLE: readonly IceSlideMode[] = [
-    'campaign',
-    'daily',
-    'expedition',
-] as const satisfies readonly IceSlideMode[]
-const DIFFICULTY_TUPLE: readonly IceSlideDifficulty[] = [
-    'tutorial',
-    'easy',
-    'medium',
-    'hard',
-] as const satisfies readonly IceSlideDifficulty[]
-const OBJECTIVE_TUPLE: readonly IceSlideObjectiveId[] = [
-    'collect_all_crystals',
-    'no_falls',
-    'no_reset',
-] as const satisfies readonly IceSlideObjectiveId[]
+const MODE_RECORD = {
+    campaign: true,
+    daily: true,
+    expedition: true,
+} as const satisfies Record<IceSlideMode, true>
+const DIFFICULTY_RECORD = {
+    tutorial: true,
+    easy: true,
+    medium: true,
+    hard: true,
+} as const satisfies Record<IceSlideDifficulty, true>
+const OBJECTIVE_RECORD = {
+    collect_all_crystals: true,
+    no_falls: true,
+    no_reset: true,
+} as const satisfies Record<IceSlideObjectiveId, true>
 
-const MODES = new Set<IceSlideMode>(MODE_TUPLE)
-const DIFFICULTIES = new Set<IceSlideDifficulty>(DIFFICULTY_TUPLE)
-const OBJECTIVES = new Set<IceSlideObjectiveId>(OBJECTIVE_TUPLE)
+const MODES = new Set<IceSlideMode>(Object.keys(MODE_RECORD) as IceSlideMode[])
+const DIFFICULTIES = new Set<IceSlideDifficulty>(
+    Object.keys(DIFFICULTY_RECORD) as IceSlideDifficulty[]
+)
+const OBJECTIVES = new Set<IceSlideObjectiveId>(
+    Object.keys(OBJECTIVE_RECORD) as IceSlideObjectiveId[]
+)
 const TRANSFORMS = new Set<BoardTransform>(BOARD_TRANSFORMS)
 
 function assertPositiveInt(value: number, field: string): void {

--- a/src/lib/games/ice-slide/run.ts
+++ b/src/lib/games/ice-slide/run.ts
@@ -22,19 +22,26 @@ export const CAMPAIGN_RUN_KEY =
 export function createIceSlideStageSignature(input: {
     rows: readonly string[]
     parMoves: number
+    transform: BoardTransform
+    mutationIds: readonly string[]
+    difficulty: IceSlideDifficulty
     objectiveIds: readonly IceSlideObjectiveId[]
     scoreMultiplierBps: number
 }): string {
+    const sortedMutationIds = [...input.mutationIds].sort()
     const sortedObjectiveIds = [...input.objectiveIds].sort()
     const payload = [
-        'ice-slide-stage:v1',
+        'ice-slide-stage:v2',
         `rows=${serializeBoardRows(input.rows)}`,
         `parMoves=${input.parMoves}`,
+        `transform=${input.transform}`,
+        `mutationIds=${sortedMutationIds.join(',')}`,
+        `difficulty=${input.difficulty}`,
         `objectiveIds=${sortedObjectiveIds.join(',')}`,
         `scoreMultiplierBps=${input.scoreMultiplierBps}`,
     ].join('\u001d')
 
-    return `is1-${hashString32Hex(payload)}`
+    return `is2-${hashString32Hex(payload)}`
 }
 
 const CAMPAIGN_DIFFICULTIES: readonly IceSlideDifficulty[] = [
@@ -49,6 +56,11 @@ const CAMPAIGN_DIFFICULTIES: readonly IceSlideDifficulty[] = [
 ]
 
 export function createCampaignRunDefinition(): IceSlideRunDefinition {
+    if (CAMPAIGN_DIFFICULTIES.length !== ICE_SLIDE_LEVELS.length) {
+        throw new Error(
+            'CAMPAIGN_DIFFICULTIES and ICE_SLIDE_LEVELS must have the same length'
+        )
+    }
     return {
         schemaVersion: ICE_SLIDE_RUN_SCHEMA_VERSION,
         generatorVersion: ICE_SLIDE_CAMPAIGN_GENERATOR_VERSION,
@@ -84,18 +96,26 @@ const DAILY_KEY_PATTERN =
 const EXPEDITION_KEY_PATTERN =
     /^ice-slide:expedition:([0-9a-f]{8}):g([1-9]\d*):r([1-9]\d*)$/
 
-const MODES = new Set<IceSlideMode>(['campaign', 'daily', 'expedition'])
-const DIFFICULTIES = new Set<IceSlideDifficulty>([
+const MODE_TUPLE: readonly IceSlideMode[] = [
+    'campaign',
+    'daily',
+    'expedition',
+] as const satisfies readonly IceSlideMode[]
+const DIFFICULTY_TUPLE: readonly IceSlideDifficulty[] = [
     'tutorial',
     'easy',
     'medium',
     'hard',
-])
-const OBJECTIVES = new Set<IceSlideObjectiveId>([
+] as const satisfies readonly IceSlideDifficulty[]
+const OBJECTIVE_TUPLE: readonly IceSlideObjectiveId[] = [
     'collect_all_crystals',
     'no_falls',
     'no_reset',
-])
+] as const satisfies readonly IceSlideObjectiveId[]
+
+const MODES = new Set<IceSlideMode>(MODE_TUPLE)
+const DIFFICULTIES = new Set<IceSlideDifficulty>(DIFFICULTY_TUPLE)
+const OBJECTIVES = new Set<IceSlideObjectiveId>(OBJECTIVE_TUPLE)
 const TRANSFORMS = new Set<BoardTransform>(BOARD_TRANSFORMS)
 
 function assertPositiveInt(value: number, field: string): void {
@@ -158,6 +178,21 @@ export function assertValidIceSlideRunDefinition(
         const match = DAILY_KEY_PATTERN.exec(run.runKey)
         if (!match) {
             throw new RangeError('daily runKey must match the daily key format')
+        }
+        const dateSegment = match[1]
+        const [yearStr, monthStr, dayStr] = dateSegment.split('-')
+        const year = Number(yearStr)
+        const month = Number(monthStr)
+        const day = Number(dayStr)
+        const date = new Date(Date.UTC(year, month - 1, day))
+        if (
+            date.getUTCFullYear() !== year ||
+            date.getUTCMonth() !== month - 1 ||
+            date.getUTCDate() !== day
+        ) {
+            throw new RangeError(
+                'daily runKey date must be a calendar-valid YYYY-MM-DD date'
+            )
         }
         const generatorVersion = Number(match[2])
         const rulesetVersion = Number(match[3])
@@ -236,6 +271,9 @@ export function assertValidIceSlideRunDefinition(
             throw new RangeError('stage rows must not be empty')
         }
         const cols = stage.rows[0].length
+        if (cols === 0) {
+            throw new RangeError('stage rows must not have zero columns')
+        }
         for (const row of stage.rows) {
             if (row.length !== cols) {
                 throw new RangeError('stage rows must be rectangular')
@@ -268,6 +306,9 @@ export function assertValidIceSlideRunDefinition(
         const expectedSignature = createIceSlideStageSignature({
             rows: stage.rows,
             parMoves: stage.parMoves,
+            transform: stage.transform,
+            mutationIds: stage.mutationIds,
+            difficulty: stage.difficulty,
             objectiveIds: stage.objectiveIds,
             scoreMultiplierBps: stage.scoreMultiplierBps,
         })

--- a/src/lib/games/ice-slide/test-fixtures.ts
+++ b/src/lib/games/ice-slide/test-fixtures.ts
@@ -1,0 +1,56 @@
+import { hashString32Hex } from '../shared/seeded-rng'
+import {
+    createIceSlideStageSignature,
+    ICE_SLIDE_RULESET_VERSION,
+    ICE_SLIDE_RUN_SCHEMA_VERSION,
+} from './run'
+import type { IceSlideRunDefinition, IceSlideStageDefinition } from './types'
+
+export function createTestStage(
+    overrides: Partial<IceSlideStageDefinition> = {}
+): IceSlideStageDefinition {
+    const base: IceSlideStageDefinition = {
+        id: 'test:1',
+        name: 'Test Stage',
+        templateId: 'test:1',
+        difficulty: 'easy',
+        rows: ['#####', '#S.G#', '#####'],
+        parMoves: 1,
+        transform: 'identity',
+        mutationIds: [],
+        objectiveIds: [],
+        scoreMultiplierBps: 10000,
+        signature: '',
+    }
+    const stage = {
+        ...base,
+        ...overrides,
+        rows: [...(overrides.rows ?? base.rows)],
+        mutationIds: [...(overrides.mutationIds ?? base.mutationIds)],
+        objectiveIds: [...(overrides.objectiveIds ?? base.objectiveIds)],
+    }
+    stage.signature = createIceSlideStageSignature(stage)
+    return stage
+}
+
+export function createTestRun(
+    stages: IceSlideStageDefinition[] = [createTestStage()],
+    overrides: Partial<IceSlideRunDefinition> = {}
+): IceSlideRunDefinition {
+    return {
+        schemaVersion: ICE_SLIDE_RUN_SCHEMA_VERSION,
+        generatorVersion: 1,
+        rulesetVersion: ICE_SLIDE_RULESET_VERSION,
+        mode: 'expedition',
+        runKey:
+            'ice-slide:expedition:' + hashString32Hex('test-seed') + ':g1:r1',
+        seed: 'test-seed',
+        stages: stages.map(stage => ({
+            ...stage,
+            rows: [...stage.rows],
+            mutationIds: [...stage.mutationIds],
+            objectiveIds: [...stage.objectiveIds],
+        })),
+        ...overrides,
+    }
+}

--- a/src/lib/games/ice-slide/test-fixtures.ts
+++ b/src/lib/games/ice-slide/test-fixtures.ts
@@ -43,7 +43,9 @@ export function createTestRun(
         rulesetVersion: ICE_SLIDE_RULESET_VERSION,
         mode: 'expedition',
         runKey:
-            'ice-slide:expedition:' + hashString32Hex('test-seed') + ':g1:r1',
+            'ice-slide:expedition:' +
+            hashString32Hex('test-seed') +
+            `:g1:r${ICE_SLIDE_RULESET_VERSION}`,
         seed: 'test-seed',
         stages: stages.map(stage => ({
             ...stage,

--- a/src/lib/games/ice-slide/transforms.test.ts
+++ b/src/lib/games/ice-slide/transforms.test.ts
@@ -1,0 +1,92 @@
+import { describe, expect, it } from 'vitest'
+import {
+    BOARD_TRANSFORMS,
+    getUniqueBoardTransforms,
+    hashBoardRows,
+    inverseBoardTransform,
+    serializeBoardRows,
+    transformPosition,
+    transformRows,
+} from './transforms'
+
+describe('Ice Slide board transforms', () => {
+    const rows = ['ABC', 'DEF'] as const
+
+    it.each([
+        ['identity', ['ABC', 'DEF']],
+        ['rotate_90', ['DA', 'EB', 'FC']],
+        ['rotate_180', ['FED', 'CBA']],
+        ['rotate_270', ['CF', 'BE', 'AD']],
+        ['reflect_horizontal', ['DEF', 'ABC']],
+        ['reflect_vertical', ['CBA', 'FED']],
+        ['reflect_main_diagonal', ['AD', 'BE', 'CF']],
+        ['reflect_anti_diagonal', ['FC', 'EB', 'DA']],
+    ] as const)('applies %s', (transform, expected) => {
+        expect(transformRows(rows, transform)).toEqual(expected)
+    })
+
+    it('locks transform enumeration order', () => {
+        expect(BOARD_TRANSFORMS).toEqual([
+            'identity',
+            'rotate_90',
+            'rotate_180',
+            'rotate_270',
+            'reflect_horizontal',
+            'reflect_vertical',
+            'reflect_main_diagonal',
+            'reflect_anti_diagonal',
+        ])
+    })
+})
+
+it.each(BOARD_TRANSFORMS)(
+    'keeps transformed coordinates aligned for %s',
+    transform => {
+        const source = ['ABC', 'DEF']
+        const transformed = transformRows(source, transform)
+
+        for (let row = 0; row < source.length; row++) {
+            for (let col = 0; col < source[0].length; col++) {
+                const target = transformPosition({ row, col }, 2, 3, transform)
+                expect(transformed[target.row][target.col]).toBe(
+                    source[row][col]
+                )
+            }
+        }
+    }
+)
+
+it.each(BOARD_TRANSFORMS)('round-trips rows through inverse %s', transform => {
+    const source = ['ABC', 'DEF']
+    const transformed = transformRows(source, transform)
+    expect(
+        transformRows(transformed, inverseBoardTransform(transform))
+    ).toEqual(source)
+})
+
+it('serializes dimensions and row boundaries exactly', () => {
+    expect(serializeBoardRows(['AB', 'CD'])).toBe('2x2\u001fAB\u001eCD')
+    expect(hashBoardRows(['AB', 'CD'])).toMatch(/^[0-9a-f]{8}$/)
+})
+
+it.each([
+    [[]] as [string[]],
+    [['']] as [string[]],
+    [['ABC', 'DE']] as [string[]],
+])('rejects malformed canonical rows %j', rows => {
+    expect(() => serializeBoardRows(rows)).toThrow(RangeError)
+    expect(() => hashBoardRows(rows)).toThrow(RangeError)
+})
+
+it('deduplicates by complete canonical serialization', () => {
+    const variants = getUniqueBoardTransforms(['AAA', 'ABA', 'AAA'])
+    expect(variants).toHaveLength(1)
+    expect(variants[0].transform).toBe('identity')
+})
+
+it('retains all variants for an asymmetric rectangle', () => {
+    const variants = getUniqueBoardTransforms(['ABC', 'DEF'])
+    expect(variants).toHaveLength(8)
+    expect(variants.map(variant => variant.transform)).toEqual(BOARD_TRANSFORMS)
+    expect(new Set(variants.map(variant => variant.canonicalKey)).size).toBe(8)
+})

--- a/src/lib/games/ice-slide/transforms.test.ts
+++ b/src/lib/games/ice-slide/transforms.test.ts
@@ -78,6 +78,22 @@ it.each([
     expect(() => hashBoardRows(rows)).toThrow(RangeError)
 })
 
+it.each([
+    ['negative row', { row: -1, col: 0 }, 2, 2],
+    ['negative col', { row: 0, col: -1 }, 2, 2],
+    ['row out of range', { row: 2, col: 0 }, 2, 2],
+    ['col out of range', { row: 0, col: 2 }, 2, 2],
+    ['non-integer rows', { row: 0, col: 0 }, 1.5, 2],
+    ['non-integer cols', { row: 0, col: 0 }, 2, 0],
+] as const)(
+    'rejects out-of-bounds position for %s',
+    (_name, position, rows, cols) => {
+        expect(() =>
+            transformPosition(position, rows, cols, 'identity')
+        ).toThrow(RangeError)
+    }
+)
+
 it('deduplicates by complete canonical serialization', () => {
     const variants = getUniqueBoardTransforms(['AAA', 'ABA', 'AAA'])
     expect(variants).toHaveLength(1)

--- a/src/lib/games/ice-slide/transforms.test.ts
+++ b/src/lib/games/ice-slide/transforms.test.ts
@@ -1,4 +1,5 @@
 import { describe, expect, it } from 'vitest'
+import type { BoardTransform, GridPosition } from './types'
 import {
     BOARD_TRANSFORMS,
     getUniqueBoardTransforms,
@@ -21,9 +22,12 @@ describe('Ice Slide board transforms', () => {
         ['reflect_vertical', ['CBA', 'FED']],
         ['reflect_main_diagonal', ['AD', 'BE', 'CF']],
         ['reflect_anti_diagonal', ['FC', 'EB', 'DA']],
-    ] as const)('applies %s', (transform, expected) => {
-        expect(transformRows(rows, transform)).toEqual(expected)
-    })
+    ] as const)(
+        'applies %s',
+        (transform: BoardTransform, expected: readonly string[]) => {
+            expect(transformRows(rows, transform)).toEqual(expected)
+        }
+    )
 
     it('locks transform enumeration order', () => {
         expect(BOARD_TRANSFORMS).toEqual([
@@ -41,7 +45,7 @@ describe('Ice Slide board transforms', () => {
 
 it.each(BOARD_TRANSFORMS)(
     'keeps transformed coordinates aligned for %s',
-    transform => {
+    (transform: BoardTransform) => {
         const source = ['ABC', 'DEF']
         const transformed = transformRows(source, transform)
 
@@ -70,13 +74,16 @@ it('throws RangeError for an out-of-range position', () => {
     ).toThrow(RangeError)
 })
 
-it.each(BOARD_TRANSFORMS)('round-trips rows through inverse %s', transform => {
-    const source = ['ABC', 'DEF']
-    const transformed = transformRows(source, transform)
-    expect(
-        transformRows(transformed, inverseBoardTransform(transform))
-    ).toEqual(source)
-})
+it.each(BOARD_TRANSFORMS)(
+    'round-trips rows through inverse %s',
+    (transform: BoardTransform) => {
+        const source = ['ABC', 'DEF']
+        const transformed = transformRows(source, transform)
+        expect(
+            transformRows(transformed, inverseBoardTransform(transform))
+        ).toEqual(source)
+    }
+)
 
 it('serializes dimensions and row boundaries exactly', () => {
     expect(serializeBoardRows(['AB', 'CD'])).toBe('2x2\u001fAB\u001eCD')
@@ -87,7 +94,7 @@ it.each([
     [[]] as [string[]],
     [['']] as [string[]],
     [['ABC', 'DE']] as [string[]],
-])('rejects malformed canonical rows %j', rows => {
+])('rejects malformed canonical rows %j', (rows: string[]) => {
     expect(() => serializeBoardRows(rows)).toThrow(RangeError)
     expect(() => hashBoardRows(rows)).toThrow(RangeError)
 })
@@ -104,9 +111,14 @@ it.each([
     ['zero inputCols', { row: 0, col: 0 }, 2, 0],
 ] as const)(
     'rejects out-of-bounds position for %s',
-    (_name, position, rows, cols) => {
+    (
+        _name: string,
+        position: GridPosition,
+        inputRows: number,
+        inputCols: number
+    ) => {
         expect(() =>
-            transformPosition(position, rows, cols, 'identity')
+            transformPosition(position, inputRows, inputCols, 'identity')
         ).toThrow(RangeError)
     }
 )

--- a/src/lib/games/ice-slide/transforms.test.ts
+++ b/src/lib/games/ice-slide/transforms.test.ts
@@ -97,8 +97,11 @@ it.each([
     ['negative col', { row: 0, col: -1 }, 2, 2],
     ['row out of range', { row: 2, col: 0 }, 2, 2],
     ['col out of range', { row: 0, col: 2 }, 2, 2],
-    ['non-integer rows', { row: 0, col: 0 }, 1.5, 2],
-    ['non-integer cols', { row: 0, col: 0 }, 2, 0],
+    ['fractional inputRows', { row: 0, col: 0 }, 1.5, 2],
+    ['fractional inputCols', { row: 0, col: 0 }, 2, 1.5],
+    ['fractional position row', { row: 0.5, col: 0 }, 2, 2],
+    ['fractional position col', { row: 0, col: 0.5 }, 2, 2],
+    ['zero inputCols', { row: 0, col: 0 }, 2, 0],
 ] as const)(
     'rejects out-of-bounds position for %s',
     (_name, position, rows, cols) => {
@@ -119,4 +122,26 @@ it('retains all variants for an asymmetric rectangle', () => {
     expect(variants).toHaveLength(8)
     expect(variants.map(variant => variant.transform)).toEqual(BOARD_TRANSFORMS)
     expect(new Set(variants.map(variant => variant.canonicalKey)).size).toBe(8)
+})
+
+it('keeps exactly two variants for a board with fourfold rotation symmetry', () => {
+    const variants = getUniqueBoardTransforms(['ABCA', 'CDDB', 'BDDC', 'ACBA'])
+    expect(variants).toHaveLength(2)
+    expect(variants.map(variant => variant.transform)).toEqual([
+        'identity',
+        'reflect_horizontal',
+    ])
+    expect(new Set(variants.map(variant => variant.canonicalKey)).size).toBe(2)
+})
+
+it('keeps exactly four variants for a board with half-turn symmetry', () => {
+    const variants = getUniqueBoardTransforms(['ABC', 'CBA'])
+    expect(variants).toHaveLength(4)
+    expect(variants.map(variant => variant.transform)).toEqual([
+        'identity',
+        'rotate_90',
+        'reflect_horizontal',
+        'reflect_main_diagonal',
+    ])
+    expect(new Set(variants.map(variant => variant.canonicalKey)).size).toBe(4)
 })

--- a/src/lib/games/ice-slide/transforms.test.ts
+++ b/src/lib/games/ice-slide/transforms.test.ts
@@ -45,9 +45,17 @@ it.each(BOARD_TRANSFORMS)(
         const source = ['ABC', 'DEF']
         const transformed = transformRows(source, transform)
 
-        for (let row = 0; row < source.length; row++) {
-            for (let col = 0; col < source[0].length; col++) {
-                const target = transformPosition({ row, col }, 2, 3, transform)
+        const sourceRows = source.length
+        const sourceCols = source[0].length
+
+        for (let row = 0; row < sourceRows; row++) {
+            for (let col = 0; col < sourceCols; col++) {
+                const target = transformPosition(
+                    { row, col },
+                    sourceRows,
+                    sourceCols,
+                    transform
+                )
                 expect(transformed[target.row][target.col]).toBe(
                     source[row][col]
                 )
@@ -55,6 +63,12 @@ it.each(BOARD_TRANSFORMS)(
         }
     }
 )
+
+it('throws RangeError for an out-of-range position', () => {
+    expect(() =>
+        transformPosition({ row: 5, col: 0 }, 2, 3, 'identity')
+    ).toThrow(RangeError)
+})
 
 it.each(BOARD_TRANSFORMS)('round-trips rows through inverse %s', transform => {
     const source = ['ABC', 'DEF']

--- a/src/lib/games/ice-slide/transforms.ts
+++ b/src/lib/games/ice-slide/transforms.ts
@@ -1,0 +1,173 @@
+import { hashString32Hex } from '../shared/seeded-rng'
+import type { BoardTransform, GridPosition } from './types'
+
+export const BOARD_TRANSFORMS: readonly BoardTransform[] = [
+    'identity',
+    'rotate_90',
+    'rotate_180',
+    'rotate_270',
+    'reflect_horizontal',
+    'reflect_vertical',
+    'reflect_main_diagonal',
+    'reflect_anti_diagonal',
+]
+
+function validateRows(rows: readonly string[]): {
+    rowCount: number
+    columnCount: number
+} {
+    if (rows.length === 0) {
+        throw new RangeError('board rows must not be empty')
+    }
+    const columnCount = rows[0].length
+    if (columnCount === 0) {
+        throw new RangeError('board rows must not have zero columns')
+    }
+    for (const row of rows) {
+        if (row.length !== columnCount) {
+            throw new RangeError('board rows must be rectangular')
+        }
+    }
+    return { rowCount: rows.length, columnCount }
+}
+
+export function transformPosition(
+    position: GridPosition,
+    inputRows: number,
+    inputCols: number,
+    transform: BoardTransform
+): GridPosition {
+    if (
+        !Number.isInteger(inputRows) ||
+        !Number.isInteger(inputCols) ||
+        inputRows < 1 ||
+        inputCols < 1 ||
+        position.row < 0 ||
+        position.row >= inputRows ||
+        position.col < 0 ||
+        position.col >= inputCols
+    ) {
+        throw new RangeError('position is outside the input board')
+    }
+
+    const { row, col } = position
+    switch (transform) {
+        case 'identity':
+            return { row, col }
+        case 'rotate_90':
+            return { row: col, col: inputRows - 1 - row }
+        case 'rotate_180':
+            return {
+                row: inputRows - 1 - row,
+                col: inputCols - 1 - col,
+            }
+        case 'rotate_270':
+            return { row: inputCols - 1 - col, col: row }
+        case 'reflect_horizontal':
+            return { row: inputRows - 1 - row, col }
+        case 'reflect_vertical':
+            return { row, col: inputCols - 1 - col }
+        case 'reflect_main_diagonal':
+            return { row: col, col: row }
+        case 'reflect_anti_diagonal':
+            return {
+                row: inputCols - 1 - col,
+                col: inputRows - 1 - row,
+            }
+    }
+}
+
+function outputDimensions(
+    inputRows: number,
+    inputCols: number,
+    transform: BoardTransform
+): { rows: number; cols: number } {
+    switch (transform) {
+        case 'rotate_90':
+        case 'rotate_270':
+        case 'reflect_main_diagonal':
+        case 'reflect_anti_diagonal':
+            return { rows: inputCols, cols: inputRows }
+        default:
+            return { rows: inputRows, cols: inputCols }
+    }
+}
+
+export function transformRows(
+    rows: readonly string[],
+    transform: BoardTransform
+): string[] {
+    const { rowCount, columnCount } = validateRows(rows)
+    const dimensions = outputDimensions(rowCount, columnCount, transform)
+    const output = Array.from({ length: dimensions.rows }, () =>
+        Array<string>(dimensions.cols)
+    )
+
+    for (let row = 0; row < rowCount; row++) {
+        for (let col = 0; col < columnCount; col++) {
+            const target = transformPosition(
+                { row, col },
+                rowCount,
+                columnCount,
+                transform
+            )
+            output[target.row][target.col] = rows[row][col]
+        }
+    }
+
+    return output.map(row => row.join(''))
+}
+
+export function inverseBoardTransform(
+    transform: BoardTransform
+): BoardTransform {
+    switch (transform) {
+        case 'rotate_90':
+            return 'rotate_270'
+        case 'rotate_270':
+            return 'rotate_90'
+        default:
+            return transform
+    }
+}
+
+export function serializeBoardRows(rows: readonly string[]): string {
+    const { rowCount, columnCount } = validateRows(rows)
+    return `${rowCount}x${columnCount}\u001f${rows.join('\u001e')}`
+}
+
+export function hashBoardRows(rows: readonly string[]): string {
+    return hashString32Hex(serializeBoardRows(rows))
+}
+
+export interface TransformedBoardVariant {
+    transform: BoardTransform
+    rows: string[]
+    canonicalKey: string
+    hash: string
+}
+
+export function getUniqueBoardTransforms(
+    rows: readonly string[]
+): TransformedBoardVariant[] {
+    validateRows(rows)
+    const seen = new Set<string>()
+    const variants: TransformedBoardVariant[] = []
+
+    for (const transform of BOARD_TRANSFORMS) {
+        const transformed = transformRows(rows, transform)
+        const canonicalKey = serializeBoardRows(transformed)
+        if (seen.has(canonicalKey)) {
+            continue
+        }
+        seen.add(canonicalKey)
+        variants.push({
+            transform,
+            rows: transformed,
+            canonicalKey,
+            hash: hashString32Hex(canonicalKey),
+        })
+    }
+
+    return variants
+}

--- a/src/lib/games/ice-slide/transforms.ts
+++ b/src/lib/games/ice-slide/transforms.ts
@@ -40,6 +40,8 @@ export function transformPosition(
     if (
         !Number.isInteger(inputRows) ||
         !Number.isInteger(inputCols) ||
+        !Number.isInteger(position.row) ||
+        !Number.isInteger(position.col) ||
         inputRows < 1 ||
         inputCols < 1 ||
         position.row < 0 ||

--- a/src/lib/games/ice-slide/types.ts
+++ b/src/lib/games/ice-slide/types.ts
@@ -71,6 +71,24 @@ export const DIRECTION_DELTA: Record<Direction, GridPosition> = {
     W: { row: 0, col: -1 },
 }
 
+export type IceSlideMode = 'campaign' | 'daily' | 'expedition'
+export type IceSlideDifficulty = 'tutorial' | 'easy' | 'medium' | 'hard'
+
+export type IceSlideObjectiveId =
+    | 'collect_all_crystals'
+    | 'no_falls'
+    | 'no_reset'
+
+export type BoardTransform =
+    | 'identity'
+    | 'rotate_90'
+    | 'rotate_180'
+    | 'rotate_270'
+    | 'reflect_horizontal'
+    | 'reflect_vertical'
+    | 'reflect_main_diagonal'
+    | 'reflect_anti_diagonal'
+
 export const GLYPH_TO_CELL: Record<string, CellType> = {
     '#': 'wall',
     '.': 'ice',

--- a/src/lib/games/ice-slide/types.ts
+++ b/src/lib/games/ice-slide/types.ts
@@ -42,6 +42,16 @@ export interface IceSlideState {
     perfectLevels: number
     levelsCleared: number
     lastSlidePath: GridPosition[]
+    mode: IceSlideMode
+    runKey: string
+    runSchemaVersion: 1
+    generatorVersion: number
+    rulesetVersion: number
+    stagesTotal: number
+    starsEarned: number
+    falls: number
+    resets: number
+    stageSignatures: string[]
 }
 
 export interface IceSlideGameData {
@@ -51,6 +61,16 @@ export interface IceSlideGameData {
     elapsedSeconds: number
     solved: boolean
     perfectLevels: number
+    mode: IceSlideMode
+    runKey: string
+    runSchemaVersion: 1
+    generatorVersion: number
+    rulesetVersion: number
+    stagesTotal: number
+    starsEarned: number
+    falls: number
+    resets: number
+    stageSignatures: string[]
 }
 
 export interface IceSlideCallbacks {
@@ -88,6 +108,30 @@ export type BoardTransform =
     | 'reflect_vertical'
     | 'reflect_main_diagonal'
     | 'reflect_anti_diagonal'
+
+export interface IceSlideRunDefinition {
+    schemaVersion: 1
+    generatorVersion: number
+    rulesetVersion: number
+    mode: IceSlideMode
+    runKey: string
+    seed: string | null
+    stages: IceSlideStageDefinition[]
+}
+
+export interface IceSlideStageDefinition {
+    id: string
+    name: string
+    templateId: string
+    difficulty: IceSlideDifficulty
+    rows: string[]
+    parMoves: number
+    transform: BoardTransform
+    mutationIds: string[]
+    objectiveIds: IceSlideObjectiveId[]
+    scoreMultiplierBps: number
+    signature: string
+}
 
 export const GLYPH_TO_CELL: Record<string, CellType> = {
     '#': 'wall',

--- a/src/lib/games/shared/seeded-rng.test.ts
+++ b/src/lib/games/shared/seeded-rng.test.ts
@@ -17,6 +17,13 @@ describe('seeded RNG hashing and stream', () => {
             rng.nextUint32(),
         ]).toEqual([1843037723, 574486829, 1018436590, 1120027984, 770965377])
     })
+
+    it('locks the first nextFloat() value in [0, 1)', () => {
+        const value = createSeededRng('ice-slide:test').nextFloat()
+        expect(value).toBe(0.4291156593244523)
+        expect(value).toBeGreaterThanOrEqual(0)
+        expect(value).toBeLessThan(1)
+    })
 })
 
 describe('seeded RNG bounded selection', () => {

--- a/src/lib/games/shared/seeded-rng.test.ts
+++ b/src/lib/games/shared/seeded-rng.test.ts
@@ -1,0 +1,136 @@
+import { afterEach, describe, expect, it, vi } from 'vitest'
+import { createSeededRng, hashString32, hashString32Hex } from './seeded-rng'
+
+describe('seeded RNG hashing and stream', () => {
+    it('locks the FNV-1a seed hash', () => {
+        expect(hashString32('ice-slide:test')).toBe(2769670846)
+        expect(hashString32Hex('ice-slide:test')).toBe('a515d2be')
+    })
+
+    it('maps the seed hash directly into the Mulberry32 state', () => {
+        const rng = createSeededRng('ice-slide:test')
+        expect([
+            rng.nextUint32(),
+            rng.nextUint32(),
+            rng.nextUint32(),
+            rng.nextUint32(),
+            rng.nextUint32(),
+        ]).toEqual([1843037723, 574486829, 1018436590, 1120027984, 770965377])
+    })
+})
+
+describe('seeded RNG bounded selection', () => {
+    it('returns zero for a unit bound from a fresh stream', () => {
+        expect(createSeededRng('ice-slide:test').nextInt(1)).toBe(0)
+    })
+
+    it('locks five nextInt(7) draws from a separate fresh stream', () => {
+        const rng = createSeededRng('ice-slide:test')
+        expect([
+            rng.nextInt(7),
+            rng.nextInt(7),
+            rng.nextInt(7),
+            rng.nextInt(7),
+            rng.nextInt(7),
+        ]).toEqual([2, 0, 3, 5, 0])
+    })
+
+    it.each([0, -1, 1.5, Number.NaN, Number.POSITIVE_INFINITY, 0x80000000])(
+        'rejects invalid maxExclusive %s',
+        maxExclusive => {
+            expect(() =>
+                createSeededRng('ice-slide:test').nextInt(maxExclusive)
+            ).toThrow(RangeError)
+        }
+    )
+
+    it('accepts the signed 32-bit upper bound', () => {
+        const value = createSeededRng('ice-slide:test').nextInt(0x7fffffff)
+        expect(value).toBeGreaterThanOrEqual(0)
+        expect(value).toBeLessThan(0x7fffffff)
+    })
+})
+
+describe('seeded RNG collection helpers', () => {
+    it('pick consumes one bounded draw', () => {
+        expect(
+            createSeededRng('ice-slide:test').pick(['A', 'B', 'C', 'D', 'E'])
+        ).toBe('D')
+    })
+
+    it('pick rejects an empty collection', () => {
+        expect(() => createSeededRng('ice-slide:test').pick([])).toThrow(
+            RangeError
+        )
+    })
+
+    it('pick still consumes a draw for one item', () => {
+        const rng = createSeededRng('ice-slide:test')
+        expect(rng.pick(['only'])).toBe('only')
+        expect(rng.nextUint32()).toBe(574486829)
+    })
+
+    it('uses descending Fisher-Yates without mutating input', () => {
+        const input = ['A', 'B', 'C', 'D', 'E'] as const
+        const shuffled = createSeededRng('ice-slide:test').shuffle(input)
+
+        expect(shuffled).toEqual(['C', 'A', 'E', 'B', 'D'])
+        expect(input).toEqual(['A', 'B', 'C', 'D', 'E'])
+    })
+})
+
+describe('seeded RNG labeled forks', () => {
+    it('derives forks from immutable paths, not draw position', () => {
+        const parent = createSeededRng('ice-slide:test')
+        const before = parent.fork('stage:1')
+        parent.nextUint32()
+        parent.nextUint32()
+        const after = parent.fork('stage:1')
+
+        expect(before.nextUint32()).toBe(694760629)
+        expect(after.nextUint32()).toBe(694760629)
+        expect(
+            createSeededRng('ice-slide:test').fork('stage:2').nextUint32()
+        ).toBe(2216382472)
+    })
+
+    it('keeps nested fork paths and instances independent', () => {
+        const parent = createSeededRng('ice-slide:test')
+        const first = parent.fork('stage').fork('objective')
+        const second = parent.fork('stage').fork('objective')
+
+        expect(first.nextUint32()).toBe(second.nextUint32())
+        first.nextUint32()
+        expect(first.nextUint32()).not.toBe(second.nextUint32())
+    })
+
+    it.each(['', 'a\u001fb'])('rejects invalid seed key %j', seed => {
+        expect(() => createSeededRng(seed)).toThrow(RangeError)
+    })
+
+    it.each(['', 'a\u001fb'])('rejects invalid fork label %j', label => {
+        expect(() => createSeededRng('ice-slide:test').fork(label)).toThrow(
+            RangeError
+        )
+    })
+})
+
+afterEach(() => {
+    vi.restoreAllMocks()
+})
+
+it('never calls Math.random', () => {
+    const randomSpy = vi.spyOn(Math, 'random').mockImplementation(() => {
+        throw new Error('Math.random must not be called')
+    })
+
+    const rng = createSeededRng('ice-slide:test')
+    rng.nextUint32()
+    rng.nextFloat()
+    rng.nextInt(7)
+    rng.pick(['A', 'B'])
+    rng.shuffle(['A', 'B', 'C'])
+    rng.fork('stage').nextUint32()
+
+    expect(randomSpy).not.toHaveBeenCalled()
+})

--- a/src/lib/games/shared/seeded-rng.test.ts
+++ b/src/lib/games/shared/seeded-rng.test.ts
@@ -44,7 +44,7 @@ describe('seeded RNG bounded selection', () => {
 
     it.each([0, -1, 1.5, Number.NaN, Number.POSITIVE_INFINITY, 0x80000000])(
         'rejects invalid maxExclusive %s',
-        maxExclusive => {
+        (maxExclusive: number) => {
             expect(() =>
                 createSeededRng('ice-slide:test').nextInt(maxExclusive)
             ).toThrow(RangeError)
@@ -111,15 +111,18 @@ describe('seeded RNG labeled forks', () => {
         expect(first.nextUint32()).not.toBe(second.nextUint32())
     })
 
-    it.each(['', 'a\u001fb'])('rejects invalid seed key %j', seed => {
+    it.each(['', 'a\u001fb'])('rejects invalid seed key %j', (seed: string) => {
         expect(() => createSeededRng(seed)).toThrow(RangeError)
     })
 
-    it.each(['', 'a\u001fb'])('rejects invalid fork label %j', label => {
-        expect(() => createSeededRng('ice-slide:test').fork(label)).toThrow(
-            RangeError
-        )
-    })
+    it.each(['', 'a\u001fb'])(
+        'rejects invalid fork label %j',
+        (label: string) => {
+            expect(() => createSeededRng('ice-slide:test').fork(label)).toThrow(
+                RangeError
+            )
+        }
+    )
 })
 
 afterEach(() => {

--- a/src/lib/games/shared/seeded-rng.ts
+++ b/src/lib/games/shared/seeded-rng.ts
@@ -11,6 +11,9 @@ export interface SeededRng {
     fork(label: string): SeededRng
 }
 
+// FNV-1a 32-bit hash. 0x811c9dc5 is the FNV-1a offset basis and 0x01000193 is
+// the FNV prime; the unsigned shift normalizes the result to [0, 2^32). This
+// deterministic hash is the contract used by hashString32Hex.
 export function hashString32(value: string): number {
     let hash = 0x811c9dc5
     for (let index = 0; index < value.length; index++) {
@@ -32,6 +35,8 @@ function assertSeedSegment(value: string, field: string): void {
     }
 }
 
+// Mulberry32 PRNG. The state transition adds the constant 0x6d2b79f5 before
+// the bit-mixing steps; the unsigned shift keeps state in [0, 2^32).
 function createSeededRngFromPath(seedPath: string): SeededRng {
     let state = hashString32(seedPath)
 
@@ -56,6 +61,9 @@ function createSeededRngFromPath(seedPath: string): SeededRng {
             )
         }
 
+        // Rejection sampling to remove modulo bias: `limit` is the largest
+        // multiple of maxExclusive not exceeding 2^32, so any draw >= limit
+        // is discarded and redrawn rather than reduced via the modulo.
         const limit = Math.floor(UINT32_RANGE / maxExclusive) * maxExclusive
         let value: number
         do {

--- a/src/lib/games/shared/seeded-rng.ts
+++ b/src/lib/games/shared/seeded-rng.ts
@@ -1,0 +1,105 @@
+const FORK_SEPARATOR = '\u001f'
+const UINT32_RANGE = 0x1_0000_0000
+const MAX_INT_BOUND = 0x7fffffff
+
+export interface SeededRng {
+    nextUint32(): number
+    nextFloat(): number
+    nextInt(maxExclusive: number): number
+    pick<T>(items: readonly T[]): T
+    shuffle<T>(items: readonly T[]): T[]
+    fork(label: string): SeededRng
+}
+
+export function hashString32(value: string): number {
+    let hash = 0x811c9dc5
+    for (let index = 0; index < value.length; index++) {
+        hash ^= value.charCodeAt(index)
+        hash = Math.imul(hash, 0x01000193)
+    }
+    return hash >>> 0
+}
+
+export function hashString32Hex(value: string): string {
+    return hashString32(value).toString(16).padStart(8, '0')
+}
+
+function assertSeedSegment(value: string, field: string): void {
+    if (value.length === 0 || value.includes(FORK_SEPARATOR)) {
+        throw new RangeError(
+            `${field} must be non-empty and must not contain U+001F`
+        )
+    }
+}
+
+function createSeededRngFromPath(seedPath: string): SeededRng {
+    let state = hashString32(seedPath)
+
+    const nextUint32 = (): number => {
+        state = (state + 0x6d2b79f5) >>> 0
+        let value = state
+        value = Math.imul(value ^ (value >>> 15), value | 1)
+        value ^= value + Math.imul(value ^ (value >>> 7), value | 61)
+        return (value ^ (value >>> 14)) >>> 0
+    }
+
+    const nextFloat = (): number => nextUint32() / UINT32_RANGE
+
+    const nextInt = (maxExclusive: number): number => {
+        if (
+            !Number.isInteger(maxExclusive) ||
+            maxExclusive < 1 ||
+            maxExclusive > MAX_INT_BOUND
+        ) {
+            throw new RangeError(
+                'maxExclusive must be an integer from 1 through 2147483647'
+            )
+        }
+
+        const limit = Math.floor(UINT32_RANGE / maxExclusive) * maxExclusive
+        let value: number
+        do {
+            value = nextUint32()
+        } while (value >= limit)
+
+        return value % maxExclusive
+    }
+
+    const pick = <T>(items: readonly T[]): T => {
+        if (items.length === 0) {
+            throw new RangeError('pick requires at least one item')
+        }
+        return items[nextInt(items.length)]
+    }
+
+    const shuffle = <T>(items: readonly T[]): T[] => {
+        const result = [...items]
+        for (let index = result.length - 1; index > 0; index--) {
+            const swapIndex = nextInt(index + 1)
+            ;[result[index], result[swapIndex]] = [
+                result[swapIndex],
+                result[index],
+            ]
+        }
+        return result
+    }
+
+    const fork = (label: string): SeededRng => {
+        assertSeedSegment(label, 'label')
+        return createSeededRngFromPath(`${seedPath}${FORK_SEPARATOR}${label}`)
+    }
+
+    return {
+        nextUint32,
+        nextFloat,
+        nextInt,
+        pick,
+        shuffle,
+        fork,
+    }
+}
+
+export function createSeededRng(seedKey: string): SeededRng {
+    assertSeedSegment(seedKey, 'seedKey')
+    return createSeededRngFromPath(seedKey)
+}


### PR DESCRIPTION
## Summary

Implements [HPA-485](https://linear.app/cwchanap/issue/HPA-485): deterministic Ice Slide run infrastructure — a dependency-free seeded RNG, board transforms/canonicalization, versioned Campaign run materialization with structural validation, and a refactor of `IceSlideGame` to consume explicit run definitions. Current Campaign behavior is preserved byte-for-byte; this unblocks future Daily/Expedition generated runs (HPA-486/487, out of scope).

Builds on the approved design from #52 (closed; plan moved into implementation on this branch). Executed task-by-task via subagent-driven development with a per-task review gate and a final whole-branch review.

## Commits (4 logical commits, in order)

- `feat(games): add deterministic seeded rng` — FNV-1a + Mulberry32 stream, rejection-sampled `nextInt`, `pick`, descending Fisher–Yates `shuffle`, immutable-path labeled `fork`. All locked vectors green.
- `feat(ice-slide): add board transforms and canonical variants` — 8 rectangular transforms, coordinate mapping + inverses, canonical serialization (`RxC\^_…`), symmetry dedup keyed on complete serialization.
- `feat(ice-slide): materialize versioned campaign runs` — versioned run/stage contracts, additive `IceSlideState`/`IceSlideGameData` fields, `is2-<8hex>` stage signatures (First Frost = `is2-d1feaba1`), structural run validation (Campaign/Daily/Expedition key–seed–version rules), Campaign adapter, deep clone, and `parseGrid` narrowing to `IceSlideGridSource { id, rows }`.
- `refactor(ice-slide): consume explicit run definitions` — `IceSlideGame` holds a defensive active-run snapshot; `start(run?)` validates+clones explicit runs before any state/timer mutation; state rebuilds re-derive full-run signatures and preserve cumulative counters; getters copy signature arrays + metadata; the four `vi.mock('./levels')` branch suites migrated to explicit runs.

## Documents

- Design: `docs/superpowers/specs/2026-08-02-deterministic-ice-slide-runs-design.md`
- Plan: `docs/superpowers/plans/2026-08-02-deterministic-ice-slide-runs.md`

## Verification

- **Tests:** full repo `bun run test:run` → 2660/2660 passing (136 files); targeted Ice Slide + RNG suite green.
- **Typecheck:** down to **2 pre-existing baseline errors** (`init.test.ts:36`, `init.ts:178`) in files this plan explicitly forbids modifying — present on `main`, not introduced here. If branch protection requires a fully green typecheck job, these need a separate fix or a documented baseline exception.
- **Lint / Format:** clean on all touched files.
- **Boundaries:** `levels.ts`, `scoring.ts`, `init.ts`, `renderer.ts`, `challenges.ts`, `shared/types.ts`, `achievements.ts` untouched; no `Math.random` in deterministic modules; no remaining `vi.mock('./levels')`.

## Notes for review

- Locked vectors (RNG stream / `nextInt` / `pick` / `shuffle` / `fork`; 8 transforms; canonical serialization; `is2-d1feaba1`; `ice-slide:campaign:g1:r1`) are asserted in tests and match the design verbatim.
- Two brief-verbatim test snippets required intent-preserving fixes to typecheck under the repo's strict `astro check` (documented per-task): wrapping the malformed-board `it.each` fixture (Vitest table-spread), and annotating `it.each` callback params / dropping dead `name`/`parMoves` props after the parser narrowed to `{id, rows}`. All assertions unchanged.
- Follow-ups (non-blocking, acceptable post-merge): stronger validator rejection tests (stale signature, malformed Daily/Expedition keys); harder mutation/preservation assertions; resolve the two pre-existing typecheck baseline errors separately.

## Out of scope

- Solver extraction and solvability/quality validation (HPA-486)
- Generated-run error boundaries and achievement-mode gates (HPA-487)
- Daily/Expedition generation, UI, score-context persistence changes

<!-- This is an auto-generated comment: release notes by coderabbit.ai -->
## Summary by CodeRabbit

- **New Features**
  - Added deterministic Ice Slide runs with versioned metadata, stage signatures, validation, and progress tracking.
  - Added support for campaign and custom run definitions.
  - Added seeded generation and board transformations, including rotations and reflections.
  - Preserved run metadata, stars, falls, and resets across progression and reloads.

- **Tests**
  - Expanded coverage for generation, validation, transformations, physics, progression, and game states.

- **Documentation**
  - Added design and implementation specifications for deterministic Ice Slide runs.
<!-- end of auto-generated comment: release notes by coderabbit.ai -->
