### PR TITLE
docs(ice-slide): design and plan production solver (HPA-486)

### DIFF
--- a/docs/superpowers/plans/2026-08-03-ice-slide-production-solver.md
+++ b/docs/superpowers/plans/2026-08-03-ice-slide-production-solver.md
@@ -2,9 +2,9 @@
 
 > **For agentic workers:** REQUIRED SUB-SKILL: Use superpowers:subagent-driven-development (recommended) or superpowers:executing-plans to implement this plan task-by-task. Steps use checkbox (`- [ ]`) syntax for tracking.
 
-**Goal:** Extract Ice Slide's test-only BFS into bounded deterministic production code and add a lean stage-quality validator for later Daily and Expedition generation.
+**Goal:** Extract Ice Slide's duplicated test BFS into a bounded production solver, then add the ticket-required lean quality validator for future generated candidates.
 
-**Architecture:** `solver.ts` owns complete BFS traversal over player position and a bounded numeric crystal mask. `quality.ts` owns ordered candidate acceptance policy. Campaign tests call the solver directly; runtime gameplay remains unchanged.
+**Architecture:** `solver.ts` returns search facts only: reachability, exact par, crystal facts, stop count, explored states, and truncation. `quality.ts` catches invalid solver input, applies duplicate/par/objective policy, and returns bounded rejection results. Campaign tests consume the solver directly; runtime gameplay remains unchanged.
 
 **Tech Stack:** TypeScript 6, Vitest 3, Bun 1.3, existing Ice Slide physics and transformation utilities.
 
@@ -13,41 +13,22 @@
 - Follow `docs/superpowers/specs/2026-08-03-ice-slide-production-solver-design.md`.
 - Reuse `parseGrid()`, `cloneGrid()`, `slide()`, `DIRECTION_DELTA`, and `serializeBoardRows()`.
 - Require an explicit positive safe-integer `maxStates`.
-- Use a `number` crystal mask with `MAX_SOLVER_CRYSTALS = 30`.
-- A truncated result is never accepted as solvable, but preserves an already-proven
-  shortest `minMoves`.
-- Keep the HPA-486-required result fields: stop count, crystal IDs, objective
-  feasibility, explored-state count, and truncation.
-- Do not modify runtime gameplay, run contracts, score behavior, UI, generator loops,
+- Use an internal 30-crystal `number`-mask ceiling; do not export it.
+- A truncated result returns `solvable: false` and `minMoves: null`.
+- Keep objective policy out of `solver.ts`.
+- Do not change runtime gameplay, run contracts, generator loops, score, database, UI,
   or future snow/cracked-ice mechanics.
-- Do not add a generic search abstraction, path output, caching, or worker execution.
-- Deliver the solver as one complete task; do not commit a half-populated public API.
+- Do not add path output, a generic search abstraction, caching, or worker execution.
 
----
+Implementation is limited to:
 
-## File Map
-
-### Create
-
-- `src/lib/games/ice-slide/solver.ts`
-- `src/lib/games/ice-slide/solver.test.ts`
-- `src/lib/games/ice-slide/quality.ts`
-- `src/lib/games/ice-slide/quality.test.ts`
-
-### Modify
-
-- `src/lib/games/ice-slide/physics.test.ts`
-
-### Must remain untouched
-
-- `src/lib/games/ice-slide/types.ts`
-- `src/lib/games/ice-slide/run.ts`
-- `src/lib/games/ice-slide/game.ts`
-- `src/lib/games/ice-slide/physics.ts`
-- `src/lib/games/ice-slide/levels.ts`
-- `src/lib/games/ice-slide/transforms.ts`
-- `src/lib/games/ice-slide/init.ts`
-- `src/lib/games/ice-slide/renderer.ts`
+```text
+src/lib/games/ice-slide/solver.ts
+src/lib/games/ice-slide/solver.test.ts
+src/lib/games/ice-slide/quality.ts
+src/lib/games/ice-slide/quality.test.ts
+src/lib/games/ice-slide/physics.test.ts
+```
 
 ---
 
@@ -60,8 +41,6 @@
 **Produces:**
 
 ```ts
-export const MAX_SOLVER_CRYSTALS = 30
-
 export interface IceSlideSolverLimits {
     maxStates: number
 }
@@ -71,7 +50,7 @@ export interface IceSlideSolveResult {
     minMoves: number | null
     reachableStopCount: number
     reachableCrystalIds: string[]
-    objectiveFeasibility: Record<IceSlideObjectiveId, boolean>
+    reachedGoalWithAllCrystals: boolean
     exploredStates: number
     truncated: boolean
 }
@@ -82,32 +61,26 @@ export function solveIceSlideBoard(
 ): IceSlideSolveResult
 ```
 
-- [ ] **Step 1: Write the failing solver tests**
+- [ ] **Step 1: Write failing solver tests**
 
-Create `solver.test.ts` with these named cases:
+Create `solver.test.ts` with these cases:
 
-| Test | Required assertion |
+| Test | Required behavior |
 |---|---|
-| `returns an exact one-move solution` | `minMoves === 1`, start+goal stop count, not truncated |
-| `finds a multi-move Campaign minimum` | Campaign level 2 matches current par |
-| `distinguishes the same stop with different crystal masks` | collect crystal, revisit a coordinate, then retain a valid goal route |
-| `returns row-major reachable crystal IDs` | IDs use zero-based `"row,col"` strings |
-| `excludes unreachable crystals` | isolated crystal is absent |
-| `reports all three objective contracts` | collect-all search result plus derived no-falls/no-reset semantics |
-| `counts explored states and unique stops` | state count distinguishes masks; stop count does not |
-| `does not mutate caller rows` | repeated calls return equal results and original rows remain equal |
-| `rejects invalid solver input` | empty/zero-column/jagged/unknown glyph, start/goal count, >30 crystals, invalid cap |
-| `truncates before a goal` | `truncated`, `solvable: false`, `minMoves: null` |
-| `preserves a proven minimum when later truncated` | `truncated`, `solvable: false`, non-null exact `minMoves` |
+| one-move board | exact `minMoves`, start+goal stops, not truncated |
+| Campaign level 2 | computed minimum matches current par |
+| crystal-mask state | revisiting one coordinate after collection is explored as a new state |
+| crystal IDs | reachable IDs are zero-based row-major `"row,col"` strings |
+| unreachable crystal | isolated crystal is absent |
+| all-crystals goal | `reachedGoalWithAllCrystals` reflects an actual goal state |
+| stop/state relationship | mask-distinguished `exploredStates` exceeds `reachableStopCount`; avoid an exact count |
+| immutability/determinism | repeated results match and caller rows remain unchanged |
+| invalid input | rows, glyphs, exact start/goal counts, >30 crystals, and invalid cap throw |
+| truncation | `truncated: true`, `solvable: false`, `minMoves: null`, states do not exceed cap |
 
-Use a crystal-state fixture where a correct result requires revisiting a previously seen
-coordinate after collecting a crystal. This test must fail if the visited key contains
-position only.
+The crystal fixture must fail if the visited key uses player position only.
 
-Use a separate branching fixture for post-goal truncation: direction order must reach a
-short goal first, then encounter enough additional unseen states to hit the cap.
-
-- [ ] **Step 2: Run tests and confirm the module is absent**
+- [ ] **Step 2: Verify the red test state**
 
 ```bash
 bun run test:run -- src/lib/games/ice-slide/solver.test.ts
@@ -115,79 +88,60 @@ bun run test:run -- src/lib/games/ice-slide/solver.test.ts
 
 Expected: FAIL because `./solver` does not exist.
 
-- [ ] **Step 3: Implement input scanning and state encoding**
+- [ ] **Step 3: Implement board scanning and state encoding**
 
 In `solver.ts`:
 
 - validate `maxStates` with `Number.isSafeInteger(value) && value >= 1`;
-- call `parseGrid(source)`;
-- reject a zero-column board explicitly;
+- call `parseGrid(source)` and explicitly reject zero-column rows;
 - scan once for exactly one start, exactly one goal, hazards, and row-major crystals;
-- reject crystal count above `MAX_SOLVER_CRYSTALS`;
-- map each crystal ID to bit `1 << index`;
-- use the private state key:
+- throw when crystal count exceeds the internal limit of 30;
+- map each crystal index to `1 << index`;
+- encode visited state as `row,col,mask`;
+- do not import `IceSlideObjectiveId`.
+
+Use this internal state:
 
 ```ts
-function encodeStateKey(
-    position: GridPosition,
+interface SolverState {
+    position: GridPosition
+    moves: number
     crystalMask: number
-): string {
-    return `${position.row},${position.col},${crystalMask}`
+    grid: CellType[][]
 }
 ```
 
-The direct solver throws for invalid content. Do not add an exported validation helper.
+Keep the grid in the state because `slide()` mutates collected crystals. Do not add
+base-grid reconstruction logic in this task.
 
 - [ ] **Step 4: Implement complete BFS traversal**
 
-Use this exact traversal policy:
+Use this traversal policy:
 
-1. Clone the parsed grid and replace the start cell with ice.
-2. Queue the start state with `moves: 0` and mask `0`.
+1. Clone the parsed grid and replace the start with ice.
+2. Queue the start state with mask `0` and moves `0`.
 3. Use an array plus queue cursor.
 4. Try directions in `N`, `E`, `S`, `W` order.
-5. Clone the current state's grid before each `slide()` call.
+5. Clone the current grid before each `slide()` call.
 6. Skip `noop` and `hazard` outcomes.
-7. Update the crystal mask from crystal coordinates in `outcome.path`.
-8. Skip already-seen `(position, mask)` states.
-9. Before admitting an unseen state, compare `seen.size` with `maxStates`.
+7. Update the mask from crystal coordinates in `outcome.path`.
+8. Skip seen `(position, mask)` states.
+9. Before admitting an unseen state, enforce `maxStates`.
 10. Record goal states but do not enqueue them.
-11. Continue after the first goal until the queue is exhausted or the cap truncates.
+11. Continue after the first goal unless the cap truncates the search.
 
 Track:
 
-- `minMoves` from the first reached goal;
-- unique stop-coordinate IDs in a `Set<string>`;
-- reachable crystals in a `Set<string>`, returned by filtering the original row-major
-  crystal list;
-- whether any goal state consumed the complete crystal mask;
-- whether the board contains at least one hazard.
+- first goal depth;
+- unique stop coordinates;
+- reachable crystals, returned by filtering the original row-major list;
+- whether any goal consumed the full crystal mask;
+- admitted-state count.
 
-- [ ] **Step 5: Implement result semantics**
+On truncation, return `solvable: false`, `minMoves: null`, and already observed
+stop/crystal diagnostics. Do not preserve a partial par.
 
-For a complete search:
-
-```ts
-solvable = minMoves !== null
-objectiveFeasibility = {
-    collect_all_crystals:
-        crystalCount > 0 && reachedGoalWithAllCrystals,
-    no_falls: hasHazard && solvable,
-    no_reset: solvable,
-}
-```
-
-For truncation:
-
-- return immediately before admitting the over-cap state;
-- set `truncated: true` and `solvable: false`;
-- keep the current `minMoves`, which may be `null`;
-- keep already-observed stop/crystal counts and witnessed objective feasibility;
-- set `exploredStates` to `seen.size`.
-
-No result path or predecessor map is required.
-
-- [ ] **Step 6: Run and format the solver suite**
+- [ ] **Step 5: Run, format, and lint the solver**
 
 ```bash
 bun run test:run -- src/lib/games/ice-slide/solver.test.ts
@@ -201,7 +155,7 @@ bunx eslint \
 
 Expected: solver tests pass; formatter and lint exit successfully.
 
-- [ ] **Step 7: Commit the complete solver**
+- [ ] **Step 6: Commit the complete solver**
 
 ```bash
 git add \
@@ -217,6 +171,10 @@ git commit -m "feat(ice-slide): add bounded production solver"
 **Files:**
 - Create: `src/lib/games/ice-slide/quality.ts`
 - Create: `src/lib/games/ice-slide/quality.test.ts`
+
+**Why this task exists:** HPA-486 explicitly requires a pure stage-quality validator and
+canonical duplicate detection. Do not add generator retries, mutation advice, aggregate
+counters, or fallback selection.
 
 **Produces:**
 
@@ -248,6 +206,7 @@ export type IceSlideStageQualityResult =
           accepted: true
           parMoves: number
           canonicalKey: string
+          objectiveFeasibility: Record<IceSlideObjectiveId, boolean>
           solveResult: IceSlideSolveResult
       }
     | {
@@ -259,27 +218,25 @@ export type IceSlideStageQualityResult =
       }
 ```
 
-- [ ] **Step 1: Write the failing quality tests**
+- [ ] **Step 1: Write failing quality tests**
 
 Create `quality.test.ts` with this matrix:
 
-| Fixture | Expected reason |
+| Fixture | Expected result |
 |---|---|
-| empty, zero-column, jagged, unknown glyph | `invalid_board` |
-| missing/multiple start | `invalid_board`, count in message |
-| missing/multiple goal | `invalid_board`, count in message |
-| more than 30 crystals | `invalid_board` |
-| existing exact canonical key | `duplicate_board` |
-| state cap hit | `solver_truncated` even when `minMoves` is present |
+| empty, zero-column, jagged rows | `invalid_board` |
+| unknown glyph, missing/multiple start or goal, >30 crystals | solver error mapped to `invalid_board` |
+| existing exact canonical key | `duplicate_board` before BFS |
+| state cap hit | `solver_truncated` |
 | fully explored impossible goal | `unsolvable` |
-| computed par below/above band | `par_out_of_band` |
-| assigned collect-all with unreachable crystal | `objective_infeasible`, crystal detail in message |
-| assigned collect-all without all-crystals goal route | `objective_infeasible` |
-| assigned no-falls on no-hazard board | `objective_infeasible` |
-| valid candidate | accepted with computed par, canonical key, and solver result |
+| computed par outside band | `par_out_of_band` |
+| crystal-free collect-all | `objective_infeasible` |
+| unreachable/all-crystals-impossible collect-all | `objective_infeasible` with crystal detail |
+| hazard-free no-falls | `objective_infeasible` |
+| valid candidate | accepted with par, canonical key, objective feasibility, and solver result |
 | invalid constraints | throws `RangeError` |
 
-- [ ] **Step 2: Run tests and confirm the module is absent**
+- [ ] **Step 2: Verify the red test state**
 
 ```bash
 bun run test:run -- src/lib/games/ice-slide/quality.test.ts
@@ -287,41 +244,50 @@ bun run test:run -- src/lib/games/ice-slide/quality.test.ts
 
 Expected: FAIL because `./quality` does not exist.
 
-- [ ] **Step 3: Implement configuration and structural validation**
+- [ ] **Step 3: Implement constraint, shape, and duplicate checks**
 
 In `quality.ts`:
 
 - validate `maxStates`, `parBand.minMoves`, and `parBand.maxMoves` as positive safe
   integers;
 - throw when `minMoves > maxMoves`;
-- parse rows and scan crystal/start/goal counts;
-- map parsing, zero-column, crystal-ceiling, and exact-count failures to
-  `invalid_board` with concise diagnostic messages;
-- compute `canonicalKey = serializeBoardRows(candidate.rows)`;
-- reject an existing exact key as `duplicate_board` before calling the solver.
+- call `serializeBoardRows(candidate.rows)` inside a try/catch and map invalid shape to
+  `invalid_board`;
+- reject membership in `existingCanonicalKeys` as `duplicate_board` before BFS.
 
-The quality scan intentionally duplicates the solver's cheap defensive scan so direct
-solver calls still validate themselves. Do not add a third shared module.
+Do not parse or count start/goal tiles in `quality.ts`.
 
-- [ ] **Step 4: Implement ordered solver policy**
+- [ ] **Step 4: Call the solver and map invalid content once**
 
-After structural and duplicate checks:
+Call `solveIceSlideBoard(candidate, { maxStates })` inside a try/catch. Map parser,
+glyph, crystal-ceiling, and exact start/goal errors to `invalid_board` using the solver's
+message. This keeps validation wording in one place.
 
-1. Call `solveIceSlideBoard(candidate, { maxStates })`.
-2. Reject `solveResult.truncated` as `solver_truncated` before all other solver checks.
-3. Reject a complete unreachable search as `unsolvable`.
-4. Reject computed par outside the inclusive band as `par_out_of_band`.
-5. Evaluate assigned objectives in input order:
-   - for `collect_all_crystals`, use crystal counts and
-     `solveResult.objectiveFeasibility.collect_all_crystals`; make the message identify
-     unreachable crystals when the reachable count is lower;
-   - use `solveResult.objectiveFeasibility` for all other objective IDs;
-   - reject any failure as `objective_infeasible`.
-6. Return accepted result with computed par, canonical key, and solver result.
+Then apply checks in order:
 
-Callers branch on `reason`, never on message text.
+1. `truncated` → `solver_truncated`;
+2. `!solvable` → `unsolvable`;
+3. par outside the inclusive band → `par_out_of_band`.
 
-- [ ] **Step 5: Run and format quality tests**
+- [ ] **Step 5: Derive objective assignment feasibility**
+
+Count `C` and `H` glyphs from the final candidate rows and derive:
+
+```ts
+const objectiveFeasibility = {
+    collect_all_crystals:
+        crystalCount > 0 && solveResult.reachedGoalWithAllCrystals,
+    no_falls: hasHazard && solveResult.solvable,
+    no_reset: solveResult.solvable,
+}
+```
+
+These are policy/eligibility results, not solver search modes. Evaluate assigned
+`objectiveIds` in input order and reject the first false value as
+`objective_infeasible`. For collect-all failures, distinguish unreachable crystals in
+the diagnostic message when `reachableCrystalIds.length < crystalCount`.
+
+- [ ] **Step 6: Run, format, and lint quality validation**
 
 ```bash
 bun run test:run -- \
@@ -337,7 +303,7 @@ bunx eslint \
 
 Expected: both suites pass; formatter and lint exit successfully.
 
-- [ ] **Step 6: Commit quality validation**
+- [ ] **Step 7: Commit quality validation**
 
 ```bash
 git add \
@@ -353,7 +319,7 @@ git commit -m "feat(ice-slide): validate generated stage quality"
 **Files:**
 - Modify: `src/lib/games/ice-slide/physics.test.ts`
 
-- [ ] **Step 1: Replace Campaign minimum-move BFS**
+- [ ] **Step 1: Replace the Campaign minimum-move BFS**
 
 Import `solveIceSlideBoard`, delete the local `minMoves()` helper, and for every
 `ICE_SLIDE_LEVELS` entry assert:
@@ -365,12 +331,10 @@ expect(result.solvable, `level ${level.id} solvable`).toBe(true)
 expect(result.minMoves, `level ${level.id} par`).toBe(level.parMoves)
 ```
 
-- [ ] **Step 2: Replace Campaign crystal BFS**
+- [ ] **Step 2: Replace the Campaign crystal BFS**
 
-Delete the second local queue traversal. Derive expected IDs from `C` glyphs in row-major
-order and compare them with `result.reachableCrystalIds` from the same explicit cap.
-
-Keep `cloneGrid` imported because earlier physics tests still use it.
+Delete the second local traversal. Derive expected IDs from `C` glyphs in row-major order
+and compare them with `result.reachableCrystalIds` under the same explicit cap.
 
 - [ ] **Step 3: Run targeted and full tests**
 
@@ -394,52 +358,28 @@ bun run typecheck 2>&1 | tee /tmp/hpa-486-typecheck.txt
 ```
 
 Compare typecheck output with a clean worktree at the implementation base commit. The
-requirement is no new diagnostics; do not assume the two errors reported by PR #53 still
-form the current baseline.
+bar is no new diagnostics because `astro check` reports across the whole repository.
 
-- [ ] **Step 5: Verify implementation scope**
-
-```bash
-git diff --name-only origin/main...HEAD
-```
-
-Expected implementation files:
-
-```text
-src/lib/games/ice-slide/physics.test.ts
-src/lib/games/ice-slide/quality.test.ts
-src/lib/games/ice-slide/quality.ts
-src/lib/games/ice-slide/solver.test.ts
-src/lib/games/ice-slide/solver.ts
-```
-
-- [ ] **Step 6: Commit Campaign migration**
+- [ ] **Step 5: Commit the Campaign migration**
 
 ```bash
 git add src/lib/games/ice-slide/physics.test.ts
 git commit -m "test(ice-slide): use production solver for campaign content"
 ```
 
-- [ ] **Step 7: Open a draft implementation PR**
+- [ ] **Step 6: Open a draft implementation PR**
 
-The PR summary must state:
-
-- complete bounded solver with numeric crystal masks;
-- quality rejection policy and six reason codes;
-- preserved Campaign pars and crystal reachability;
-- truncation preserves proven `minMoves` but is always rejected;
-- no runtime, generator-loop, UI, score, or future-mechanic changes;
-- targeted/full test, lint, format, and baseline-aware typecheck results.
-
-Do not enable auto-merge.
+Summarize the solver, quality gate, Campaign regression replacement, YAGNI boundaries,
+and actual verification results. Do not enable auto-merge.
 
 ---
 
 ## Plan Self-Review
 
-- **Spec coverage:** all HPA-486 required fields and rejection checks map to Tasks 1–3.
-- **No partial API:** Task 1 delivers the complete solver in one commit.
-- **YAGNI:** no full source dump, generic framework, solution path, generator
-  orchestration, or future-state scaffolding.
-- **Type consistency:** `number` mask ceiling, six reason codes, truncation semantics,
-  and public interfaces match the design.
+- **Coverage:** solver extraction, ticket-required quality validation, Campaign migration,
+  truncation, objective policy, and verification each have an owning task.
+- **API consistency:** objective IDs appear only in `quality.ts`; solver results contain
+  search facts only.
+- **YAGNI:** no partial par after truncation, exported crystal-limit constant, duplicate
+  start/goal scan, exact traversal-count assertions, generator behavior, path output, or
+  generic framework remains.

--- a/docs/superpowers/plans/2026-08-03-ice-slide-production-solver.md
+++ b/docs/superpowers/plans/2026-08-03-ice-slide-production-solver.md
@@ -2,22 +2,26 @@
 
 > **For agentic workers:** REQUIRED SUB-SKILL: Use superpowers:subagent-driven-development (recommended) or superpowers:executing-plans to implement this plan task-by-task. Steps use checkbox (`- [ ]`) syntax for tracking.
 
-**Goal:** Extract Ice Slide's test-only BFS into bounded deterministic production code and add a pure stage-quality validator for future Daily and Expedition generation.
+**Goal:** Extract Ice Slide's test-only BFS into bounded deterministic production code and add a lean stage-quality validator for later Daily and Expedition generation.
 
-**Architecture:** `solver.ts` owns breadth-first traversal over player position and consumed-crystal state while reusing `slide()` as the only movement transition. `quality.ts` applies ordered candidate acceptance rules around the solver and returns a discriminated rejection union. Runtime gameplay remains unchanged.
+**Architecture:** `solver.ts` owns complete BFS traversal over player position and a bounded numeric crystal mask. `quality.ts` owns ordered candidate acceptance policy. Campaign tests call the solver directly; runtime gameplay remains unchanged.
 
 **Tech Stack:** TypeScript 6, Vitest 3, Bun 1.3, existing Ice Slide physics and transformation utilities.
 
 ## Global Constraints
 
 - Follow `docs/superpowers/specs/2026-08-03-ice-slide-production-solver-design.md`.
-- Keep solver and quality modules pure: no DOM, Pixi, storage, network, time, randomness, or logging.
 - Reuse `parseGrid()`, `cloneGrid()`, `slide()`, `DIRECTION_DELTA`, and `serializeBoardRows()`.
-- Require an explicit positive safe-integer `maxStates`; do not add an unbounded or hidden-default mode.
-- Treat truncation as rejection: `truncated: true`, `solvable: false`, and `minMoves: null`.
-- Do not modify runtime gameplay, generation loops, score behavior, or future snow/cracked-ice mechanics.
-- Do not create a generic graph-search abstraction or return solution paths.
-- Use TDD and commit each independently reviewable task.
+- Require an explicit positive safe-integer `maxStates`.
+- Use a `number` crystal mask with `MAX_SOLVER_CRYSTALS = 30`.
+- A truncated result is never accepted as solvable, but preserves an already-proven
+  shortest `minMoves`.
+- Keep the HPA-486-required result fields: stop count, crystal IDs, objective
+  feasibility, explored-state count, and truncation.
+- Do not modify runtime gameplay, run contracts, score behavior, UI, generator loops,
+  or future snow/cracked-ice mechanics.
+- Do not add a generic search abstraction, path output, caching, or worker execution.
+- Deliver the solver as one complete task; do not commit a half-populated public API.
 
 ---
 
@@ -26,26 +30,13 @@
 ### Create
 
 - `src/lib/games/ice-slide/solver.ts`
-  - solver contracts;
-  - bounded BFS;
-  - crystal-mask state;
-  - objective feasibility.
-
 - `src/lib/games/ice-slide/solver.test.ts`
-  - traversal, state-key, objective, cap, determinism, and immutability tests.
-
 - `src/lib/games/ice-slide/quality.ts`
-  - quality contracts;
-  - constraint validation;
-  - ordered candidate rejection.
-
 - `src/lib/games/ice-slide/quality.test.ts`
-  - invalid fixture and accepted-candidate tests.
 
 ### Modify
 
 - `src/lib/games/ice-slide/physics.test.ts`
-  - replace both embedded BFS helpers with production solver assertions.
 
 ### Must remain untouched
 
@@ -60,150 +51,16 @@
 
 ---
 
-### Task 1: Add bounded minimum-move BFS
+### Task 1: Deliver the complete bounded solver
 
 **Files:**
-- Create: `src/lib/games/ice-slide/solver.test.ts`
 - Create: `src/lib/games/ice-slide/solver.ts`
+- Create: `src/lib/games/ice-slide/solver.test.ts`
 
-**Interfaces:**
-- Consumes:
-  - `IceSlideGridSource`, `parseGrid`, `cloneGrid`, and `slide` from `./physics`
-  - `DIRECTION_DELTA`, `GridPosition`, `CellType`, and `IceSlideObjectiveId` from `./types`
-- Produces:
-  - `IceSlideSolverLimits`
-  - `IceSlideSolveResult`
-  - `solveIceSlideBoard(source, limits)`
-
-- [ ] **Step 1: Write failing tests for basic traversal and bounds**
-
-Create `src/lib/games/ice-slide/solver.test.ts` with the initial tests:
+**Produces:**
 
 ```ts
-import { describe, expect, it } from 'vitest'
-import { ICE_SLIDE_LEVELS } from './levels'
-import { solveIceSlideBoard } from './solver'
-
-describe('solveIceSlideBoard', () => {
-    it('returns the exact minimum moves and unique reachable stops', () => {
-        const result = solveIceSlideBoard(
-            {
-                id: 'one-move',
-                rows: ['#####', '#S.G#', '#####'],
-            },
-            { maxStates: 100 }
-        )
-
-        expect(result).toMatchObject({
-            solvable: true,
-            minMoves: 1,
-            reachableStopCount: 2,
-            exploredStates: 2,
-            truncated: false,
-        })
-    })
-
-    it('finds a multi-move Campaign minimum', () => {
-        const level = ICE_SLIDE_LEVELS[1]
-        const result = solveIceSlideBoard(level, { maxStates: 10_000 })
-
-        expect(result.truncated).toBe(false)
-        expect(result.solvable).toBe(true)
-        expect(result.minMoves).toBe(level.parMoves)
-    })
-
-    it('rejects a non-positive or unsafe state cap', () => {
-        const source = {
-            id: 'invalid-cap',
-            rows: ['#####', '#S.G#', '#####'],
-        }
-
-        expect(() =>
-            solveIceSlideBoard(source, { maxStates: 0 })
-        ).toThrow(/maxStates/)
-        expect(() =>
-            solveIceSlideBoard(source, {
-                maxStates: Number.MAX_SAFE_INTEGER + 1,
-            })
-        ).toThrow(/maxStates/)
-    })
-
-    it.each([
-        [
-            'zero-column',
-            [''],
-            /at least one column/,
-        ],
-        [
-            'multiple starts',
-            ['######', '#SS.G#', '######'],
-            /exactly one start/,
-        ],
-        [
-            'multiple goals',
-            ['######', '#S.GG#', '######'],
-            /exactly one goal/,
-        ],
-    ] as const)('rejects invalid solver input: %s', (_name, rows, error) => {
-        expect(() =>
-            solveIceSlideBoard(
-                { id: 'invalid-board', rows },
-                { maxStates: 100 }
-            )
-        ).toThrow(error)
-    })
-
-    it('reports truncation before admitting a state beyond the cap', () => {
-        const result = solveIceSlideBoard(
-            {
-                id: 'truncated',
-                rows: ['#####', '#S.G#', '#####'],
-            },
-            { maxStates: 1 }
-        )
-
-        expect(result).toMatchObject({
-            solvable: false,
-            minMoves: null,
-            exploredStates: 1,
-            truncated: true,
-        })
-        expect(result.objectiveFeasibility).toEqual({
-            collect_all_crystals: false,
-            no_falls: false,
-            no_reset: false,
-        })
-    })
-})
-```
-
-- [ ] **Step 2: Run the new tests and confirm the module is missing**
-
-Run:
-
-```bash
-bun run test:run -- src/lib/games/ice-slide/solver.test.ts
-```
-
-Expected: FAIL because `./solver` does not exist.
-
-- [ ] **Step 3: Add the solver contracts and basic BFS**
-
-Create `src/lib/games/ice-slide/solver.ts` with these exported contracts:
-
-```ts
-import {
-    cloneGrid,
-    parseGrid,
-    slide,
-    type IceSlideGridSource,
-} from './physics'
-import {
-    DIRECTION_DELTA,
-    type CellType,
-    type GridPosition,
-    type IceSlideObjectiveId,
-} from './types'
+export const MAX_SOLVER_CRYSTALS = 30
 
 export interface IceSlideSolverLimits {
     maxStates: number
@@ -219,197 +76,121 @@ export interface IceSlideSolveResult {
     truncated: boolean
 }
 
-interface SolverState {
-    position: GridPosition
-    moves: number
-    collectedCrystalMask: bigint
-    grid: CellType[][]
-}
-
-const DIRECTIONS = [
-    DIRECTION_DELTA.N,
-    DIRECTION_DELTA.E,
-    DIRECTION_DELTA.S,
-    DIRECTION_DELTA.W,
-] as const
-
-function assertValidMaxStates(maxStates: number): void {
-    if (!Number.isSafeInteger(maxStates) || maxStates < 1) {
-        throw new RangeError('maxStates must be a positive safe integer')
-    }
-}
-
-function findUniqueStartAndGoal(grid: readonly (readonly CellType[])[]): {
-    start: GridPosition
-} {
-    if ((grid[0]?.length ?? 0) === 0) {
-        throw new RangeError('board must have at least one column')
-    }
-
-    let start: GridPosition | null = null
-    let startCount = 0
-    let goalCount = 0
-
-    for (let row = 0; row < grid.length; row++) {
-        for (let col = 0; col < grid[row].length; col++) {
-            if (grid[row][col] === 'start') {
-                start = { row, col }
-                startCount++
-            }
-            if (grid[row][col] === 'goal') {
-                goalCount++
-            }
-        }
-    }
-
-    if (startCount !== 1 || start === null) {
-        throw new RangeError(
-            `board must contain exactly one start tile; found ${startCount}`
-        )
-    }
-    if (goalCount !== 1) {
-        throw new RangeError(
-            `board must contain exactly one goal tile; found ${goalCount}`
-        )
-    }
-
-    return { start }
-}
-
-function encodeStateKey(
-    position: GridPosition,
-    collectedCrystalMask: bigint
-): string {
-    return `${position.row},${position.col},${collectedCrystalMask.toString(16)}`
-}
-
-function truncatedResult(input: {
-    reachableStopCount: number
-    reachableCrystalIds: string[]
-    exploredStates: number
-}): IceSlideSolveResult {
-    return {
-        solvable: false,
-        minMoves: null,
-        reachableStopCount: input.reachableStopCount,
-        reachableCrystalIds: input.reachableCrystalIds,
-        objectiveFeasibility: {
-            collect_all_crystals: false,
-            no_falls: false,
-            no_reset: false,
-        },
-        exploredStates: input.exploredStates,
-        truncated: true,
-    }
-}
-```
-
-Implement the first traversal version:
-
-```ts
 export function solveIceSlideBoard(
     source: IceSlideGridSource,
     limits: IceSlideSolverLimits
-): IceSlideSolveResult {
-    assertValidMaxStates(limits.maxStates)
-
-    const baseGrid = parseGrid(source)
-    const { start } = findUniqueStartAndGoal(baseGrid)
-    const initialGrid = cloneGrid(baseGrid)
-    initialGrid[start.row][start.col] = 'ice'
-
-    const initialState: SolverState = {
-        position: start,
-        moves: 0,
-        collectedCrystalMask: 0n,
-        grid: initialGrid,
-    }
-    const queue: SolverState[] = [initialState]
-    let queueIndex = 0
-    const seen = new Set([
-        encodeStateKey(start, initialState.collectedCrystalMask),
-    ])
-    const reachableStops = new Set([`${start.row},${start.col}`])
-    let minMoves: number | null = null
-
-    while (queueIndex < queue.length) {
-        const current = queue[queueIndex++]
-
-        for (const direction of DIRECTIONS) {
-            const nextGrid = cloneGrid(current.grid)
-            const outcome = slide(nextGrid, current.position, direction)
-            if (outcome.kind !== 'moved') {
-                continue
-            }
-
-            const nextMoves = current.moves + 1
-            const nextKey = encodeStateKey(
-                outcome.end,
-                current.collectedCrystalMask
-            )
-            if (seen.has(nextKey)) {
-                continue
-            }
-            if (seen.size >= limits.maxStates) {
-                return truncatedResult({
-                    reachableStopCount: reachableStops.size,
-                    reachableCrystalIds: [],
-                    exploredStates: seen.size,
-                })
-            }
-
-            seen.add(nextKey)
-            reachableStops.add(`${outcome.end.row},${outcome.end.col}`)
-
-            if (outcome.reachedGoal) {
-                minMoves ??= nextMoves
-                continue
-            }
-
-            queue.push({
-                position: outcome.end,
-                moves: nextMoves,
-                collectedCrystalMask: current.collectedCrystalMask,
-                grid: nextGrid,
-            })
-        }
-    }
-
-    const solvable = minMoves !== null
-    return {
-        solvable,
-        minMoves,
-        reachableStopCount: reachableStops.size,
-        reachableCrystalIds: [],
-        objectiveFeasibility: {
-            collect_all_crystals: false,
-            no_falls: false,
-            no_reset: solvable,
-        },
-        exploredStates: seen.size,
-        truncated: false,
-    }
-}
+): IceSlideSolveResult
 ```
 
-This step intentionally leaves crystal-aware state and full objective feasibility for
-Task 2 while establishing the bounded BFS and result shape.
+- [ ] **Step 1: Write the failing solver tests**
 
-- [ ] **Step 4: Run the solver tests**
+Create `solver.test.ts` with these named cases:
 
-Run:
+| Test | Required assertion |
+|---|---|
+| `returns an exact one-move solution` | `minMoves === 1`, start+goal stop count, not truncated |
+| `finds a multi-move Campaign minimum` | Campaign level 2 matches current par |
+| `distinguishes the same stop with different crystal masks` | collect crystal, revisit a coordinate, then retain a valid goal route |
+| `returns row-major reachable crystal IDs` | IDs use zero-based `"row,col"` strings |
+| `excludes unreachable crystals` | isolated crystal is absent |
+| `reports all three objective contracts` | collect-all search result plus derived no-falls/no-reset semantics |
+| `counts explored states and unique stops` | state count distinguishes masks; stop count does not |
+| `does not mutate caller rows` | repeated calls return equal results and original rows remain equal |
+| `rejects invalid solver input` | empty/zero-column/jagged/unknown glyph, start/goal count, >30 crystals, invalid cap |
+| `truncates before a goal` | `truncated`, `solvable: false`, `minMoves: null` |
+| `preserves a proven minimum when later truncated` | `truncated`, `solvable: false`, non-null exact `minMoves` |
+
+Use a crystal-state fixture where a correct result requires revisiting a previously seen
+coordinate after collecting a crystal. This test must fail if the visited key contains
+position only.
+
+Use a separate branching fixture for post-goal truncation: direction order must reach a
+short goal first, then encounter enough additional unseen states to hit the cap.
+
+- [ ] **Step 2: Run tests and confirm the module is absent**
 
 ```bash
 bun run test:run -- src/lib/games/ice-slide/solver.test.ts
 ```
 
-Expected: PASS for all initial traversal, input, and cap tests.
+Expected: FAIL because `./solver` does not exist.
 
-- [ ] **Step 5: Run formatter and lint on the new files**
+- [ ] **Step 3: Implement input scanning and state encoding**
 
-Run:
+In `solver.ts`:
+
+- validate `maxStates` with `Number.isSafeInteger(value) && value >= 1`;
+- call `parseGrid(source)`;
+- reject a zero-column board explicitly;
+- scan once for exactly one start, exactly one goal, hazards, and row-major crystals;
+- reject crystal count above `MAX_SOLVER_CRYSTALS`;
+- map each crystal ID to bit `1 << index`;
+- use the private state key:
+
+```ts
+function encodeStateKey(
+    position: GridPosition,
+    crystalMask: number
+): string {
+    return `${position.row},${position.col},${crystalMask}`
+}
+```
+
+The direct solver throws for invalid content. Do not add an exported validation helper.
+
+- [ ] **Step 4: Implement complete BFS traversal**
+
+Use this exact traversal policy:
+
+1. Clone the parsed grid and replace the start cell with ice.
+2. Queue the start state with `moves: 0` and mask `0`.
+3. Use an array plus queue cursor.
+4. Try directions in `N`, `E`, `S`, `W` order.
+5. Clone the current state's grid before each `slide()` call.
+6. Skip `noop` and `hazard` outcomes.
+7. Update the crystal mask from crystal coordinates in `outcome.path`.
+8. Skip already-seen `(position, mask)` states.
+9. Before admitting an unseen state, compare `seen.size` with `maxStates`.
+10. Record goal states but do not enqueue them.
+11. Continue after the first goal until the queue is exhausted or the cap truncates.
+
+Track:
+
+- `minMoves` from the first reached goal;
+- unique stop-coordinate IDs in a `Set<string>`;
+- reachable crystals in a `Set<string>`, returned by filtering the original row-major
+  crystal list;
+- whether any goal state consumed the complete crystal mask;
+- whether the board contains at least one hazard.
+
+- [ ] **Step 5: Implement result semantics**
+
+For a complete search:
+
+```ts
+solvable = minMoves !== null
+objectiveFeasibility = {
+    collect_all_crystals:
+        crystalCount > 0 && reachedGoalWithAllCrystals,
+    no_falls: hasHazard && solvable,
+    no_reset: solvable,
+}
+```
+
+For truncation:
+
+- return immediately before admitting the over-cap state;
+- set `truncated: true` and `solvable: false`;
+- keep the current `minMoves`, which may be `null`;
+- keep already-observed stop/crystal counts and witnessed objective feasibility;
+- set `exploredStates` to `seen.size`.
+
+No result path or predecessor map is required.
+
+- [ ] **Step 6: Run and format the solver suite**
 
 ```bash
+bun run test:run -- src/lib/games/ice-slide/solver.test.ts
 bunx prettier --write \
   src/lib/games/ice-slide/solver.ts \
   src/lib/games/ice-slide/solver.test.ts
@@ -418,9 +199,9 @@ bunx eslint \
   src/lib/games/ice-slide/solver.test.ts
 ```
 
-Expected: both commands exit successfully.
+Expected: solver tests pass; formatter and lint exit successfully.
 
-- [ ] **Step 6: Commit Task 1**
+- [ ] **Step 7: Commit the complete solver**
 
 ```bash
 git add \
@@ -431,471 +212,35 @@ git commit -m "feat(ice-slide): add bounded production solver"
 
 ---
 
-### Task 2: Add crystal-state search and objective feasibility
+### Task 2: Add lean stage-quality validation
 
 **Files:**
-- Modify: `src/lib/games/ice-slide/solver.test.ts`
-- Modify: `src/lib/games/ice-slide/solver.ts`
-
-**Interfaces:**
-- Consumes: the Task 1 solver contracts.
-- Produces: complete `reachableCrystalIds` and `objectiveFeasibility` semantics without
-  changing the exported API.
-
-- [ ] **Step 1: Add the crystal-mask fixture and objective tests**
-
-Append to the existing `describe('solveIceSlideBoard', ...)` block:
-
-```ts
-it('revisits the same stop after collecting a crystal', () => {
-    const result = solveIceSlideBoard(
-        {
-            id: 'crystal-mask',
-            rows: [
-                '#######',
-                '#.O.O.#',
-                '#..C..#',
-                '#G.S..#',
-                '#..O..#',
-                '#.....#',
-                '#######',
-            ],
-        },
-        { maxStates: 1_000 }
-    )
-
-    expect(result.truncated).toBe(false)
-    expect(result.solvable).toBe(true)
-    expect(result.minMoves).toBe(1)
-    expect(result.reachableCrystalIds).toEqual(['2,3'])
-    expect(result.objectiveFeasibility).toEqual({
-        collect_all_crystals: true,
-        no_falls: false,
-        no_reset: true,
-    })
-})
-
-it('reports only crystals reachable on non-hazard slides', () => {
-    const result = solveIceSlideBoard(
-        {
-            id: 'isolated-crystal',
-            rows: [
-                '#######',
-                '#S...G#',
-                '#######',
-                '###C###',
-                '#######',
-            ],
-        },
-        { maxStates: 1_000 }
-    )
-
-    expect(result.solvable).toBe(true)
-    expect(result.reachableCrystalIds).toEqual([])
-    expect(result.objectiveFeasibility.collect_all_crystals).toBe(false)
-})
-
-it('requires board content for optional-objective eligibility', () => {
-    const noHazard = solveIceSlideBoard(
-        {
-            id: 'no-hazard',
-            rows: ['#####', '#S.G#', '#####'],
-        },
-        { maxStates: 100 }
-    )
-    const withHazard = solveIceSlideBoard(
-        ICE_SLIDE_LEVELS[3],
-        { maxStates: 10_000 }
-    )
-
-    expect(noHazard.objectiveFeasibility.no_falls).toBe(false)
-    expect(noHazard.objectiveFeasibility.collect_all_crystals).toBe(false)
-    expect(noHazard.objectiveFeasibility.no_reset).toBe(true)
-
-    expect(withHazard.solvable).toBe(true)
-    expect(withHazard.objectiveFeasibility.no_falls).toBe(true)
-    expect(withHazard.objectiveFeasibility.no_reset).toBe(true)
-})
-
-it('is deterministic and leaves caller rows unchanged', () => {
-    const rows = [
-        '#######',
-        '#.O.O.#',
-        '#..C..#',
-        '#G.S..#',
-        '#..O..#',
-        '#.....#',
-        '#######',
-    ] as const
-    const before = [...rows]
-
-    const first = solveIceSlideBoard(
-        { id: 'deterministic', rows },
-        { maxStates: 1_000 }
-    )
-    const second = solveIceSlideBoard(
-        { id: 'deterministic', rows },
-        { maxStates: 1_000 }
-    )
-
-    expect(second).toEqual(first)
-    expect(rows).toEqual(before)
-})
-```
-
-- [ ] **Step 2: Run the new tests and confirm crystal behavior fails**
-
-Run:
-
-```bash
-bun run test:run -- src/lib/games/ice-slide/solver.test.ts
-```
-
-Expected: FAIL because `reachableCrystalIds` is empty and the current visited key does
-not advance the crystal mask.
-
-- [ ] **Step 3: Scan and index crystals once**
-
-Add these helpers to `solver.ts`:
-
-```ts
-interface CrystalIndex {
-    ids: string[]
-    indexById: Map<string, number>
-}
-
-function positionId(position: GridPosition): string {
-    return `${position.row},${position.col}`
-}
-
-function indexCrystals(grid: readonly (readonly CellType[])[]): CrystalIndex {
-    const ids: string[] = []
-    const indexById = new Map<string, number>()
-
-    for (let row = 0; row < grid.length; row++) {
-        for (let col = 0; col < grid[row].length; col++) {
-            if (grid[row][col] !== 'crystal') {
-                continue
-            }
-            const id = positionId({ row, col })
-            indexById.set(id, ids.length)
-            ids.push(id)
-        }
-    }
-
-    return { ids, indexById }
-}
-
-function maskForSlidePath(
-    currentMask: bigint,
-    path: readonly GridPosition[],
-    crystalIndexById: ReadonlyMap<string, number>
-): bigint {
-    let mask = currentMask
-
-    for (const position of path) {
-        const crystalIndex = crystalIndexById.get(positionId(position))
-        if (crystalIndex !== undefined) {
-            mask |= 1n << BigInt(crystalIndex)
-        }
-    }
-
-    return mask
-}
-```
-
-At the start of `solveIceSlideBoard()`, after parsing:
-
-```ts
-const crystalIndex = indexCrystals(baseGrid)
-const allCrystalsMask =
-    crystalIndex.ids.length === 0
-        ? 0n
-        : (1n << BigInt(crystalIndex.ids.length)) - 1n
-const hasHazard = baseGrid.some(row => row.includes('hazard'))
-const reachableCrystalIds = new Set<string>()
-let reachedGoalWithAllCrystals = false
-```
-
-- [ ] **Step 4: Include the crystal mask in each transition**
-
-Replace the Task 1 `nextKey` construction with:
-
-```ts
-const nextCrystalMask = maskForSlidePath(
-    current.collectedCrystalMask,
-    outcome.path,
-    crystalIndex.indexById
-)
-
-for (const position of outcome.path) {
-    const id = positionId(position)
-    if (crystalIndex.indexById.has(id)) {
-        reachableCrystalIds.add(id)
-    }
-}
-
-const nextKey = encodeStateKey(outcome.end, nextCrystalMask)
-```
-
-When returning a truncated result, pass row-major reachable IDs:
-
-```ts
-reachableCrystalIds: crystalIndex.ids.filter(id =>
-    reachableCrystalIds.has(id)
-),
-```
-
-When a goal is reached:
-
-```ts
-minMoves ??= nextMoves
-if (
-    crystalIndex.ids.length > 0 &&
-    nextCrystalMask === allCrystalsMask
-) {
-    reachedGoalWithAllCrystals = true
-}
-continue
-```
-
-When enqueuing:
-
-```ts
-queue.push({
-    position: outcome.end,
-    moves: nextMoves,
-    collectedCrystalMask: nextCrystalMask,
-    grid: nextGrid,
-})
-```
-
-- [ ] **Step 5: Complete objective feasibility and deterministic arrays**
-
-Replace the successful final return with:
-
-```ts
-const solvable = minMoves !== null
-return {
-    solvable,
-    minMoves,
-    reachableStopCount: reachableStops.size,
-    reachableCrystalIds: crystalIndex.ids.filter(id =>
-        reachableCrystalIds.has(id)
-    ),
-    objectiveFeasibility: {
-        collect_all_crystals:
-            crystalIndex.ids.length > 0 && reachedGoalWithAllCrystals,
-        no_falls: hasHazard && solvable,
-        no_reset: solvable,
-    },
-    exploredStates: seen.size,
-    truncated: false,
-}
-```
-
-- [ ] **Step 6: Run the complete solver suite**
-
-Run:
-
-```bash
-bun run test:run -- src/lib/games/ice-slide/solver.test.ts
-```
-
-Expected: PASS.
-
-- [ ] **Step 7: Run format and lint**
-
-Run:
-
-```bash
-bunx prettier --write \
-  src/lib/games/ice-slide/solver.ts \
-  src/lib/games/ice-slide/solver.test.ts
-bunx eslint \
-  src/lib/games/ice-slide/solver.ts \
-  src/lib/games/ice-slide/solver.test.ts
-```
-
-Expected: both commands exit successfully.
-
-- [ ] **Step 8: Commit Task 2**
-
-```bash
-git add \
-  src/lib/games/ice-slide/solver.ts \
-  src/lib/games/ice-slide/solver.test.ts
-git commit -m "feat(ice-slide): report crystal and objective feasibility"
-```
-
----
-
-### Task 3: Add deterministic stage-quality validation
-
-**Files:**
-- Create: `src/lib/games/ice-slide/quality.test.ts`
 - Create: `src/lib/games/ice-slide/quality.ts`
+- Create: `src/lib/games/ice-slide/quality.test.ts`
 
-**Interfaces:**
-- Consumes:
-  - `solveIceSlideBoard()` and `IceSlideSolveResult` from `./solver`
-  - `parseGrid()` and `IceSlideGridSource` from `./physics`
-  - `serializeBoardRows()` from `./transforms`
-  - `IceSlideObjectiveId` from `./types`
-- Produces:
-  - `IceSlideStageQualityCandidate`
-  - `IceSlideParBand`
-  - `IceSlideStageQualityConstraints`
-  - `IceSlideStageRejectionReason`
-  - `IceSlideStageQualityResult`
-  - `validateIceSlideStageQuality(candidate, constraints)`
-
-- [ ] **Step 1: Write structural and duplicate rejection tests**
-
-Create `src/lib/games/ice-slide/quality.test.ts`:
+**Produces:**
 
 ```ts
-import { describe, expect, it } from 'vitest'
-import { serializeBoardRows } from './transforms'
-import {
-    validateIceSlideStageQuality,
-    type IceSlideStageQualityCandidate,
-} from './quality'
-
-const BASIC_ROWS = ['#####', '#S.G#', '#####'] as const
-
-function candidate(
-    rows: readonly string[] = BASIC_ROWS,
-    objectiveIds: IceSlideStageQualityCandidate['objectiveIds'] = []
-): IceSlideStageQualityCandidate {
-    return {
-        id: 'candidate',
-        rows,
-        objectiveIds,
-    }
-}
-
-const ACCEPTING_CONSTRAINTS = {
-    parBand: { minMoves: 1, maxMoves: 10 },
-    maxStates: 10_000,
-} as const
-
-describe('validateIceSlideStageQuality', () => {
-    it.each([
-        ['empty', []],
-        ['zero-column', ['']],
-        ['jagged', ['#####', '#S.G#', '####']],
-        ['unknown glyph', ['#####', '#SXG#', '#####']],
-    ])('rejects an invalid %s board', (_name, rows) => {
-        const result = validateIceSlideStageQuality(
-            candidate(rows),
-            ACCEPTING_CONSTRAINTS
-        )
-
-        expect(result).toMatchObject({
-            accepted: false,
-            reason: 'invalid_board',
-        })
-    })
-
-    it.each([
-        [
-            'missing start',
-            ['#####', '#..G#', '#####'],
-            'invalid_start_count',
-        ],
-        [
-            'multiple starts',
-            ['######', '#SS.G#', '######'],
-            'invalid_start_count',
-        ],
-        [
-            'missing goal',
-            ['#####', '#S..#', '#####'],
-            'invalid_goal_count',
-        ],
-        [
-            'multiple goals',
-            ['######', '#S.GG#', '######'],
-            'invalid_goal_count',
-        ],
-    ] as const)('rejects %s', (_name, rows, reason) => {
-        const result = validateIceSlideStageQuality(
-            candidate(rows),
-            ACCEPTING_CONSTRAINTS
-        )
-
-        expect(result).toMatchObject({
-            accepted: false,
-            reason,
-        })
-    })
-
-    it('rejects a duplicate before solving', () => {
-        const canonicalKey = serializeBoardRows(BASIC_ROWS)
-        const result = validateIceSlideStageQuality(candidate(), {
-            ...ACCEPTING_CONSTRAINTS,
-            existingCanonicalKeys: new Set([canonicalKey]),
-        })
-
-        expect(result).toEqual({
-            accepted: false,
-            reason: 'duplicate_board',
-            message: 'board duplicates an existing canonical key',
-            canonicalKey,
-        })
-    })
-})
-```
-
-- [ ] **Step 2: Run the quality tests and confirm the module is missing**
-
-Run:
-
-```bash
-bun run test:run -- src/lib/games/ice-slide/quality.test.ts
-```
-
-Expected: FAIL because `./quality` does not exist.
-
-- [ ] **Step 3: Add quality contracts and configuration validation**
-
-Create `src/lib/games/ice-slide/quality.ts`:
-
-```ts
-import { parseGrid, type IceSlideGridSource } from './physics'
-import {
-    solveIceSlideBoard,
-    type IceSlideSolveResult,
-} from './solver'
-import { serializeBoardRows } from './transforms'
-import type { IceSlideObjectiveId } from './types'
-
 export interface IceSlideStageQualityCandidate
     extends IceSlideGridSource {
     objectiveIds: readonly IceSlideObjectiveId[]
 }
 
-export interface IceSlideParBand {
-    minMoves: number
-    maxMoves: number
-}
-
 export interface IceSlideStageQualityConstraints {
-    parBand: IceSlideParBand
+    parBand: {
+        minMoves: number
+        maxMoves: number
+    }
     maxStates: number
     existingCanonicalKeys?: ReadonlySet<string>
 }
 
 export type IceSlideStageRejectionReason =
     | 'invalid_board'
-    | 'invalid_start_count'
-    | 'invalid_goal_count'
     | 'duplicate_board'
     | 'solver_truncated'
     | 'unsolvable'
     | 'par_out_of_band'
-    | 'required_crystal_unreachable'
     | 'objective_infeasible'
 
 export type IceSlideStageQualityResult =
@@ -912,370 +257,76 @@ export type IceSlideStageQualityResult =
           canonicalKey?: string
           solveResult?: IceSlideSolveResult
       }
-
-function assertPositiveSafeInteger(value: number, field: string): void {
-    if (!Number.isSafeInteger(value) || value < 1) {
-        throw new RangeError(`${field} must be a positive safe integer`)
-    }
-}
-
-function assertValidConstraints(
-    constraints: IceSlideStageQualityConstraints
-): void {
-    assertPositiveSafeInteger(constraints.maxStates, 'maxStates')
-    assertPositiveSafeInteger(
-        constraints.parBand.minMoves,
-        'parBand.minMoves'
-    )
-    assertPositiveSafeInteger(
-        constraints.parBand.maxMoves,
-        'parBand.maxMoves'
-    )
-    if (
-        constraints.parBand.minMoves >
-        constraints.parBand.maxMoves
-    ) {
-        throw new RangeError(
-            'parBand.minMoves must not exceed parBand.maxMoves'
-        )
-    }
-}
 ```
 
-- [ ] **Step 4: Implement structural validation and duplicate detection**
+- [ ] **Step 1: Write the failing quality tests**
 
-Add:
+Create `quality.test.ts` with this matrix:
 
-```ts
-function rejection(
-    reason: IceSlideStageRejectionReason,
-    message: string,
-    extras: {
-        canonicalKey?: string
-        solveResult?: IceSlideSolveResult
-    } = {}
-): IceSlideStageQualityResult {
-    return {
-        accepted: false,
-        reason,
-        message,
-        ...extras,
-    }
-}
+| Fixture | Expected reason |
+|---|---|
+| empty, zero-column, jagged, unknown glyph | `invalid_board` |
+| missing/multiple start | `invalid_board`, count in message |
+| missing/multiple goal | `invalid_board`, count in message |
+| more than 30 crystals | `invalid_board` |
+| existing exact canonical key | `duplicate_board` |
+| state cap hit | `solver_truncated` even when `minMoves` is present |
+| fully explored impossible goal | `unsolvable` |
+| computed par below/above band | `par_out_of_band` |
+| assigned collect-all with unreachable crystal | `objective_infeasible`, crystal detail in message |
+| assigned collect-all without all-crystals goal route | `objective_infeasible` |
+| assigned no-falls on no-hazard board | `objective_infeasible` |
+| valid candidate | accepted with computed par, canonical key, and solver result |
+| invalid constraints | throws `RangeError` |
 
-export function validateIceSlideStageQuality(
-    candidate: IceSlideStageQualityCandidate,
-    constraints: IceSlideStageQualityConstraints
-): IceSlideStageQualityResult {
-    assertValidConstraints(constraints)
-
-    if (candidate.rows[0]?.length === 0) {
-        return rejection(
-            'invalid_board',
-            'board must have at least one column'
-        )
-    }
-
-    let grid: ReturnType<typeof parseGrid>
-    try {
-        grid = parseGrid(candidate)
-    } catch (error) {
-        return rejection(
-            'invalid_board',
-            error instanceof Error
-                ? error.message
-                : 'board parsing failed'
-        )
-    }
-
-    let startCount = 0
-    let goalCount = 0
-    let crystalCount = 0
-    for (const row of grid) {
-        for (const cell of row) {
-            if (cell === 'start') startCount++
-            if (cell === 'goal') goalCount++
-            if (cell === 'crystal') crystalCount++
-        }
-    }
-
-    if (startCount !== 1) {
-        return rejection(
-            'invalid_start_count',
-            `expected exactly one start tile, found ${startCount}`
-        )
-    }
-    if (goalCount !== 1) {
-        return rejection(
-            'invalid_goal_count',
-            `expected exactly one goal tile, found ${goalCount}`
-        )
-    }
-
-    const canonicalKey = serializeBoardRows(candidate.rows)
-    if (constraints.existingCanonicalKeys?.has(canonicalKey)) {
-        return rejection(
-            'duplicate_board',
-            'board duplicates an existing canonical key',
-            { canonicalKey }
-        )
-    }
-
-    // Solver and policy checks are added in the next step.
-    throw new Error(
-        `quality policy not implemented for ${canonicalKey} with ${crystalCount} crystals`
-    )
-}
-```
-
-- [ ] **Step 5: Run only the structural tests**
-
-Run:
-
-```bash
-bun run test:run -- \
-  src/lib/games/ice-slide/quality.test.ts \
-  -t "invalid|missing|multiple|duplicate"
-```
-
-Expected: PASS for structural and duplicate cases.
-
-- [ ] **Step 6: Add solver-policy failing tests**
-
-Append to `quality.test.ts`:
-
-```ts
-it('rejects a fully explored unsolvable board', () => {
-    const result = validateIceSlideStageQuality(
-        candidate(['#####', '#S#G#', '#####']),
-        ACCEPTING_CONSTRAINTS
-    )
-
-    expect(result).toMatchObject({
-        accepted: false,
-        reason: 'unsolvable',
-        solveResult: {
-            solvable: false,
-            truncated: false,
-        },
-    })
-})
-
-it('rejects state-cap truncation before solvability', () => {
-    const result = validateIceSlideStageQuality(candidate(), {
-        ...ACCEPTING_CONSTRAINTS,
-        maxStates: 1,
-    })
-
-    expect(result).toMatchObject({
-        accepted: false,
-        reason: 'solver_truncated',
-        solveResult: {
-            solvable: false,
-            truncated: true,
-        },
-    })
-})
-
-it.each([
-    [{ minMoves: 2, maxMoves: 3 }, 1],
-    [{ minMoves: 1, maxMoves: 1 }, 3],
-] as const)(
-    'rejects computed par outside %o',
-    (parBand, expectedPar) => {
-        const rows =
-            expectedPar === 1
-                ? BASIC_ROWS
-                : ['######', '#S#..#', '#....#', '##.#.#', '#...G#', '######']
-        const result = validateIceSlideStageQuality(candidate(rows), {
-            ...ACCEPTING_CONSTRAINTS,
-            parBand,
-        })
-
-        expect(result).toMatchObject({
-            accepted: false,
-            reason: 'par_out_of_band',
-            solveResult: {
-                minMoves: expectedPar,
-            },
-        })
-    }
-)
-
-it('rejects an unreachable required crystal', () => {
-    const result = validateIceSlideStageQuality(
-        candidate(
-            [
-                '#######',
-                '#S...G#',
-                '#######',
-                '###C###',
-                '#######',
-            ],
-            ['collect_all_crystals']
-        ),
-        ACCEPTING_CONSTRAINTS
-    )
-
-    expect(result).toMatchObject({
-        accepted: false,
-        reason: 'required_crystal_unreachable',
-    })
-})
-
-it.each([
-    ['collect_all_crystals', 'objective collect_all_crystals'],
-    ['no_falls', 'objective no_falls'],
-] as const)(
-    'rejects ineligible %s',
-    (objectiveId, message) => {
-        const result = validateIceSlideStageQuality(
-            candidate(BASIC_ROWS, [objectiveId]),
-            ACCEPTING_CONSTRAINTS
-        )
-
-        expect(result).toMatchObject({
-            accepted: false,
-            reason: 'objective_infeasible',
-        })
-        if (!result.accepted) {
-            expect(result.message).toContain(message)
-        }
-    }
-)
-
-it('returns computed par and canonical rows for an accepted candidate', () => {
-    const rows = [
-        '#######',
-        '#.O.O.#',
-        '#..C..#',
-        '#G.S..#',
-        '#..O..#',
-        '#.....#',
-        '#######',
-    ] as const
-    const result = validateIceSlideStageQuality(
-        candidate(rows, ['collect_all_crystals', 'no_reset']),
-        ACCEPTING_CONSTRAINTS
-    )
-
-    expect(result).toEqual({
-        accepted: true,
-        parMoves: 1,
-        canonicalKey: serializeBoardRows(rows),
-        solveResult: expect.objectContaining({
-            solvable: true,
-            minMoves: 1,
-            truncated: false,
-            reachableCrystalIds: ['2,3'],
-        }),
-    })
-})
-
-it('throws for invalid validator constraints', () => {
-    expect(() =>
-        validateIceSlideStageQuality(candidate(), {
-            parBand: { minMoves: 2, maxMoves: 1 },
-            maxStates: 100,
-        })
-    ).toThrow(/minMoves/)
-})
-```
-
-- [ ] **Step 7: Run the policy tests and confirm the temporary throw fails**
-
-Run:
+- [ ] **Step 2: Run tests and confirm the module is absent**
 
 ```bash
 bun run test:run -- src/lib/games/ice-slide/quality.test.ts
 ```
 
-Expected: FAIL at the temporary `quality policy not implemented` error.
+Expected: FAIL because `./quality` does not exist.
 
-- [ ] **Step 8: Implement the ordered solver policy**
+- [ ] **Step 3: Implement configuration and structural validation**
 
-Replace the temporary throw in `validateIceSlideStageQuality()` with:
+In `quality.ts`:
 
-```ts
-const solveResult = solveIceSlideBoard(candidate, {
-    maxStates: constraints.maxStates,
-})
+- validate `maxStates`, `parBand.minMoves`, and `parBand.maxMoves` as positive safe
+  integers;
+- throw when `minMoves > maxMoves`;
+- parse rows and scan crystal/start/goal counts;
+- map parsing, zero-column, crystal-ceiling, and exact-count failures to
+  `invalid_board` with concise diagnostic messages;
+- compute `canonicalKey = serializeBoardRows(candidate.rows)`;
+- reject an existing exact key as `duplicate_board` before calling the solver.
 
-if (solveResult.truncated) {
-    return rejection(
-        'solver_truncated',
-        `solver reached the ${constraints.maxStates}-state cap`,
-        { canonicalKey, solveResult }
-    )
-}
+The quality scan intentionally duplicates the solver's cheap defensive scan so direct
+solver calls still validate themselves. Do not add a third shared module.
 
-if (!solveResult.solvable || solveResult.minMoves === null) {
-    return rejection(
-        'unsolvable',
-        'goal is unreachable under current Ice Slide physics',
-        { canonicalKey, solveResult }
-    )
-}
+- [ ] **Step 4: Implement ordered solver policy**
 
-if (
-    solveResult.minMoves < constraints.parBand.minMoves ||
-    solveResult.minMoves > constraints.parBand.maxMoves
-) {
-    return rejection(
-        'par_out_of_band',
-        `computed par ${solveResult.minMoves} is outside inclusive band ` +
-            `${constraints.parBand.minMoves}..${constraints.parBand.maxMoves}`,
-        { canonicalKey, solveResult }
-    )
-}
+After structural and duplicate checks:
 
-if (
-    candidate.objectiveIds.includes('collect_all_crystals') &&
-    solveResult.reachableCrystalIds.length < crystalCount
-) {
-    return rejection(
-        'required_crystal_unreachable',
-        `only ${solveResult.reachableCrystalIds.length} of ` +
-            `${crystalCount} required crystals are reachable`,
-        { canonicalKey, solveResult }
-    )
-}
+1. Call `solveIceSlideBoard(candidate, { maxStates })`.
+2. Reject `solveResult.truncated` as `solver_truncated` before all other solver checks.
+3. Reject a complete unreachable search as `unsolvable`.
+4. Reject computed par outside the inclusive band as `par_out_of_band`.
+5. Evaluate assigned objectives in input order:
+   - for `collect_all_crystals`, use crystal counts and
+     `solveResult.objectiveFeasibility.collect_all_crystals`; make the message identify
+     unreachable crystals when the reachable count is lower;
+   - use `solveResult.objectiveFeasibility` for all other objective IDs;
+   - reject any failure as `objective_infeasible`.
+6. Return accepted result with computed par, canonical key, and solver result.
 
-for (const objectiveId of candidate.objectiveIds) {
-    if (!solveResult.objectiveFeasibility[objectiveId]) {
-        return rejection(
-            'objective_infeasible',
-            `objective ${objectiveId} is not feasible for this board`,
-            { canonicalKey, solveResult }
-        )
-    }
-}
+Callers branch on `reason`, never on message text.
 
-return {
-    accepted: true,
-    parMoves: solveResult.minMoves,
-    canonicalKey,
-    solveResult,
-}
-```
-
-- [ ] **Step 9: Run the complete quality and solver suites**
-
-Run:
+- [ ] **Step 5: Run and format quality tests**
 
 ```bash
 bun run test:run -- \
   src/lib/games/ice-slide/solver.test.ts \
   src/lib/games/ice-slide/quality.test.ts
-```
-
-Expected: PASS.
-
-- [ ] **Step 10: Run format and lint**
-
-Run:
-
-```bash
 bunx prettier --write \
   src/lib/games/ice-slide/quality.ts \
   src/lib/games/ice-slide/quality.test.ts
@@ -1284,9 +335,9 @@ bunx eslint \
   src/lib/games/ice-slide/quality.test.ts
 ```
 
-Expected: both commands exit successfully.
+Expected: both suites pass; formatter and lint exit successfully.
 
-- [ ] **Step 11: Commit Task 3**
+- [ ] **Step 6: Commit quality validation**
 
 ```bash
 git add \
@@ -1297,155 +348,62 @@ git commit -m "feat(ice-slide): validate generated stage quality"
 
 ---
 
-### Task 4: Replace test-only BFS and verify the repository
+### Task 3: Replace test-only BFS and verify the repository
 
 **Files:**
 - Modify: `src/lib/games/ice-slide/physics.test.ts`
-- Test: all Ice Slide tests and full repository verification.
 
-**Interfaces:**
-- Consumes: `solveIceSlideBoard()` from Task 1 and complete crystal reporting from Task 2.
-- Produces: Campaign regression coverage with no duplicated local BFS.
+- [ ] **Step 1: Replace Campaign minimum-move BFS**
 
-- [ ] **Step 1: Replace the minimum-move helper**
-
-In `physics.test.ts`:
-
-1. Add:
+Import `solveIceSlideBoard`, delete the local `minMoves()` helper, and for every
+`ICE_SLIDE_LEVELS` entry assert:
 
 ```ts
-import { solveIceSlideBoard } from './solver'
+const result = solveIceSlideBoard(level, { maxStates: 10_000 })
+expect(result.truncated, `level ${level.id} truncated`).toBe(false)
+expect(result.solvable, `level ${level.id} solvable`).toBe(true)
+expect(result.minMoves, `level ${level.id} par`).toBe(level.parMoves)
 ```
 
-2. Delete the local `minMoves()` function inside `describe('ice-slide levels', ...)`.
-3. Replace the Campaign solvability test body with:
+- [ ] **Step 2: Replace Campaign crystal BFS**
 
-```ts
-it('ships exactly 8 solvable levels with matching parMoves', () => {
-    expect(ICE_SLIDE_LEVELS).toHaveLength(8)
+Delete the second local queue traversal. Derive expected IDs from `C` glyphs in row-major
+order and compare them with `result.reachableCrystalIds` from the same explicit cap.
 
-    for (const level of ICE_SLIDE_LEVELS) {
-        const result = solveIceSlideBoard(level, {
-            maxStates: 10_000,
-        })
+Keep `cloneGrid` imported because earlier physics tests still use it.
 
-        expect(result.truncated, `level ${level.id} truncated`).toBe(false)
-        expect(result.solvable, `level ${level.id} solvable`).toBe(true)
-        expect(result.minMoves, `level ${level.id} par`).toBe(
-            level.parMoves
-        )
-    }
-})
-```
-
-- [ ] **Step 2: Replace the crystal-reachability BFS**
-
-Delete the second queue/`Set` traversal from
-`it('makes every authored crystal collectable on a reachable slide', ...)`.
-
-Use:
-
-```ts
-it('makes every authored crystal collectable on a reachable slide', () => {
-    for (const level of ICE_SLIDE_LEVELS) {
-        const expectedCrystalIds: string[] = []
-
-        for (let row = 0; row < level.rows.length; row++) {
-            for (let col = 0; col < level.rows[row].length; col++) {
-                if (level.rows[row][col] === 'C') {
-                    expectedCrystalIds.push(`${row},${col}`)
-                }
-            }
-        }
-
-        const result = solveIceSlideBoard(level, {
-            maxStates: 10_000,
-        })
-
-        expect(result.truncated, `level ${level.id} truncated`).toBe(false)
-        expect(
-            result.reachableCrystalIds,
-            `level ${level.id} reachable crystals`
-        ).toEqual(expectedCrystalIds)
-    }
-})
-```
-
-Remove imports that were used only by the deleted BFS. Keep `cloneGrid` because the
-earlier deep-clone test still uses it.
-
-- [ ] **Step 3: Run targeted Ice Slide tests**
-
-Run:
+- [ ] **Step 3: Run targeted and full tests**
 
 ```bash
 bun run test:run -- \
   src/lib/games/ice-slide/solver.test.ts \
   src/lib/games/ice-slide/quality.test.ts \
   src/lib/games/ice-slide/physics.test.ts
-```
-
-Expected: PASS.
-
-- [ ] **Step 4: Run all Ice Slide tests**
-
-Run:
-
-```bash
 bun run test:run -- src/lib/games/ice-slide
-```
-
-Expected: PASS.
-
-- [ ] **Step 5: Run repository tests**
-
-Run:
-
-```bash
 bun run test:run
 ```
 
-Expected: PASS with no new failures.
+Expected: all commands pass.
 
-- [ ] **Step 6: Run lint and format checks**
-
-Run:
+- [ ] **Step 4: Run static checks**
 
 ```bash
 bun run lint
 bun run format:check
-```
-
-Expected: both commands exit successfully.
-
-- [ ] **Step 7: Run typecheck and compare against `main`**
-
-Run on the implementation branch:
-
-```bash
 bun run typecheck 2>&1 | tee /tmp/hpa-486-typecheck.txt
 ```
 
-Run the same command on a clean `main` worktree or the implementation base commit:
+Compare typecheck output with a clean worktree at the implementation base commit. The
+requirement is no new diagnostics; do not assume the two errors reported by PR #53 still
+form the current baseline.
 
-```bash
-bun run typecheck 2>&1 | tee /tmp/hpa-486-main-typecheck.txt
-diff -u /tmp/hpa-486-main-typecheck.txt /tmp/hpa-486-typecheck.txt
-```
-
-Expected: no new diagnostic introduced by HPA-486. PR #53 reported two pre-existing
-diagnostics in `init.ts` and `init.test.ts`; use the current base output as the source of
-truth rather than assuming that baseline is unchanged.
-
-- [ ] **Step 8: Verify the changed-file boundary**
-
-Run:
+- [ ] **Step 5: Verify implementation scope**
 
 ```bash
 git diff --name-only origin/main...HEAD
 ```
 
-Expected implementation paths:
+Expected implementation files:
 
 ```text
 src/lib/games/ice-slide/physics.test.ts
@@ -1455,78 +413,33 @@ src/lib/games/ice-slide/solver.test.ts
 src/lib/games/ice-slide/solver.ts
 ```
 
-Documentation from the planning PR is not part of the implementation branch unless the
-implementation intentionally branches from the merged planning commit.
-
-- [ ] **Step 9: Commit Task 4**
+- [ ] **Step 6: Commit Campaign migration**
 
 ```bash
 git add src/lib/games/ice-slide/physics.test.ts
 git commit -m "test(ice-slide): use production solver for campaign content"
 ```
 
-- [ ] **Step 10: Prepare the implementation PR summary**
+- [ ] **Step 7: Open a draft implementation PR**
 
-Use this PR scope:
+The PR summary must state:
 
-```markdown
-## Summary
+- complete bounded solver with numeric crystal masks;
+- quality rejection policy and six reason codes;
+- preserved Campaign pars and crystal reachability;
+- truncation preserves proven `minMoves` but is always rejected;
+- no runtime, generator-loop, UI, score, or future-mechanic changes;
+- targeted/full test, lint, format, and baseline-aware typecheck results.
 
-Implements HPA-486 by extracting the Ice Slide Campaign BFS into a bounded pure
-production solver and adding deterministic stage-quality validation for later Daily and
-Expedition generation.
-
-## Changes
-
-- add player-position + consumed-crystal BFS state;
-- report exact par, stops, crystals, objective feasibility, explored states, and
-  truncation;
-- add ordered structural, duplicate, par-band, objective, and cap rejection results;
-- replace duplicated Campaign BFS assertions with production-solver tests.
-
-## YAGNI boundaries
-
-- no generator loop or fallback selection;
-- no runtime solver integration;
-- no generic graph-search framework;
-- no snow, cracked ice, Undo, or solution paths.
-
-## Verification
-
-- targeted Ice Slide suites;
-- full test suite;
-- lint and format checks;
-- typecheck compared with the current `main` baseline.
-```
-
-Create the implementation PR as a draft and link HPA-486. Do not enable auto-merge.
+Do not enable auto-merge.
 
 ---
 
 ## Plan Self-Review
 
-### Spec coverage
-
-- Bounded BFS and exact minimum: Task 1.
-- Consumed-crystal state and objective feasibility: Task 2.
-- Structural, duplicate, par, objective, and truncation rejection: Task 3.
-- Campaign compatibility and removal of duplicate BFS: Task 4.
-- Determinism, immutability, explicit caps, and no runtime integration: Tasks 1–4 and
-  Global Constraints.
-- Cracked-ice extension point: private `encodeStateKey()` in Task 1, with no unused
-  dynamic state added.
-
-### Placeholder scan
-
-The plan contains no unresolved placeholder or unspecified error-handling step. The
-deliberate temporary throw in Task 3 is a TDD checkpoint and is explicitly removed
-within the same task.
-
-### Type consistency
-
-- `maxStates`, `parBand.minMoves`, and `parBand.maxMoves` are consistent across the
-  design, tests, and implementation.
-- `reachableCrystalIds` uses zero-based `"row,col"` strings everywhere.
-- `validateIceSlideStageQuality()` returns the same discriminated union consumed by all
-  tests.
-- Truncation semantics are identical in solver and quality policy.
+- **Spec coverage:** all HPA-486 required fields and rejection checks map to Tasks 1–3.
+- **No partial API:** Task 1 delivers the complete solver in one commit.
+- **YAGNI:** no full source dump, generic framework, solution path, generator
+  orchestration, or future-state scaffolding.
+- **Type consistency:** `number` mask ceiling, six reason codes, truncation semantics,
+  and public interfaces match the design.

--- a/docs/superpowers/plans/2026-08-03-ice-slide-production-solver.md
+++ b/docs/superpowers/plans/2026-08-03-ice-slide-production-solver.md
@@ -1,0 +1,1532 @@
+# Ice Slide Production Solver and Stage Quality Validation Implementation Plan
+
+> **For agentic workers:** REQUIRED SUB-SKILL: Use superpowers:subagent-driven-development (recommended) or superpowers:executing-plans to implement this plan task-by-task. Steps use checkbox (`- [ ]`) syntax for tracking.
+
+**Goal:** Extract Ice Slide's test-only BFS into bounded deterministic production code and add a pure stage-quality validator for future Daily and Expedition generation.
+
+**Architecture:** `solver.ts` owns breadth-first traversal over player position and consumed-crystal state while reusing `slide()` as the only movement transition. `quality.ts` applies ordered candidate acceptance rules around the solver and returns a discriminated rejection union. Runtime gameplay remains unchanged.
+
+**Tech Stack:** TypeScript 6, Vitest 3, Bun 1.3, existing Ice Slide physics and transformation utilities.
+
+## Global Constraints
+
+- Follow `docs/superpowers/specs/2026-08-03-ice-slide-production-solver-design.md`.
+- Keep solver and quality modules pure: no DOM, Pixi, storage, network, time, randomness, or logging.
+- Reuse `parseGrid()`, `cloneGrid()`, `slide()`, `DIRECTION_DELTA`, and `serializeBoardRows()`.
+- Require an explicit positive safe-integer `maxStates`; do not add an unbounded or hidden-default mode.
+- Treat truncation as rejection: `truncated: true`, `solvable: false`, and `minMoves: null`.
+- Do not modify runtime gameplay, generation loops, score behavior, or future snow/cracked-ice mechanics.
+- Do not create a generic graph-search abstraction or return solution paths.
+- Use TDD and commit each independently reviewable task.
+
+---
+
+## File Map
+
+### Create
+
+- `src/lib/games/ice-slide/solver.ts`
+  - solver contracts;
+  - bounded BFS;
+  - crystal-mask state;
+  - objective feasibility.
+
+- `src/lib/games/ice-slide/solver.test.ts`
+  - traversal, state-key, objective, cap, determinism, and immutability tests.
+
+- `src/lib/games/ice-slide/quality.ts`
+  - quality contracts;
+  - constraint validation;
+  - ordered candidate rejection.
+
+- `src/lib/games/ice-slide/quality.test.ts`
+  - invalid fixture and accepted-candidate tests.
+
+### Modify
+
+- `src/lib/games/ice-slide/physics.test.ts`
+  - replace both embedded BFS helpers with production solver assertions.
+
+### Must remain untouched
+
+- `src/lib/games/ice-slide/types.ts`
+- `src/lib/games/ice-slide/run.ts`
+- `src/lib/games/ice-slide/game.ts`
+- `src/lib/games/ice-slide/physics.ts`
+- `src/lib/games/ice-slide/levels.ts`
+- `src/lib/games/ice-slide/transforms.ts`
+- `src/lib/games/ice-slide/init.ts`
+- `src/lib/games/ice-slide/renderer.ts`
+
+---
+
+### Task 1: Add bounded minimum-move BFS
+
+**Files:**
+- Create: `src/lib/games/ice-slide/solver.test.ts`
+- Create: `src/lib/games/ice-slide/solver.ts`
+
+**Interfaces:**
+- Consumes:
+  - `IceSlideGridSource`, `parseGrid`, `cloneGrid`, and `slide` from `./physics`
+  - `DIRECTION_DELTA`, `GridPosition`, `CellType`, and `IceSlideObjectiveId` from `./types`
+- Produces:
+  - `IceSlideSolverLimits`
+  - `IceSlideSolveResult`
+  - `solveIceSlideBoard(source, limits)`
+
+- [ ] **Step 1: Write failing tests for basic traversal and bounds**
+
+Create `src/lib/games/ice-slide/solver.test.ts` with the initial tests:
+
+```ts
+import { describe, expect, it } from 'vitest'
+import { ICE_SLIDE_LEVELS } from './levels'
+import { solveIceSlideBoard } from './solver'
+
+describe('solveIceSlideBoard', () => {
+    it('returns the exact minimum moves and unique reachable stops', () => {
+        const result = solveIceSlideBoard(
+            {
+                id: 'one-move',
+                rows: ['#####', '#S.G#', '#####'],
+            },
+            { maxStates: 100 }
+        )
+
+        expect(result).toMatchObject({
+            solvable: true,
+            minMoves: 1,
+            reachableStopCount: 2,
+            exploredStates: 2,
+            truncated: false,
+        })
+    })
+
+    it('finds a multi-move Campaign minimum', () => {
+        const level = ICE_SLIDE_LEVELS[1]
+        const result = solveIceSlideBoard(level, { maxStates: 10_000 })
+
+        expect(result.truncated).toBe(false)
+        expect(result.solvable).toBe(true)
+        expect(result.minMoves).toBe(level.parMoves)
+    })
+
+    it('rejects a non-positive or unsafe state cap', () => {
+        const source = {
+            id: 'invalid-cap',
+            rows: ['#####', '#S.G#', '#####'],
+        }
+
+        expect(() =>
+            solveIceSlideBoard(source, { maxStates: 0 })
+        ).toThrow(/maxStates/)
+        expect(() =>
+            solveIceSlideBoard(source, {
+                maxStates: Number.MAX_SAFE_INTEGER + 1,
+            })
+        ).toThrow(/maxStates/)
+    })
+
+    it.each([
+        [
+            'zero-column',
+            [''],
+            /at least one column/,
+        ],
+        [
+            'multiple starts',
+            ['######', '#SS.G#', '######'],
+            /exactly one start/,
+        ],
+        [
+            'multiple goals',
+            ['######', '#S.GG#', '######'],
+            /exactly one goal/,
+        ],
+    ] as const)('rejects invalid solver input: %s', (_name, rows, error) => {
+        expect(() =>
+            solveIceSlideBoard(
+                { id: 'invalid-board', rows },
+                { maxStates: 100 }
+            )
+        ).toThrow(error)
+    })
+
+    it('reports truncation before admitting a state beyond the cap', () => {
+        const result = solveIceSlideBoard(
+            {
+                id: 'truncated',
+                rows: ['#####', '#S.G#', '#####'],
+            },
+            { maxStates: 1 }
+        )
+
+        expect(result).toMatchObject({
+            solvable: false,
+            minMoves: null,
+            exploredStates: 1,
+            truncated: true,
+        })
+        expect(result.objectiveFeasibility).toEqual({
+            collect_all_crystals: false,
+            no_falls: false,
+            no_reset: false,
+        })
+    })
+})
+```
+
+- [ ] **Step 2: Run the new tests and confirm the module is missing**
+
+Run:
+
+```bash
+bun run test:run -- src/lib/games/ice-slide/solver.test.ts
+```
+
+Expected: FAIL because `./solver` does not exist.
+
+- [ ] **Step 3: Add the solver contracts and basic BFS**
+
+Create `src/lib/games/ice-slide/solver.ts` with these exported contracts:
+
+```ts
+import {
+    cloneGrid,
+    parseGrid,
+    slide,
+    type IceSlideGridSource,
+} from './physics'
+import {
+    DIRECTION_DELTA,
+    type CellType,
+    type GridPosition,
+    type IceSlideObjectiveId,
+} from './types'
+
+export interface IceSlideSolverLimits {
+    maxStates: number
+}
+
+export interface IceSlideSolveResult {
+    solvable: boolean
+    minMoves: number | null
+    reachableStopCount: number
+    reachableCrystalIds: string[]
+    objectiveFeasibility: Record<IceSlideObjectiveId, boolean>
+    exploredStates: number
+    truncated: boolean
+}
+
+interface SolverState {
+    position: GridPosition
+    moves: number
+    collectedCrystalMask: bigint
+    grid: CellType[][]
+}
+
+const DIRECTIONS = [
+    DIRECTION_DELTA.N,
+    DIRECTION_DELTA.E,
+    DIRECTION_DELTA.S,
+    DIRECTION_DELTA.W,
+] as const
+
+function assertValidMaxStates(maxStates: number): void {
+    if (!Number.isSafeInteger(maxStates) || maxStates < 1) {
+        throw new RangeError('maxStates must be a positive safe integer')
+    }
+}
+
+function findUniqueStartAndGoal(grid: readonly (readonly CellType[])[]): {
+    start: GridPosition
+} {
+    if ((grid[0]?.length ?? 0) === 0) {
+        throw new RangeError('board must have at least one column')
+    }
+
+    let start: GridPosition | null = null
+    let startCount = 0
+    let goalCount = 0
+
+    for (let row = 0; row < grid.length; row++) {
+        for (let col = 0; col < grid[row].length; col++) {
+            if (grid[row][col] === 'start') {
+                start = { row, col }
+                startCount++
+            }
+            if (grid[row][col] === 'goal') {
+                goalCount++
+            }
+        }
+    }
+
+    if (startCount !== 1 || start === null) {
+        throw new RangeError(
+            `board must contain exactly one start tile; found ${startCount}`
+        )
+    }
+    if (goalCount !== 1) {
+        throw new RangeError(
+            `board must contain exactly one goal tile; found ${goalCount}`
+        )
+    }
+
+    return { start }
+}
+
+function encodeStateKey(
+    position: GridPosition,
+    collectedCrystalMask: bigint
+): string {
+    return `${position.row},${position.col},${collectedCrystalMask.toString(16)}`
+}
+
+function truncatedResult(input: {
+    reachableStopCount: number
+    reachableCrystalIds: string[]
+    exploredStates: number
+}): IceSlideSolveResult {
+    return {
+        solvable: false,
+        minMoves: null,
+        reachableStopCount: input.reachableStopCount,
+        reachableCrystalIds: input.reachableCrystalIds,
+        objectiveFeasibility: {
+            collect_all_crystals: false,
+            no_falls: false,
+            no_reset: false,
+        },
+        exploredStates: input.exploredStates,
+        truncated: true,
+    }
+}
+```
+
+Implement the first traversal version:
+
+```ts
+export function solveIceSlideBoard(
+    source: IceSlideGridSource,
+    limits: IceSlideSolverLimits
+): IceSlideSolveResult {
+    assertValidMaxStates(limits.maxStates)
+
+    const baseGrid = parseGrid(source)
+    const { start } = findUniqueStartAndGoal(baseGrid)
+    const initialGrid = cloneGrid(baseGrid)
+    initialGrid[start.row][start.col] = 'ice'
+
+    const initialState: SolverState = {
+        position: start,
+        moves: 0,
+        collectedCrystalMask: 0n,
+        grid: initialGrid,
+    }
+    const queue: SolverState[] = [initialState]
+    let queueIndex = 0
+    const seen = new Set([
+        encodeStateKey(start, initialState.collectedCrystalMask),
+    ])
+    const reachableStops = new Set([`${start.row},${start.col}`])
+    let minMoves: number | null = null
+
+    while (queueIndex < queue.length) {
+        const current = queue[queueIndex++]
+
+        for (const direction of DIRECTIONS) {
+            const nextGrid = cloneGrid(current.grid)
+            const outcome = slide(nextGrid, current.position, direction)
+            if (outcome.kind !== 'moved') {
+                continue
+            }
+
+            const nextMoves = current.moves + 1
+            const nextKey = encodeStateKey(
+                outcome.end,
+                current.collectedCrystalMask
+            )
+            if (seen.has(nextKey)) {
+                continue
+            }
+            if (seen.size >= limits.maxStates) {
+                return truncatedResult({
+                    reachableStopCount: reachableStops.size,
+                    reachableCrystalIds: [],
+                    exploredStates: seen.size,
+                })
+            }
+
+            seen.add(nextKey)
+            reachableStops.add(`${outcome.end.row},${outcome.end.col}`)
+
+            if (outcome.reachedGoal) {
+                minMoves ??= nextMoves
+                continue
+            }
+
+            queue.push({
+                position: outcome.end,
+                moves: nextMoves,
+                collectedCrystalMask: current.collectedCrystalMask,
+                grid: nextGrid,
+            })
+        }
+    }
+
+    const solvable = minMoves !== null
+    return {
+        solvable,
+        minMoves,
+        reachableStopCount: reachableStops.size,
+        reachableCrystalIds: [],
+        objectiveFeasibility: {
+            collect_all_crystals: false,
+            no_falls: false,
+            no_reset: solvable,
+        },
+        exploredStates: seen.size,
+        truncated: false,
+    }
+}
+```
+
+This step intentionally leaves crystal-aware state and full objective feasibility for
+Task 2 while establishing the bounded BFS and result shape.
+
+- [ ] **Step 4: Run the solver tests**
+
+Run:
+
+```bash
+bun run test:run -- src/lib/games/ice-slide/solver.test.ts
+```
+
+Expected: PASS for all initial traversal, input, and cap tests.
+
+- [ ] **Step 5: Run formatter and lint on the new files**
+
+Run:
+
+```bash
+bunx prettier --write \
+  src/lib/games/ice-slide/solver.ts \
+  src/lib/games/ice-slide/solver.test.ts
+bunx eslint \
+  src/lib/games/ice-slide/solver.ts \
+  src/lib/games/ice-slide/solver.test.ts
+```
+
+Expected: both commands exit successfully.
+
+- [ ] **Step 6: Commit Task 1**
+
+```bash
+git add \
+  src/lib/games/ice-slide/solver.ts \
+  src/lib/games/ice-slide/solver.test.ts
+git commit -m "feat(ice-slide): add bounded production solver"
+```
+
+---
+
+### Task 2: Add crystal-state search and objective feasibility
+
+**Files:**
+- Modify: `src/lib/games/ice-slide/solver.test.ts`
+- Modify: `src/lib/games/ice-slide/solver.ts`
+
+**Interfaces:**
+- Consumes: the Task 1 solver contracts.
+- Produces: complete `reachableCrystalIds` and `objectiveFeasibility` semantics without
+  changing the exported API.
+
+- [ ] **Step 1: Add the crystal-mask fixture and objective tests**
+
+Append to the existing `describe('solveIceSlideBoard', ...)` block:
+
+```ts
+it('revisits the same stop after collecting a crystal', () => {
+    const result = solveIceSlideBoard(
+        {
+            id: 'crystal-mask',
+            rows: [
+                '#######',
+                '#.O.O.#',
+                '#..C..#',
+                '#G.S..#',
+                '#..O..#',
+                '#.....#',
+                '#######',
+            ],
+        },
+        { maxStates: 1_000 }
+    )
+
+    expect(result.truncated).toBe(false)
+    expect(result.solvable).toBe(true)
+    expect(result.minMoves).toBe(1)
+    expect(result.reachableCrystalIds).toEqual(['2,3'])
+    expect(result.objectiveFeasibility).toEqual({
+        collect_all_crystals: true,
+        no_falls: false,
+        no_reset: true,
+    })
+})
+
+it('reports only crystals reachable on non-hazard slides', () => {
+    const result = solveIceSlideBoard(
+        {
+            id: 'isolated-crystal',
+            rows: [
+                '#######',
+                '#S...G#',
+                '#######',
+                '###C###',
+                '#######',
+            ],
+        },
+        { maxStates: 1_000 }
+    )
+
+    expect(result.solvable).toBe(true)
+    expect(result.reachableCrystalIds).toEqual([])
+    expect(result.objectiveFeasibility.collect_all_crystals).toBe(false)
+})
+
+it('requires board content for optional-objective eligibility', () => {
+    const noHazard = solveIceSlideBoard(
+        {
+            id: 'no-hazard',
+            rows: ['#####', '#S.G#', '#####'],
+        },
+        { maxStates: 100 }
+    )
+    const withHazard = solveIceSlideBoard(
+        ICE_SLIDE_LEVELS[3],
+        { maxStates: 10_000 }
+    )
+
+    expect(noHazard.objectiveFeasibility.no_falls).toBe(false)
+    expect(noHazard.objectiveFeasibility.collect_all_crystals).toBe(false)
+    expect(noHazard.objectiveFeasibility.no_reset).toBe(true)
+
+    expect(withHazard.solvable).toBe(true)
+    expect(withHazard.objectiveFeasibility.no_falls).toBe(true)
+    expect(withHazard.objectiveFeasibility.no_reset).toBe(true)
+})
+
+it('is deterministic and leaves caller rows unchanged', () => {
+    const rows = [
+        '#######',
+        '#.O.O.#',
+        '#..C..#',
+        '#G.S..#',
+        '#..O..#',
+        '#.....#',
+        '#######',
+    ] as const
+    const before = [...rows]
+
+    const first = solveIceSlideBoard(
+        { id: 'deterministic', rows },
+        { maxStates: 1_000 }
+    )
+    const second = solveIceSlideBoard(
+        { id: 'deterministic', rows },
+        { maxStates: 1_000 }
+    )
+
+    expect(second).toEqual(first)
+    expect(rows).toEqual(before)
+})
+```
+
+- [ ] **Step 2: Run the new tests and confirm crystal behavior fails**
+
+Run:
+
+```bash
+bun run test:run -- src/lib/games/ice-slide/solver.test.ts
+```
+
+Expected: FAIL because `reachableCrystalIds` is empty and the current visited key does
+not advance the crystal mask.
+
+- [ ] **Step 3: Scan and index crystals once**
+
+Add these helpers to `solver.ts`:
+
+```ts
+interface CrystalIndex {
+    ids: string[]
+    indexById: Map<string, number>
+}
+
+function positionId(position: GridPosition): string {
+    return `${position.row},${position.col}`
+}
+
+function indexCrystals(grid: readonly (readonly CellType[])[]): CrystalIndex {
+    const ids: string[] = []
+    const indexById = new Map<string, number>()
+
+    for (let row = 0; row < grid.length; row++) {
+        for (let col = 0; col < grid[row].length; col++) {
+            if (grid[row][col] !== 'crystal') {
+                continue
+            }
+            const id = positionId({ row, col })
+            indexById.set(id, ids.length)
+            ids.push(id)
+        }
+    }
+
+    return { ids, indexById }
+}
+
+function maskForSlidePath(
+    currentMask: bigint,
+    path: readonly GridPosition[],
+    crystalIndexById: ReadonlyMap<string, number>
+): bigint {
+    let mask = currentMask
+
+    for (const position of path) {
+        const crystalIndex = crystalIndexById.get(positionId(position))
+        if (crystalIndex !== undefined) {
+            mask |= 1n << BigInt(crystalIndex)
+        }
+    }
+
+    return mask
+}
+```
+
+At the start of `solveIceSlideBoard()`, after parsing:
+
+```ts
+const crystalIndex = indexCrystals(baseGrid)
+const allCrystalsMask =
+    crystalIndex.ids.length === 0
+        ? 0n
+        : (1n << BigInt(crystalIndex.ids.length)) - 1n
+const hasHazard = baseGrid.some(row => row.includes('hazard'))
+const reachableCrystalIds = new Set<string>()
+let reachedGoalWithAllCrystals = false
+```
+
+- [ ] **Step 4: Include the crystal mask in each transition**
+
+Replace the Task 1 `nextKey` construction with:
+
+```ts
+const nextCrystalMask = maskForSlidePath(
+    current.collectedCrystalMask,
+    outcome.path,
+    crystalIndex.indexById
+)
+
+for (const position of outcome.path) {
+    const id = positionId(position)
+    if (crystalIndex.indexById.has(id)) {
+        reachableCrystalIds.add(id)
+    }
+}
+
+const nextKey = encodeStateKey(outcome.end, nextCrystalMask)
+```
+
+When returning a truncated result, pass row-major reachable IDs:
+
+```ts
+reachableCrystalIds: crystalIndex.ids.filter(id =>
+    reachableCrystalIds.has(id)
+),
+```
+
+When a goal is reached:
+
+```ts
+minMoves ??= nextMoves
+if (
+    crystalIndex.ids.length > 0 &&
+    nextCrystalMask === allCrystalsMask
+) {
+    reachedGoalWithAllCrystals = true
+}
+continue
+```
+
+When enqueuing:
+
+```ts
+queue.push({
+    position: outcome.end,
+    moves: nextMoves,
+    collectedCrystalMask: nextCrystalMask,
+    grid: nextGrid,
+})
+```
+
+- [ ] **Step 5: Complete objective feasibility and deterministic arrays**
+
+Replace the successful final return with:
+
+```ts
+const solvable = minMoves !== null
+return {
+    solvable,
+    minMoves,
+    reachableStopCount: reachableStops.size,
+    reachableCrystalIds: crystalIndex.ids.filter(id =>
+        reachableCrystalIds.has(id)
+    ),
+    objectiveFeasibility: {
+        collect_all_crystals:
+            crystalIndex.ids.length > 0 && reachedGoalWithAllCrystals,
+        no_falls: hasHazard && solvable,
+        no_reset: solvable,
+    },
+    exploredStates: seen.size,
+    truncated: false,
+}
+```
+
+- [ ] **Step 6: Run the complete solver suite**
+
+Run:
+
+```bash
+bun run test:run -- src/lib/games/ice-slide/solver.test.ts
+```
+
+Expected: PASS.
+
+- [ ] **Step 7: Run format and lint**
+
+Run:
+
+```bash
+bunx prettier --write \
+  src/lib/games/ice-slide/solver.ts \
+  src/lib/games/ice-slide/solver.test.ts
+bunx eslint \
+  src/lib/games/ice-slide/solver.ts \
+  src/lib/games/ice-slide/solver.test.ts
+```
+
+Expected: both commands exit successfully.
+
+- [ ] **Step 8: Commit Task 2**
+
+```bash
+git add \
+  src/lib/games/ice-slide/solver.ts \
+  src/lib/games/ice-slide/solver.test.ts
+git commit -m "feat(ice-slide): report crystal and objective feasibility"
+```
+
+---
+
+### Task 3: Add deterministic stage-quality validation
+
+**Files:**
+- Create: `src/lib/games/ice-slide/quality.test.ts`
+- Create: `src/lib/games/ice-slide/quality.ts`
+
+**Interfaces:**
+- Consumes:
+  - `solveIceSlideBoard()` and `IceSlideSolveResult` from `./solver`
+  - `parseGrid()` and `IceSlideGridSource` from `./physics`
+  - `serializeBoardRows()` from `./transforms`
+  - `IceSlideObjectiveId` from `./types`
+- Produces:
+  - `IceSlideStageQualityCandidate`
+  - `IceSlideParBand`
+  - `IceSlideStageQualityConstraints`
+  - `IceSlideStageRejectionReason`
+  - `IceSlideStageQualityResult`
+  - `validateIceSlideStageQuality(candidate, constraints)`
+
+- [ ] **Step 1: Write structural and duplicate rejection tests**
+
+Create `src/lib/games/ice-slide/quality.test.ts`:
+
+```ts
+import { describe, expect, it } from 'vitest'
+import { serializeBoardRows } from './transforms'
+import {
+    validateIceSlideStageQuality,
+    type IceSlideStageQualityCandidate,
+} from './quality'
+
+const BASIC_ROWS = ['#####', '#S.G#', '#####'] as const
+
+function candidate(
+    rows: readonly string[] = BASIC_ROWS,
+    objectiveIds: IceSlideStageQualityCandidate['objectiveIds'] = []
+): IceSlideStageQualityCandidate {
+    return {
+        id: 'candidate',
+        rows,
+        objectiveIds,
+    }
+}
+
+const ACCEPTING_CONSTRAINTS = {
+    parBand: { minMoves: 1, maxMoves: 10 },
+    maxStates: 10_000,
+} as const
+
+describe('validateIceSlideStageQuality', () => {
+    it.each([
+        ['empty', []],
+        ['zero-column', ['']],
+        ['jagged', ['#####', '#S.G#', '####']],
+        ['unknown glyph', ['#####', '#SXG#', '#####']],
+    ])('rejects an invalid %s board', (_name, rows) => {
+        const result = validateIceSlideStageQuality(
+            candidate(rows),
+            ACCEPTING_CONSTRAINTS
+        )
+
+        expect(result).toMatchObject({
+            accepted: false,
+            reason: 'invalid_board',
+        })
+    })
+
+    it.each([
+        [
+            'missing start',
+            ['#####', '#..G#', '#####'],
+            'invalid_start_count',
+        ],
+        [
+            'multiple starts',
+            ['######', '#SS.G#', '######'],
+            'invalid_start_count',
+        ],
+        [
+            'missing goal',
+            ['#####', '#S..#', '#####'],
+            'invalid_goal_count',
+        ],
+        [
+            'multiple goals',
+            ['######', '#S.GG#', '######'],
+            'invalid_goal_count',
+        ],
+    ] as const)('rejects %s', (_name, rows, reason) => {
+        const result = validateIceSlideStageQuality(
+            candidate(rows),
+            ACCEPTING_CONSTRAINTS
+        )
+
+        expect(result).toMatchObject({
+            accepted: false,
+            reason,
+        })
+    })
+
+    it('rejects a duplicate before solving', () => {
+        const canonicalKey = serializeBoardRows(BASIC_ROWS)
+        const result = validateIceSlideStageQuality(candidate(), {
+            ...ACCEPTING_CONSTRAINTS,
+            existingCanonicalKeys: new Set([canonicalKey]),
+        })
+
+        expect(result).toEqual({
+            accepted: false,
+            reason: 'duplicate_board',
+            message: 'board duplicates an existing canonical key',
+            canonicalKey,
+        })
+    })
+})
+```
+
+- [ ] **Step 2: Run the quality tests and confirm the module is missing**
+
+Run:
+
+```bash
+bun run test:run -- src/lib/games/ice-slide/quality.test.ts
+```
+
+Expected: FAIL because `./quality` does not exist.
+
+- [ ] **Step 3: Add quality contracts and configuration validation**
+
+Create `src/lib/games/ice-slide/quality.ts`:
+
+```ts
+import { parseGrid, type IceSlideGridSource } from './physics'
+import {
+    solveIceSlideBoard,
+    type IceSlideSolveResult,
+} from './solver'
+import { serializeBoardRows } from './transforms'
+import type { IceSlideObjectiveId } from './types'
+
+export interface IceSlideStageQualityCandidate
+    extends IceSlideGridSource {
+    objectiveIds: readonly IceSlideObjectiveId[]
+}
+
+export interface IceSlideParBand {
+    minMoves: number
+    maxMoves: number
+}
+
+export interface IceSlideStageQualityConstraints {
+    parBand: IceSlideParBand
+    maxStates: number
+    existingCanonicalKeys?: ReadonlySet<string>
+}
+
+export type IceSlideStageRejectionReason =
+    | 'invalid_board'
+    | 'invalid_start_count'
+    | 'invalid_goal_count'
+    | 'duplicate_board'
+    | 'solver_truncated'
+    | 'unsolvable'
+    | 'par_out_of_band'
+    | 'required_crystal_unreachable'
+    | 'objective_infeasible'
+
+export type IceSlideStageQualityResult =
+    | {
+          accepted: true
+          parMoves: number
+          canonicalKey: string
+          solveResult: IceSlideSolveResult
+      }
+    | {
+          accepted: false
+          reason: IceSlideStageRejectionReason
+          message: string
+          canonicalKey?: string
+          solveResult?: IceSlideSolveResult
+      }
+
+function assertPositiveSafeInteger(value: number, field: string): void {
+    if (!Number.isSafeInteger(value) || value < 1) {
+        throw new RangeError(`${field} must be a positive safe integer`)
+    }
+}
+
+function assertValidConstraints(
+    constraints: IceSlideStageQualityConstraints
+): void {
+    assertPositiveSafeInteger(constraints.maxStates, 'maxStates')
+    assertPositiveSafeInteger(
+        constraints.parBand.minMoves,
+        'parBand.minMoves'
+    )
+    assertPositiveSafeInteger(
+        constraints.parBand.maxMoves,
+        'parBand.maxMoves'
+    )
+    if (
+        constraints.parBand.minMoves >
+        constraints.parBand.maxMoves
+    ) {
+        throw new RangeError(
+            'parBand.minMoves must not exceed parBand.maxMoves'
+        )
+    }
+}
+```
+
+- [ ] **Step 4: Implement structural validation and duplicate detection**
+
+Add:
+
+```ts
+function rejection(
+    reason: IceSlideStageRejectionReason,
+    message: string,
+    extras: {
+        canonicalKey?: string
+        solveResult?: IceSlideSolveResult
+    } = {}
+): IceSlideStageQualityResult {
+    return {
+        accepted: false,
+        reason,
+        message,
+        ...extras,
+    }
+}
+
+export function validateIceSlideStageQuality(
+    candidate: IceSlideStageQualityCandidate,
+    constraints: IceSlideStageQualityConstraints
+): IceSlideStageQualityResult {
+    assertValidConstraints(constraints)
+
+    if (candidate.rows[0]?.length === 0) {
+        return rejection(
+            'invalid_board',
+            'board must have at least one column'
+        )
+    }
+
+    let grid: ReturnType<typeof parseGrid>
+    try {
+        grid = parseGrid(candidate)
+    } catch (error) {
+        return rejection(
+            'invalid_board',
+            error instanceof Error
+                ? error.message
+                : 'board parsing failed'
+        )
+    }
+
+    let startCount = 0
+    let goalCount = 0
+    let crystalCount = 0
+    for (const row of grid) {
+        for (const cell of row) {
+            if (cell === 'start') startCount++
+            if (cell === 'goal') goalCount++
+            if (cell === 'crystal') crystalCount++
+        }
+    }
+
+    if (startCount !== 1) {
+        return rejection(
+            'invalid_start_count',
+            `expected exactly one start tile, found ${startCount}`
+        )
+    }
+    if (goalCount !== 1) {
+        return rejection(
+            'invalid_goal_count',
+            `expected exactly one goal tile, found ${goalCount}`
+        )
+    }
+
+    const canonicalKey = serializeBoardRows(candidate.rows)
+    if (constraints.existingCanonicalKeys?.has(canonicalKey)) {
+        return rejection(
+            'duplicate_board',
+            'board duplicates an existing canonical key',
+            { canonicalKey }
+        )
+    }
+
+    // Solver and policy checks are added in the next step.
+    throw new Error(
+        `quality policy not implemented for ${canonicalKey} with ${crystalCount} crystals`
+    )
+}
+```
+
+- [ ] **Step 5: Run only the structural tests**
+
+Run:
+
+```bash
+bun run test:run -- \
+  src/lib/games/ice-slide/quality.test.ts \
+  -t "invalid|missing|multiple|duplicate"
+```
+
+Expected: PASS for structural and duplicate cases.
+
+- [ ] **Step 6: Add solver-policy failing tests**
+
+Append to `quality.test.ts`:
+
+```ts
+it('rejects a fully explored unsolvable board', () => {
+    const result = validateIceSlideStageQuality(
+        candidate(['#####', '#S#G#', '#####']),
+        ACCEPTING_CONSTRAINTS
+    )
+
+    expect(result).toMatchObject({
+        accepted: false,
+        reason: 'unsolvable',
+        solveResult: {
+            solvable: false,
+            truncated: false,
+        },
+    })
+})
+
+it('rejects state-cap truncation before solvability', () => {
+    const result = validateIceSlideStageQuality(candidate(), {
+        ...ACCEPTING_CONSTRAINTS,
+        maxStates: 1,
+    })
+
+    expect(result).toMatchObject({
+        accepted: false,
+        reason: 'solver_truncated',
+        solveResult: {
+            solvable: false,
+            truncated: true,
+        },
+    })
+})
+
+it.each([
+    [{ minMoves: 2, maxMoves: 3 }, 1],
+    [{ minMoves: 1, maxMoves: 1 }, 3],
+] as const)(
+    'rejects computed par outside %o',
+    (parBand, expectedPar) => {
+        const rows =
+            expectedPar === 1
+                ? BASIC_ROWS
+                : ['######', '#S#..#', '#....#', '##.#.#', '#...G#', '######']
+        const result = validateIceSlideStageQuality(candidate(rows), {
+            ...ACCEPTING_CONSTRAINTS,
+            parBand,
+        })
+
+        expect(result).toMatchObject({
+            accepted: false,
+            reason: 'par_out_of_band',
+            solveResult: {
+                minMoves: expectedPar,
+            },
+        })
+    }
+)
+
+it('rejects an unreachable required crystal', () => {
+    const result = validateIceSlideStageQuality(
+        candidate(
+            [
+                '#######',
+                '#S...G#',
+                '#######',
+                '###C###',
+                '#######',
+            ],
+            ['collect_all_crystals']
+        ),
+        ACCEPTING_CONSTRAINTS
+    )
+
+    expect(result).toMatchObject({
+        accepted: false,
+        reason: 'required_crystal_unreachable',
+    })
+})
+
+it.each([
+    ['collect_all_crystals', 'objective collect_all_crystals'],
+    ['no_falls', 'objective no_falls'],
+] as const)(
+    'rejects ineligible %s',
+    (objectiveId, message) => {
+        const result = validateIceSlideStageQuality(
+            candidate(BASIC_ROWS, [objectiveId]),
+            ACCEPTING_CONSTRAINTS
+        )
+
+        expect(result).toMatchObject({
+            accepted: false,
+            reason: 'objective_infeasible',
+        })
+        if (!result.accepted) {
+            expect(result.message).toContain(message)
+        }
+    }
+)
+
+it('returns computed par and canonical rows for an accepted candidate', () => {
+    const rows = [
+        '#######',
+        '#.O.O.#',
+        '#..C..#',
+        '#G.S..#',
+        '#..O..#',
+        '#.....#',
+        '#######',
+    ] as const
+    const result = validateIceSlideStageQuality(
+        candidate(rows, ['collect_all_crystals', 'no_reset']),
+        ACCEPTING_CONSTRAINTS
+    )
+
+    expect(result).toEqual({
+        accepted: true,
+        parMoves: 1,
+        canonicalKey: serializeBoardRows(rows),
+        solveResult: expect.objectContaining({
+            solvable: true,
+            minMoves: 1,
+            truncated: false,
+            reachableCrystalIds: ['2,3'],
+        }),
+    })
+})
+
+it('throws for invalid validator constraints', () => {
+    expect(() =>
+        validateIceSlideStageQuality(candidate(), {
+            parBand: { minMoves: 2, maxMoves: 1 },
+            maxStates: 100,
+        })
+    ).toThrow(/minMoves/)
+})
+```
+
+- [ ] **Step 7: Run the policy tests and confirm the temporary throw fails**
+
+Run:
+
+```bash
+bun run test:run -- src/lib/games/ice-slide/quality.test.ts
+```
+
+Expected: FAIL at the temporary `quality policy not implemented` error.
+
+- [ ] **Step 8: Implement the ordered solver policy**
+
+Replace the temporary throw in `validateIceSlideStageQuality()` with:
+
+```ts
+const solveResult = solveIceSlideBoard(candidate, {
+    maxStates: constraints.maxStates,
+})
+
+if (solveResult.truncated) {
+    return rejection(
+        'solver_truncated',
+        `solver reached the ${constraints.maxStates}-state cap`,
+        { canonicalKey, solveResult }
+    )
+}
+
+if (!solveResult.solvable || solveResult.minMoves === null) {
+    return rejection(
+        'unsolvable',
+        'goal is unreachable under current Ice Slide physics',
+        { canonicalKey, solveResult }
+    )
+}
+
+if (
+    solveResult.minMoves < constraints.parBand.minMoves ||
+    solveResult.minMoves > constraints.parBand.maxMoves
+) {
+    return rejection(
+        'par_out_of_band',
+        `computed par ${solveResult.minMoves} is outside inclusive band ` +
+            `${constraints.parBand.minMoves}..${constraints.parBand.maxMoves}`,
+        { canonicalKey, solveResult }
+    )
+}
+
+if (
+    candidate.objectiveIds.includes('collect_all_crystals') &&
+    solveResult.reachableCrystalIds.length < crystalCount
+) {
+    return rejection(
+        'required_crystal_unreachable',
+        `only ${solveResult.reachableCrystalIds.length} of ` +
+            `${crystalCount} required crystals are reachable`,
+        { canonicalKey, solveResult }
+    )
+}
+
+for (const objectiveId of candidate.objectiveIds) {
+    if (!solveResult.objectiveFeasibility[objectiveId]) {
+        return rejection(
+            'objective_infeasible',
+            `objective ${objectiveId} is not feasible for this board`,
+            { canonicalKey, solveResult }
+        )
+    }
+}
+
+return {
+    accepted: true,
+    parMoves: solveResult.minMoves,
+    canonicalKey,
+    solveResult,
+}
+```
+
+- [ ] **Step 9: Run the complete quality and solver suites**
+
+Run:
+
+```bash
+bun run test:run -- \
+  src/lib/games/ice-slide/solver.test.ts \
+  src/lib/games/ice-slide/quality.test.ts
+```
+
+Expected: PASS.
+
+- [ ] **Step 10: Run format and lint**
+
+Run:
+
+```bash
+bunx prettier --write \
+  src/lib/games/ice-slide/quality.ts \
+  src/lib/games/ice-slide/quality.test.ts
+bunx eslint \
+  src/lib/games/ice-slide/quality.ts \
+  src/lib/games/ice-slide/quality.test.ts
+```
+
+Expected: both commands exit successfully.
+
+- [ ] **Step 11: Commit Task 3**
+
+```bash
+git add \
+  src/lib/games/ice-slide/quality.ts \
+  src/lib/games/ice-slide/quality.test.ts
+git commit -m "feat(ice-slide): validate generated stage quality"
+```
+
+---
+
+### Task 4: Replace test-only BFS and verify the repository
+
+**Files:**
+- Modify: `src/lib/games/ice-slide/physics.test.ts`
+- Test: all Ice Slide tests and full repository verification.
+
+**Interfaces:**
+- Consumes: `solveIceSlideBoard()` from Task 1 and complete crystal reporting from Task 2.
+- Produces: Campaign regression coverage with no duplicated local BFS.
+
+- [ ] **Step 1: Replace the minimum-move helper**
+
+In `physics.test.ts`:
+
+1. Add:
+
+```ts
+import { solveIceSlideBoard } from './solver'
+```
+
+2. Delete the local `minMoves()` function inside `describe('ice-slide levels', ...)`.
+3. Replace the Campaign solvability test body with:
+
+```ts
+it('ships exactly 8 solvable levels with matching parMoves', () => {
+    expect(ICE_SLIDE_LEVELS).toHaveLength(8)
+
+    for (const level of ICE_SLIDE_LEVELS) {
+        const result = solveIceSlideBoard(level, {
+            maxStates: 10_000,
+        })
+
+        expect(result.truncated, `level ${level.id} truncated`).toBe(false)
+        expect(result.solvable, `level ${level.id} solvable`).toBe(true)
+        expect(result.minMoves, `level ${level.id} par`).toBe(
+            level.parMoves
+        )
+    }
+})
+```
+
+- [ ] **Step 2: Replace the crystal-reachability BFS**
+
+Delete the second queue/`Set` traversal from
+`it('makes every authored crystal collectable on a reachable slide', ...)`.
+
+Use:
+
+```ts
+it('makes every authored crystal collectable on a reachable slide', () => {
+    for (const level of ICE_SLIDE_LEVELS) {
+        const expectedCrystalIds: string[] = []
+
+        for (let row = 0; row < level.rows.length; row++) {
+            for (let col = 0; col < level.rows[row].length; col++) {
+                if (level.rows[row][col] === 'C') {
+                    expectedCrystalIds.push(`${row},${col}`)
+                }
+            }
+        }
+
+        const result = solveIceSlideBoard(level, {
+            maxStates: 10_000,
+        })
+
+        expect(result.truncated, `level ${level.id} truncated`).toBe(false)
+        expect(
+            result.reachableCrystalIds,
+            `level ${level.id} reachable crystals`
+        ).toEqual(expectedCrystalIds)
+    }
+})
+```
+
+Remove imports that were used only by the deleted BFS. Keep `cloneGrid` because the
+earlier deep-clone test still uses it.
+
+- [ ] **Step 3: Run targeted Ice Slide tests**
+
+Run:
+
+```bash
+bun run test:run -- \
+  src/lib/games/ice-slide/solver.test.ts \
+  src/lib/games/ice-slide/quality.test.ts \
+  src/lib/games/ice-slide/physics.test.ts
+```
+
+Expected: PASS.
+
+- [ ] **Step 4: Run all Ice Slide tests**
+
+Run:
+
+```bash
+bun run test:run -- src/lib/games/ice-slide
+```
+
+Expected: PASS.
+
+- [ ] **Step 5: Run repository tests**
+
+Run:
+
+```bash
+bun run test:run
+```
+
+Expected: PASS with no new failures.
+
+- [ ] **Step 6: Run lint and format checks**
+
+Run:
+
+```bash
+bun run lint
+bun run format:check
+```
+
+Expected: both commands exit successfully.
+
+- [ ] **Step 7: Run typecheck and compare against `main`**
+
+Run on the implementation branch:
+
+```bash
+bun run typecheck 2>&1 | tee /tmp/hpa-486-typecheck.txt
+```
+
+Run the same command on a clean `main` worktree or the implementation base commit:
+
+```bash
+bun run typecheck 2>&1 | tee /tmp/hpa-486-main-typecheck.txt
+diff -u /tmp/hpa-486-main-typecheck.txt /tmp/hpa-486-typecheck.txt
+```
+
+Expected: no new diagnostic introduced by HPA-486. PR #53 reported two pre-existing
+diagnostics in `init.ts` and `init.test.ts`; use the current base output as the source of
+truth rather than assuming that baseline is unchanged.
+
+- [ ] **Step 8: Verify the changed-file boundary**
+
+Run:
+
+```bash
+git diff --name-only origin/main...HEAD
+```
+
+Expected implementation paths:
+
+```text
+src/lib/games/ice-slide/physics.test.ts
+src/lib/games/ice-slide/quality.test.ts
+src/lib/games/ice-slide/quality.ts
+src/lib/games/ice-slide/solver.test.ts
+src/lib/games/ice-slide/solver.ts
+```
+
+Documentation from the planning PR is not part of the implementation branch unless the
+implementation intentionally branches from the merged planning commit.
+
+- [ ] **Step 9: Commit Task 4**
+
+```bash
+git add src/lib/games/ice-slide/physics.test.ts
+git commit -m "test(ice-slide): use production solver for campaign content"
+```
+
+- [ ] **Step 10: Prepare the implementation PR summary**
+
+Use this PR scope:
+
+```markdown
+## Summary
+
+Implements HPA-486 by extracting the Ice Slide Campaign BFS into a bounded pure
+production solver and adding deterministic stage-quality validation for later Daily and
+Expedition generation.
+
+## Changes
+
+- add player-position + consumed-crystal BFS state;
+- report exact par, stops, crystals, objective feasibility, explored states, and
+  truncation;
+- add ordered structural, duplicate, par-band, objective, and cap rejection results;
+- replace duplicated Campaign BFS assertions with production-solver tests.
+
+## YAGNI boundaries
+
+- no generator loop or fallback selection;
+- no runtime solver integration;
+- no generic graph-search framework;
+- no snow, cracked ice, Undo, or solution paths.
+
+## Verification
+
+- targeted Ice Slide suites;
+- full test suite;
+- lint and format checks;
+- typecheck compared with the current `main` baseline.
+```
+
+Create the implementation PR as a draft and link HPA-486. Do not enable auto-merge.
+
+---
+
+## Plan Self-Review
+
+### Spec coverage
+
+- Bounded BFS and exact minimum: Task 1.
+- Consumed-crystal state and objective feasibility: Task 2.
+- Structural, duplicate, par, objective, and truncation rejection: Task 3.
+- Campaign compatibility and removal of duplicate BFS: Task 4.
+- Determinism, immutability, explicit caps, and no runtime integration: Tasks 1–4 and
+  Global Constraints.
+- Cracked-ice extension point: private `encodeStateKey()` in Task 1, with no unused
+  dynamic state added.
+
+### Placeholder scan
+
+The plan contains no unresolved placeholder or unspecified error-handling step. The
+deliberate temporary throw in Task 3 is a TDD checkpoint and is explicitly removed
+within the same task.
+
+### Type consistency
+
+- `maxStates`, `parBand.minMoves`, and `parBand.maxMoves` are consistent across the
+  design, tests, and implementation.
+- `reachableCrystalIds` uses zero-based `"row,col"` strings everywhere.
+- `validateIceSlideStageQuality()` returns the same discriminated union consumed by all
+  tests.
+- Truncation semantics are identical in solver and quality policy.

--- a/docs/superpowers/specs/2026-08-03-ice-slide-production-solver-design.md
+++ b/docs/superpowers/specs/2026-08-03-ice-slide-production-solver-design.md
@@ -5,80 +5,69 @@
 - **Repository:** `cwchanap/cetus`
 - **Linear issue:** [HPA-486 — Extract the Ice Slide production solver and generation quality validator](https://linear.app/cwchanap/issue/HPA-486/extract-the-ice-slide-production-solver-and-generation-quality)
 - **Depends on:** HPA-485, completed in PR #53
-- **Source roadmap:** `docs/superpowers/specs/2026-07-30-ice-slide-replayability-design.md`
 
 ## 1. Summary
 
 Ice Slide currently proves Campaign solvability with two breadth-first searches embedded
 inside `physics.test.ts`: one computes minimum moves and another checks authored crystal
-reachability. Daily and Expedition generation need the same capability as reusable pure
-production code with explicit exploration limits and deterministic rejection semantics.
+reachability. HPA-486 extracts that traversal into pure bounded production code and adds
+the stage-quality validator explicitly required by the ticket.
 
-HPA-486 adds two focused modules:
+The implementation remains limited to two modules:
 
 1. `solver.ts` performs bounded BFS over player position and consumed-crystal state.
-2. `quality.ts` applies candidate acceptance policy around the solver.
+2. `quality.ts` converts solver facts plus board policy into deterministic candidate
+   acceptance or rejection.
 
-The design intentionally avoids a generic graph framework, generation loop, runtime
-solver hook, solution paths, and future tile-state abstractions.
+No generation loop, retry policy, runtime solver hook, path output, or future tile-state
+framework is included.
 
-## 2. Current Boundaries
+## 2. Why `quality.ts` Remains in Scope
 
-The merged HPA-485 work already provides the boundaries this task should reuse:
+`quality.ts` has no current runtime caller, but it is not an anticipatory extra: HPA-486
+explicitly requires a pure stage-quality validator covering exact start/goal structure,
+goal reachability, par bands, objective feasibility, required-crystal reachability, and
+canonical duplicate detection. HPA-486 also blocks the Daily and Expedition work that
+will consume it.
 
-- `IceSlideStageDefinition` contains final materialized rows and objective IDs.
-- `parseGrid()`, `cloneGrid()`, and `slide()` own current parsing and movement physics.
-- `serializeBoardRows()` provides the exact dimension-aware final-board key.
-- `assertValidIceSlideRunDefinition()` validates serialized contracts but does not solve
-  boards.
-- `IceSlideGame` consumes materialized runs and must remain independent from generation.
-
-The current test BFS is unsuitable for production because it is duplicated, uses an
-arbitrary move-depth guard, and cannot distinguish a complete unsolvable search from an
-incomplete capped search.
+Removing the validator would change the approved ticket rather than simplify its
+implementation. The API is therefore kept narrow and policy-focused, with six rejection
+codes and no generator-specific retry or aggregation behavior.
 
 ## 3. Goals
 
-1. Provide a deterministic pure solver for current Ice Slide physics.
-2. Return solvability, minimum moves, reachable stop count, reachable crystal IDs,
-   objective feasibility, explored-state count, and truncation status as required by
-   HPA-486.
-3. Model player position and consumed-crystal state in the visited key.
-4. Require an explicit caller-supplied state cap.
-5. Reject every truncated result in quality validation.
-6. Preserve all eight Campaign pars and authored crystal guarantees.
-7. Provide bounded rejection types that later generators can consume.
+1. Provide deterministic bounded BFS for current Ice Slide physics.
+2. Return the ticket-required search facts: solvability, minimum moves, reachable stop
+   count, reachable crystal IDs, explored-state count, and truncation.
+3. Distinguish states by player position and consumed-crystal mask.
+4. Preserve all eight Campaign pars and authored crystal guarantees.
+5. Provide a pure quality gate for later generated candidates.
+6. Keep gameplay, run contracts, renderer, score, database, and UI unchanged.
 
 ## 4. Non-goals
 
-This task does not include:
+- Daily or Expedition generation loops, retries, fallbacks, or diagnostics aggregation.
+- Mutation templates or difficulty calibration.
+- Runtime solver calls from `game.ts`, `run.ts`, `init.ts`, or the renderer.
+- Objective progress tracking during gameplay.
+- Solution paths, hints, A*, or a reusable graph-search package.
+- Snow, cracked ice, collapsed-tile state, Undo, or abilities.
+- Solver caching, workers, compact encodings, or cross-board memoization.
 
-- Daily or Expedition generation loops, retries, fallbacks, or seed diagnostics;
-- mutation templates or difficulty calibration;
-- runtime solver calls from `game.ts`, `run.ts`, `init.ts`, or the renderer;
-- objective progress tracking during gameplay;
-- solution paths, hints, A*, or a reusable graph-search package;
-- snow, cracked ice, collapsed-tile state, Undo, or abilities;
-- persistent crystal IDs or changes to run/stage contracts;
-- solver caching, workers, or cross-board memoization.
+## 5. File Scope
 
-## 5. File Boundaries
-
-### Create
+Create:
 
 - `src/lib/games/ice-slide/solver.ts`
 - `src/lib/games/ice-slide/solver.test.ts`
 - `src/lib/games/ice-slide/quality.ts`
 - `src/lib/games/ice-slide/quality.test.ts`
 
-### Modify
+Modify:
 
 - `src/lib/games/ice-slide/physics.test.ts`
 
-### Do not modify
-
-- `types.ts`, `run.ts`, `game.ts`, `physics.ts`, `levels.ts`, `transforms.ts`,
-  `renderer.ts`, `init.ts`, or score/database/UI code.
+No production gameplay or platform file changes are part of HPA-486.
 
 ## 6. Solver Contract
 
@@ -92,7 +81,7 @@ export interface IceSlideSolveResult {
     minMoves: number | null
     reachableStopCount: number
     reachableCrystalIds: string[]
-    objectiveFeasibility: Record<IceSlideObjectiveId, boolean>
+    reachedGoalWithAllCrystals: boolean
     exploredStates: number
     truncated: boolean
 }
@@ -103,23 +92,24 @@ export function solveIceSlideBoard(
 ): IceSlideSolveResult
 ```
 
+The solver returns search facts only. It does not import or return
+`IceSlideObjectiveId`, so adding future gameplay objectives does not change the search
+API.
+
 `reachableCrystalIds` uses deterministic zero-based `"row,col"` coordinate IDs.
 
 ### 6.1 Preconditions
 
-Direct solver calls require:
+Direct calls require:
 
 - a non-empty rectangular board with at least one column and known glyphs;
 - exactly one start and one goal;
-- at most `MAX_SOLVER_CRYSTALS = 30` crystals;
+- no more than 30 crystals;
 - `maxStates` as a positive safe integer.
 
-Invalid direct calls throw. The quality validator converts candidate-content failures
-into rejection results.
-
-The 30-crystal ceiling keeps the state mask as a simple JavaScript `number` using safe
-positive bit operations. Current Campaign content has at most two crystals; widening the
-representation is deferred until real content requires it.
+Invalid input throws. The 30-crystal limit is an internal implementation invariant for a
+positive JavaScript `number` bitmask; it is not exported as product API. Current Campaign
+content has at most two crystals.
 
 ### 6.2 Search State
 
@@ -127,74 +117,78 @@ representation is deferred until real content requires it.
 interface SolverState {
     position: GridPosition
     moves: number
-    collectedCrystalMask: number
+    crystalMask: number
     grid: CellType[][]
 }
 ```
 
-Crystals receive row-major indexes during the initial scan. The visited key contains:
+Crystals receive row-major indexes. The visited key is:
 
 ```text
-player row + player column + collected-crystal mask
+player row + player column + consumed-crystal mask
 ```
 
-Move count is excluded because BFS reaches each state at minimum depth first. Current
-mutable grid state is fully determined by consumed crystals.
+The grid remains in each queued state because `slide()` mutates collected crystal cells.
+Reconstructing a grid from the base board and mask would add conversion logic without a
+current performance need. The mask is still the canonical mutable-state component of the
+visited key.
 
-A private `encodeStateKey()` function is sufficient for later cracked-ice work to extend
-when collapsed-tile physics exists; HPA-486 adds no placeholder dynamic state.
+A private `encodeStateKey()` is sufficient for later dynamic-tile work to extend when
+that physics exists.
 
 ### 6.3 Traversal
 
 The solver:
 
-1. parses rows and scans start, goal, hazards, and row-major crystals once;
+1. parses and scans the board once;
 2. converts the start cell in its working grid to ice;
 3. explores directions in stable `N`, `E`, `S`, `W` order;
-4. uses `slide()` as the only transition implementation;
-5. ignores `noop` and `hazard` outcomes;
-6. clones the current grid before each attempted transition;
-7. updates the crystal mask from crystals crossed in `outcome.path`;
-8. admits unseen states only while under `maxStates`;
+4. uses `slide()` as the only movement transition;
+5. skips `noop` and `hazard` outcomes;
+6. clones the current state's grid before each attempted slide;
+7. updates the mask from crystals crossed in `outcome.path`;
+8. admits unseen `(position, mask)` states while below `maxStates`;
 9. records goal states but does not expand them;
-10. continues after the first goal to complete stop, crystal, and objective analysis
-    unless the state cap is reached.
+10. continues after the first goal so crystal and stop analysis is complete unless the
+    cap truncates the search.
 
 Use an array plus queue cursor rather than repeated `shift()`.
 
-### 6.4 Result Semantics
+### 6.4 Complete Result Semantics
 
-- `reachableStopCount` counts unique stop coordinates, including start and goal.
-- `reachableCrystalIds` is row-major and includes crystals crossed on at least one
-  accepted non-hazard slide.
-- `exploredStates` is the number of unique states admitted to the visited set.
-- The first goal depth is an exact `minMoves`, because BFS explores in nondecreasing
-  depth.
+For a fully explored search:
 
-Objective feasibility remains in the solver result because HPA-486 explicitly requires
-a consolidated result for the three Daily contracts. Its implementation stays lean:
+- `solvable` is true exactly when a goal was reached;
+- `minMoves` is the first goal depth or `null`;
+- `reachableStopCount` counts unique stop coordinates, including start and goal;
+- `reachableCrystalIds` is row-major and includes crystals crossed on accepted
+  non-hazard slides;
+- `reachedGoalWithAllCrystals` is true when any goal state consumed every authored
+  crystal; it is false for a board with no crystals;
+- `exploredStates` is the number of unique `(position, mask)` states admitted;
+- `truncated` is false.
 
-- `collect_all_crystals`: search-derived; true when a goal state is reached with every
-  crystal consumed and the board has at least one crystal;
-- `no_falls`: derived from board eligibility plus a normal goal path; true when the board
-  has a hazard and the solver reaches the goal without taking a hazard transition;
-- `no_reset`: derived from normal goal reachability.
-
-The latter two are simple derived predicates, not additional search dimensions.
+`reachedGoalWithAllCrystals` is the only objective-related search fact. All assignment
+and eligibility policy stays in `quality.ts`.
 
 ### 6.5 Truncation
 
-When admission of another unseen state would exceed `maxStates`:
+When admitting another unseen state would exceed `maxStates`, return:
 
-- `truncated` is `true`;
-- `solvable` is `false`, so the result cannot be accepted as fully validated;
-- `minMoves` retains an already-proven shortest goal depth, otherwise remains `null`;
-- already-observed diagnostics and witnessed objective feasibility may be retained;
-- `exploredStates` equals the admitted-state count and never exceeds the cap.
+```ts
+{
+    solvable: false,
+    minMoves: null,
+    truncated: true,
+    // already observed stop/crystal diagnostics retained
+}
+```
 
-Quality validation always rejects `truncated: true` before considering par or
-objectives. Preserving `minMoves` keeps proven information without weakening acceptance
-semantics.
+A truncated result makes no solvability or par claim, even if a goal was encountered
+before the cap. This avoids contradictory partial results and keeps the only supported
+consumer behavior simple: quality validation rejects every truncated result first.
+
+`exploredStates` never exceeds `maxStates`.
 
 ## 7. Quality Contract
 
@@ -221,11 +215,17 @@ export type IceSlideStageRejectionReason =
     | 'par_out_of_band'
     | 'objective_infeasible'
 
+export type IceSlideObjectiveFeasibility = Record<
+    IceSlideObjectiveId,
+    boolean
+>
+
 export type IceSlideStageQualityResult =
     | {
           accepted: true
           parMoves: number
           canonicalKey: string
+          objectiveFeasibility: IceSlideObjectiveFeasibility
           solveResult: IceSlideSolveResult
       }
     | {
@@ -242,10 +242,9 @@ export function validateIceSlideStageQuality(
 ): IceSlideStageQualityResult
 ```
 
-The six reason codes are sufficient for the first generator diagnostics. Messages carry
-specific details such as missing/multiple start or goal counts and unreachable required
-crystals. New reason codes should be added only when a production consumer needs to
-branch or aggregate them separately.
+`existingCanonicalKeys` remains because canonical duplicate detection is an explicit
+HPA-486 requirement. The validator only checks membership; run-local set ownership and
+retry behavior stay with the future generator.
 
 ### 7.1 Configuration Errors
 
@@ -256,100 +255,101 @@ Invalid validator configuration throws `RangeError`:
 
 Candidate-content failures return `accepted: false`.
 
-### 7.2 Deterministic Validation Order
+### 7.2 Validation Order
 
-1. Validate rows, glyphs, crystal ceiling, and exact start/goal counts; reject as
-   `invalid_board` with a specific message.
-2. Compute `canonicalKey = serializeBoardRows(candidate.rows)`.
-3. Reject a key in `existingCanonicalKeys` as `duplicate_board` before BFS.
-4. Run the solver with the supplied cap.
-5. Reject truncation as `solver_truncated`.
-6. Reject a fully explored unreachable goal as `unsolvable`.
+1. Validate constraints.
+2. Call `serializeBoardRows(candidate.rows)` inside a try/catch; invalid shape returns
+   `invalid_board`.
+3. Reject an exact canonical key present in `existingCanonicalKeys` as
+   `duplicate_board` before BFS.
+4. Call `solveIceSlideBoard()` inside a try/catch; parser, glyph, crystal-ceiling, and
+   exact start/goal errors map to `invalid_board`.
+5. Reject `truncated` as `solver_truncated`.
+6. Reject `solvable === false` as `unsolvable`.
 7. Reject `minMoves` outside the inclusive band as `par_out_of_band`.
-8. Reject the first assigned objective whose feasibility is false as
-   `objective_infeasible`; for `collect_all_crystals`, the message distinguishes an
-   unreachable required crystal from the absence of an all-crystals goal path.
-9. Return the computed par, canonical key, and solver result.
+8. Derive objective feasibility and reject the first assigned false objective as
+   `objective_infeasible`.
+9. Return the computed par, canonical key, feasibility record, and solver result.
 
-The order is contractual so identical input yields identical rejection output.
+This removes duplicate start/goal parsing and message maintenance from `quality.ts`.
+Shape-valid duplicate boards are rejected before exact start/goal validation, which is an
+intentional cheap-first ordering for generated candidates.
 
-### 7.3 Direct Solver Versus Quality Validation
+### 7.3 Objective Policy
 
-The quality validator checks start/goal counts before calling the solver so it can return
-a bounded rejection. The solver repeats those cheap checks because it is also a public
-direct API used by Campaign tests. A shared exported validation helper would increase
-surface area without eliminating meaningful work, so the small scan remains duplicated.
+The quality layer derives the three initial contracts from solver facts and final-board
+content:
 
-## 8. Data Flow
-
-```text
-materialized candidate
-        |
-        v
-validateIceSlideStageQuality(candidate, constraints)
-        |
-        +-- rejected -> later generator retries or falls back
-        |
-        `-- accepted -> later generator stores returned par and canonical key
+```ts
+{
+    collect_all_crystals:
+        crystalCount > 0 && solveResult.reachedGoalWithAllCrystals,
+    no_falls: hasHazard && solveResult.solvable,
+    no_reset: solveResult.solvable,
+}
 ```
 
-Campaign tests call `solveIceSlideBoard()` directly. The game engine receives only
-materialized stages and never invokes either module during play.
+These booleans represent **objective assignment feasibility**, not additional search
+modes:
 
-## 9. Testing
+- a crystal-free board is not eligible for `collect_all_crystals`;
+- a hazard-free board is not eligible for `no_falls`;
+- `no_reset` is feasible when the board has a normal solution.
 
-### Solver tests
+The solver never takes hazard transitions; `no_falls` is therefore plain content-policy
+plus normal reachability, not a separate BFS property.
+
+## 8. Testing
+
+### Solver
 
 Cover:
 
 - one-move and multi-move exact minimums;
-- same stop reached with different crystal masks;
-- row-major crystal reachability and all-crystals-at-goal feasibility;
-- stop and explored-state counts;
-- `collect_all_crystals`, `no_falls`, and `no_reset` semantics;
+- the same stop reached with different crystal masks;
+- row-major reachable and unreachable crystals;
+- `reachedGoalWithAllCrystals`;
 - deterministic repeated results and caller-row immutability;
-- invalid boards, crystal ceiling, invalid cap;
-- truncation before and after a goal, including preserved `minMoves`.
+- invalid rows, exact start/goal counts, crystal ceiling, and invalid cap;
+- truncation with `solvable: false` and `minMoves: null`;
+- explored states exceeding unique stops when masks distinguish states, rather than
+  asserting fragile exact traversal counts.
 
-### Quality tests
+### Quality
 
 Cover:
 
-- empty, zero-column, jagged, and unknown-glyph boards;
-- missing/multiple start or goal through `invalid_board` messages;
-- duplicate final rows;
-- impossible goal;
-- below/above par bands;
-- state-cap truncation;
-- impossible assigned objectives, including unreachable required crystals;
-- accepted result with computed par and canonical key;
+- invalid shape and solver-input failures mapped to `invalid_board`;
+- duplicate exact rows;
+- truncation, impossible goal, and par-band violations;
+- objective assignment feasibility for crystals, hazards, and reset;
+- accepted result with computed par, canonical key, feasibility, and solver result;
 - invalid constraint configuration.
 
-### Campaign regressions
+### Campaign Regression
 
 For every `ICE_SLIDE_LEVELS` entry:
 
-- search is not truncated under a fixed test cap;
+- search is not truncated under a fixed cap;
 - the board is solvable;
 - `minMoves === level.parMoves`;
-- all authored crystal coordinate IDs appear in `reachableCrystalIds`.
+- all authored crystal IDs appear in `reachableCrystalIds`.
 
-The two local BFS implementations in `physics.test.ts` are then removed.
+Then remove the two local BFS traversals from `physics.test.ts`.
 
-## 10. Performance and Determinism
+## 9. Performance and Determinism
 
-Current boards are at most 9×9 with at most two crystals, so cloned small grids are
-sufficient. HPA-486 does not add compact encodings, object pools, heuristics, or caches.
+Current boards are at most 9×9 with at most two crystals, so cloned small grids and a
+numeric mask are sufficient. No optimization work is included.
 
 Determinism depends on row-major crystal indexing, stable direction order, exact state
 keys, exact board serialization, and ordered quality checks. Returned crystal arrays are
 filtered from the original row-major list rather than relying on `Set` iteration order.
 
-`reachableStopCount` and `exploredStates` remain public because HPA-486 explicitly
-requires them and HPA-489 can use them for bounded generation diagnostics and template
-constraints. No additional diagnostics API is introduced.
+`reachableStopCount` and `exploredStates` remain because HPA-486 explicitly requires
+them. Tests avoid hard-coding exact counts except where enforcing the cap itself.
 
-## 11. Acceptance Criteria
+## 10. Acceptance Criteria
 
 HPA-486 is complete when:
 
@@ -357,17 +357,27 @@ HPA-486 is complete when:
 2. every authored Campaign crystal remains reachable;
 3. solver output is deterministic and does not mutate caller rows;
 4. state distinguishes identical positions with different crystal masks;
-5. capped searches report truncation, are not accepted as solvable, and preserve a
-   proven `minMoves` when available;
+5. capped searches return `truncated: true`, `solvable: false`, and `minMoves: null`;
 6. quality validation rejects invalid structure, duplicates, impossible goals,
-   par-band violations, impossible objectives, and truncation;
-7. all three initial objective contracts are supported;
-8. gameplay, UI, generation loops, and future tile mechanics are unchanged;
-9. tests run only under explicit deterministic limits.
+   par-band violations, impossible assigned objectives, and truncation;
+7. all three initial objective contracts are evaluated in the quality layer;
+8. gameplay, UI, generation loops, and future tile mechanics are unchanged.
 
-## 12. YAGNI Check
+## 11. YAGNI Decisions
 
-The design keeps only the ticket-required result fields and the two justified modules.
-It excludes generic search abstractions, path output, generator orchestration, dynamic
-state plugins, new persisted IDs, runtime validation, optimization work, and a content
-validation CLI.
+Kept because the ticket explicitly requires them:
+
+- `quality.ts`;
+- canonical duplicate detection;
+- reachable-stop and explored-state diagnostics;
+- objective feasibility for the initial Daily contracts.
+
+Removed or deferred:
+
+- objective-enum coupling in the solver;
+- partial par preservation after truncation;
+- exported crystal-limit constants;
+- duplicated start/goal validation in `quality.ts`;
+- exact explored-state assertions;
+- generator orchestration, path output, generic search abstractions, and dynamic-state
+  frameworks.

--- a/docs/superpowers/specs/2026-08-03-ice-slide-production-solver-design.md
+++ b/docs/superpowers/specs/2026-08-03-ice-slide-production-solver-design.md
@@ -10,118 +10,79 @@
 ## 1. Summary
 
 Ice Slide currently proves Campaign solvability with two breadth-first searches embedded
-inside `physics.test.ts`: one computes each level's minimum move count and another checks
-that every authored crystal is collectable. Daily and Expedition generation need the
-same reasoning as reusable production code, with explicit exploration limits and
-deterministic rejection semantics.
+inside `physics.test.ts`: one computes minimum moves and another checks authored crystal
+reachability. Daily and Expedition generation need the same capability as reusable pure
+production code with explicit exploration limits and deterministic rejection semantics.
 
-This design extracts that behavior into two focused pure modules:
+HPA-486 adds two focused modules:
 
-1. `solver.ts` performs bounded breadth-first search over player position and consumed
-   crystal state.
-2. `quality.ts` validates a materialized candidate board against structural, duplicate,
-   par-band, crystal, and objective requirements.
+1. `solver.ts` performs bounded BFS over player position and consumed-crystal state.
+2. `quality.ts` applies candidate acceptance policy around the solver.
 
-The design deliberately does not create a generic graph-search framework, generator
-loop, dynamic-tile plugin system, or runtime validation hook. It implements only the
-capability required by HPA-486 and leaves later mechanics to their owning tickets.
+The design intentionally avoids a generic graph framework, generation loop, runtime
+solver hook, solution paths, and future tile-state abstractions.
 
-## 2. Current State
+## 2. Current Boundaries
 
-The merged HPA-485 work provides the boundaries HPA-486 should reuse:
+The merged HPA-485 work already provides the boundaries this task should reuse:
 
-- `IceSlideStageDefinition` contains final materialized rows, objective IDs, par,
-  transform, mutation IDs, and a stable stage signature.
-- `parseGrid()`, `cloneGrid()`, and `slide()` implement pure grid parsing and current
-  movement physics.
-- `serializeBoardRows()` provides an exact dimension-aware canonical key for final rows.
-- `assertValidIceSlideRunDefinition()` validates run and stage structure but intentionally
-  does not solve boards.
-- `IceSlideGame.start(run?)` consumes an already-materialized run and should not perform
-  generation or expensive content validation.
+- `IceSlideStageDefinition` contains final materialized rows and objective IDs.
+- `parseGrid()`, `cloneGrid()`, and `slide()` own current parsing and movement physics.
+- `serializeBoardRows()` provides the exact dimension-aware final-board key.
+- `assertValidIceSlideRunDefinition()` validates serialized contracts but does not solve
+  boards.
+- `IceSlideGame` consumes materialized runs and must remain independent from generation.
 
-The existing test BFS has four limitations:
-
-1. It is unavailable to production generators.
-2. It uses an arbitrary move-depth guard instead of a state-space cap.
-3. Minimum-move and crystal-reachability searches duplicate traversal logic.
-4. Truncation is not represented explicitly, so future callers could confuse an
-   incomplete search with an unsolvable board.
+The current test BFS is unsuitable for production because it is duplicated, uses an
+arbitrary move-depth guard, and cannot distinguish a complete unsolvable search from an
+incomplete capped search.
 
 ## 3. Goals
 
 1. Provide a deterministic pure solver for current Ice Slide physics.
-2. Return exact minimum clear moves, reachable stop positions, reachable crystals,
-   objective feasibility, explored-state count, and truncation status.
-3. Model consumed crystals in the visited-state key.
-4. Bound all exploration with an explicit caller-supplied state cap.
-5. Reject truncated searches rather than treating partial results as valid.
-6. Provide a pure candidate-quality validator that future Daily and Expedition
-   generators can call.
-7. Preserve all eight Campaign levels, their exact `parMoves`, and current crystal
-   reachability guarantees.
-8. Leave one clear internal point where collapsed-tile state can later join the search
-   key, without implementing cracked ice now.
+2. Return solvability, minimum moves, reachable stop count, reachable crystal IDs,
+   objective feasibility, explored-state count, and truncation status as required by
+   HPA-486.
+3. Model player position and consumed-crystal state in the visited key.
+4. Require an explicit caller-supplied state cap.
+5. Reject every truncated result in quality validation.
+6. Preserve all eight Campaign pars and authored crystal guarantees.
+7. Provide bounded rejection types that later generators can consume.
 
 ## 4. Non-goals
 
-HPA-486 does not include:
+This task does not include:
 
-- Daily or Expedition generation loops.
-- Candidate retry counts, fallback selection, or diagnostics across seeds.
-- Mutation templates or difficulty calibration.
-- Runtime solver calls from `IceSlideGame`, `init.ts`, or the renderer.
-- Objective progress tracking during gameplay.
-- Snow, cracked ice, collapsed-tile state, Undo, or abilities.
-- Solution-path reconstruction or hint generation.
-- A reusable graph-search or A* package.
-- Persistent crystal IDs or changes to `IceSlideStageDefinition`.
-- Solver caching, worker threads, or cross-board memoization.
+- Daily or Expedition generation loops, retries, fallbacks, or seed diagnostics;
+- mutation templates or difficulty calibration;
+- runtime solver calls from `game.ts`, `run.ts`, `init.ts`, or the renderer;
+- objective progress tracking during gameplay;
+- solution paths, hints, A*, or a reusable graph-search package;
+- snow, cracked ice, collapsed-tile state, Undo, or abilities;
+- persistent crystal IDs or changes to run/stage contracts;
+- solver caching, workers, or cross-board memoization.
 
-## 5. Fixed Design Decisions
+## 5. File Boundaries
 
-### 5.1 Two focused modules
+### Create
 
-`solver.ts` owns state-space traversal and solver result semantics.
+- `src/lib/games/ice-slide/solver.ts`
+- `src/lib/games/ice-slide/solver.test.ts`
+- `src/lib/games/ice-slide/quality.ts`
+- `src/lib/games/ice-slide/quality.test.ts`
 
-`quality.ts` owns candidate acceptance policy and deterministic rejection reasons.
+### Modify
 
-The modules remain separate because a caller may need raw solver diagnostics without
-applying a generator tier's par band or duplicate set.
+- `src/lib/games/ice-slide/physics.test.ts`
 
-### 5.2 Existing physics is the transition function
+### Do not modify
 
-The solver calls `slide()` for each cardinal direction. It does not duplicate movement
-rules. Every transition operates on a clone of the current state's grid so crystal
-consumption remains isolated.
-
-### 5.3 The state cap is explicit
-
-`solveIceSlideBoard()` requires `maxStates`; there is no hidden unbounded mode and no
-speculative global production default in this ticket. Campaign tests use a fixed local
-cap. HPA-489 may select a generator-specific cap after representative templates exist.
-
-### 5.4 Exact board serialization is the duplicate key
-
-The quality validator uses `serializeBoardRows(finalRows)`. It compares complete final
-materialized boards, not template IDs, hashes alone, or symmetry classes. Symmetry
-deduplication remains the responsibility of HPA-485 transformation utilities before a
-candidate reaches quality validation.
-
-### 5.5 Structural run validation remains cheap
-
-`assertValidIceSlideRunDefinition()` continues to validate serialized contracts only.
-It does not call the solver. Checked-in content tests and generation code explicitly call
-the quality validator.
+- `types.ts`, `run.ts`, `game.ts`, `physics.ts`, `levels.ts`, `transforms.ts`,
+  `renderer.ts`, `init.ts`, or score/database/UI code.
 
 ## 6. Solver Contract
 
-Create `src/lib/games/ice-slide/solver.ts`.
-
 ```ts
-import type { IceSlideGridSource } from './physics'
-import type { GridPosition, IceSlideObjectiveId } from './types'
-
 export interface IceSlideSolverLimits {
     maxStates: number
 }
@@ -142,166 +103,122 @@ export function solveIceSlideBoard(
 ): IceSlideSolveResult
 ```
 
-`reachableCrystalIds` uses deterministic zero-based row/column IDs:
+`reachableCrystalIds` uses deterministic zero-based `"row,col"` coordinate IDs.
 
-```text
-<row>,<column>
-```
+### 6.1 Preconditions
 
-Examples are `3,2` and `5,6`. This reuses the coordinate identity already present in the
-authored-level tests and avoids adding a new persisted content identifier.
-
-### 6.1 Input preconditions
-
-The solver requires:
+Direct solver calls require:
 
 - a non-empty rectangular board with at least one column and known glyphs;
-- exactly one start tile;
-- exactly one goal tile;
+- exactly one start and one goal;
+- at most `MAX_SOLVER_CRYSTALS = 30` crystals;
 - `maxStates` as a positive safe integer.
 
-Invalid solver inputs are programmer/content errors and throw `RangeError` or the
-existing parser error. Generated candidates use `validateIceSlideStageQuality()`, which
-converts candidate failures into bounded rejection results.
+Invalid direct calls throw. The quality validator converts candidate-content failures
+into rejection results.
 
-### 6.2 Search state
+The 30-crystal ceiling keeps the state mask as a simple JavaScript `number` using safe
+positive bit operations. Current Campaign content has at most two crystals; widening the
+representation is deferred until real content requires it.
 
-The internal state is:
+### 6.2 Search State
 
 ```ts
 interface SolverState {
     position: GridPosition
     moves: number
-    collectedCrystalMask: bigint
+    collectedCrystalMask: number
     grid: CellType[][]
 }
 ```
 
-Crystals receive row-major indexes during the initial board scan. `bigint` avoids an
-undocumented 31-crystal ceiling while remaining internal to the solver.
-
-The visited key contains:
+Crystals receive row-major indexes during the initial scan. The visited key contains:
 
 ```text
 player row + player column + collected-crystal mask
 ```
 
-Move count is not part of the key because breadth-first search reaches a state at its
-minimum depth first. The grid is not separately encoded because current mutable board
-state is fully determined by consumed crystals.
+Move count is excluded because BFS reaches each state at minimum depth first. Current
+mutable grid state is fully determined by consumed crystals.
 
-A private `encodeStateKey()` function is the intentional cracked-ice extension point.
-HPA-493 can add collapsed-tile state to `SolverState` and that key when the physics
-exists. HPA-486 does not add placeholder masks or generic state plugins.
+A private `encodeStateKey()` function is sufficient for later cracked-ice work to extend
+when collapsed-tile physics exists; HPA-486 adds no placeholder dynamic state.
 
-### 6.3 Breadth-first traversal
+### 6.3 Traversal
 
 The solver:
 
-1. Parses the source and records start, goal, and row-major crystal positions.
-2. Converts the start cell in the working grid to ice, matching runtime setup.
-3. Adds the start state to the queue and visited set.
-4. Uses an array plus queue cursor instead of repeated `shift()`.
-5. Tries directions in stable `N`, `E`, `S`, `W` order.
-6. Ignores `noop` and `hazard` outcomes.
-7. Derives the next crystal mask from crystal coordinates crossed in `outcome.path`.
-8. Adds each unseen `(position, crystalMask)` state subject to `maxStates`.
-9. Records goal states but does not expand them.
-10. Continues after finding the first goal so crystal and objective feasibility remain
-    complete.
+1. parses rows and scans start, goal, hazards, and row-major crystals once;
+2. converts the start cell in its working grid to ice;
+3. explores directions in stable `N`, `E`, `S`, `W` order;
+4. uses `slide()` as the only transition implementation;
+5. ignores `noop` and `hazard` outcomes;
+6. clones the current grid before each attempted transition;
+7. updates the crystal mask from crystals crossed in `outcome.path`;
+8. admits unseen states only while under `maxStates`;
+9. records goal states but does not expand them;
+10. continues after the first goal to complete stop, crystal, and objective analysis
+    unless the state cap is reached.
 
-The first reached goal depth is `minMoves`.
+Use an array plus queue cursor rather than repeated `shift()`.
 
-### 6.4 Reachability semantics
+### 6.4 Result Semantics
 
-`reachableStopCount` counts unique stop coordinates, including:
+- `reachableStopCount` counts unique stop coordinates, including start and goal.
+- `reachableCrystalIds` is row-major and includes crystals crossed on at least one
+  accepted non-hazard slide.
+- `exploredStates` is the number of unique states admitted to the visited set.
+- The first goal depth is an exact `minMoves`, because BFS explores in nondecreasing
+  depth.
 
-- the start;
-- ordinary reachable endpoints;
-- the goal.
+Objective feasibility remains in the solver result because HPA-486 explicitly requires
+a consolidated result for the three Daily contracts. Its implementation stays lean:
 
-Different crystal masks at the same coordinate count as one reachable stop but remain
-distinct search states.
+- `collect_all_crystals`: search-derived; true when a goal state is reached with every
+  crystal consumed and the board has at least one crystal;
+- `no_falls`: derived from board eligibility plus a normal goal path; true when the board
+  has a hazard and the solver reaches the goal without taking a hazard transition;
+- `no_reset`: derived from normal goal reachability.
 
-`reachableCrystalIds` is the row-major ordered subset of authored crystal coordinates
-that occurs on at least one accepted non-hazard slide from a reachable state. Crystals
-crossed on a slide that ends in a hazard do not count because hazard resolution resets
-the attempt.
+The latter two are simple derived predicates, not additional search dimensions.
 
-### 6.5 Objective feasibility
+### 6.5 Truncation
 
-The result always contains all three initial objective IDs:
+When admission of another unseen state would exceed `maxStates`:
 
-- `collect_all_crystals` is feasible only when the board contains at least one crystal
-  and some goal state has consumed every crystal.
-- `no_falls` is feasible only when the board contains at least one hazard and a goal is
-  reachable without taking a hazard transition.
-- `no_reset` is feasible whenever a goal is reachable through normal slides.
+- `truncated` is `true`;
+- `solvable` is `false`, so the result cannot be accepted as fully validated;
+- `minMoves` retains an already-proven shortest goal depth, otherwise remains `null`;
+- already-observed diagnostics and witnessed objective feasibility may be retained;
+- `exploredStates` equals the admitted-state count and never exceeds the cap.
 
-The first two rules include the objective eligibility requirements from the replayability
-roadmap. A no-hazard board cannot be assigned `no_falls`; a no-crystal board cannot be
-assigned `collect_all_crystals`.
+Quality validation always rejects `truncated: true` before considering par or
+objectives. Preserving `minMoves` keeps proven information without weakening acceptance
+semantics.
 
-### 6.6 State-cap semantics
-
-`exploredStates` is the number of unique search states admitted to the visited set,
-including start and terminal goal states.
-
-Before admitting a new unseen state, the solver checks the cap. When admission would
-exceed `maxStates`, it returns:
+## 7. Quality Contract
 
 ```ts
-{
-    solvable: false,
-    minMoves: null,
-    truncated: true,
-    exploredStates: maxStates,
-    // partial stop and crystal diagnostics may remain populated
-    objectiveFeasibility: {
-        collect_all_crystals: false,
-        no_falls: false,
-        no_reset: false,
-    },
-}
-```
-
-Truncation dominates any goal found earlier. This prevents callers from accepting a
-candidate when exploration was insufficient to establish all required guarantees.
-
-## 7. Stage Quality Contract
-
-Create `src/lib/games/ice-slide/quality.ts`.
-
-```ts
-import type { IceSlideGridSource } from './physics'
-import type { IceSlideObjectiveId } from './types'
-import type { IceSlideSolveResult } from './solver'
-
 export interface IceSlideStageQualityCandidate
     extends IceSlideGridSource {
     objectiveIds: readonly IceSlideObjectiveId[]
 }
 
-export interface IceSlideParBand {
-    minMoves: number
-    maxMoves: number
-}
-
 export interface IceSlideStageQualityConstraints {
-    parBand: IceSlideParBand
+    parBand: {
+        minMoves: number
+        maxMoves: number
+    }
     maxStates: number
     existingCanonicalKeys?: ReadonlySet<string>
 }
 
 export type IceSlideStageRejectionReason =
     | 'invalid_board'
-    | 'invalid_start_count'
-    | 'invalid_goal_count'
     | 'duplicate_board'
     | 'solver_truncated'
     | 'unsolvable'
     | 'par_out_of_band'
-    | 'required_crystal_unreachable'
     | 'objective_infeasible'
 
 export type IceSlideStageQualityResult =
@@ -325,233 +242,132 @@ export function validateIceSlideStageQuality(
 ): IceSlideStageQualityResult
 ```
 
-### 7.1 Configuration errors versus candidate rejection
+The six reason codes are sufficient for the first generator diagnostics. Messages carry
+specific details such as missing/multiple start or goal counts and unreachable required
+crystals. New reason codes should be added only when a production consumer needs to
+branch or aggregate them separately.
+
+### 7.1 Configuration Errors
 
 Invalid validator configuration throws `RangeError`:
 
-- `maxStates` is not a positive safe integer;
-- `minMoves` or `maxMoves` is not a positive safe integer;
+- `maxStates`, `minMoves`, or `maxMoves` is not a positive safe integer;
 - `minMoves > maxMoves`.
 
-Candidate failures return `accepted: false`. This distinction prevents generator bugs
-from being silently treated as ordinary rejected content.
+Candidate-content failures return `accepted: false`.
 
-### 7.2 Deterministic validation order
+### 7.2 Deterministic Validation Order
 
-The validator evaluates rules in this order:
+1. Validate rows, glyphs, crystal ceiling, and exact start/goal counts; reject as
+   `invalid_board` with a specific message.
+2. Compute `canonicalKey = serializeBoardRows(candidate.rows)`.
+3. Reject a key in `existingCanonicalKeys` as `duplicate_board` before BFS.
+4. Run the solver with the supplied cap.
+5. Reject truncation as `solver_truncated`.
+6. Reject a fully explored unreachable goal as `unsolvable`.
+7. Reject `minMoves` outside the inclusive band as `par_out_of_band`.
+8. Reject the first assigned objective whose feasibility is false as
+   `objective_infeasible`; for `collect_all_crystals`, the message distinguishes an
+   unreachable required crystal from the absence of an all-crystals goal path.
+9. Return the computed par, canonical key, and solver result.
 
-1. Parse rows; map empty, jagged, zero-column, or unknown-glyph failures to
-   `invalid_board`.
-2. Count starts; require exactly one or return `invalid_start_count`.
-3. Count goals; require exactly one or return `invalid_goal_count`.
-4. Compute `canonicalKey = serializeBoardRows(candidate.rows)`.
-5. Reject a key present in `existingCanonicalKeys` as `duplicate_board`.
-6. Run `solveIceSlideBoard()` with the supplied cap.
-7. Reject `truncated` as `solver_truncated`.
-8. Reject `solvable === false` as `unsolvable`.
-9. Reject `minMoves` outside the inclusive par band as `par_out_of_band`.
-10. When `collect_all_crystals` is assigned, reject if any authored crystal is absent
-    from `reachableCrystalIds` as `required_crystal_unreachable`.
-11. Reject the first assigned objective whose feasibility is false as
-    `objective_infeasible`.
-12. Return the computed par, canonical key, and complete solver result.
+The order is contractual so identical input yields identical rejection output.
 
-The order is part of the contract so the same candidate and constraints always produce
-the same rejection reason.
+### 7.3 Direct Solver Versus Quality Validation
 
-### 7.3 Rejection messages
-
-Messages are concise developer diagnostics and include stable facts such as observed
-counts or the computed par. Callers must branch on `reason`, not parse message text.
-
-Examples:
-
-```text
-expected exactly one start tile, found 0
-computed par 6 is outside inclusive band 2..5
-objective no_falls is not feasible for this board
-```
-
-Player-facing copy and cross-attempt generation diagnostics remain out of scope.
+The quality validator checks start/goal counts before calling the solver so it can return
+a bounded rejection. The solver repeats those cheap checks because it is also a public
+direct API used by Campaign tests. A shared exported validation helper would increase
+surface area without eliminating meaningful work, so the small scan remains duplicated.
 
 ## 8. Data Flow
 
-Future generator use is intentionally simple:
-
 ```text
-materialized candidate rows
+materialized candidate
         |
         v
 validateIceSlideStageQuality(candidate, constraints)
         |
-        +-- rejected result -> generator records reason and tries another candidate
+        +-- rejected -> later generator retries or falls back
         |
-        `-- accepted result -> generator stores returned parMoves and canonicalKey
+        `-- accepted -> later generator stores returned par and canonical key
 ```
 
-The game engine receives only accepted materialized stage definitions. It never invokes
-the solver during play.
+Campaign tests call `solveIceSlideBoard()` directly. The game engine receives only
+materialized stages and never invokes either module during play.
 
-Campaign content tests call `solveIceSlideBoard()` directly because they verify known
-checked-in boards rather than applying generator quality bands.
+## 9. Testing
 
-## 9. File Boundaries
-
-### Create
-
-- `src/lib/games/ice-slide/solver.ts`
-  - bounded BFS;
-  - solver-specific contracts;
-  - crystal/objective diagnostics.
-
-- `src/lib/games/ice-slide/solver.test.ts`
-  - BFS, state-key, objective, determinism, immutability, and cap behavior.
-
-- `src/lib/games/ice-slide/quality.ts`
-  - candidate policy and bounded rejection union.
-
-- `src/lib/games/ice-slide/quality.test.ts`
-  - structural and quality rejection fixtures.
-
-### Modify
-
-- `src/lib/games/ice-slide/physics.test.ts`
-  - remove embedded BFS helpers;
-  - assert Campaign pars and crystal reachability through the production solver.
-
-### Do not modify
-
-- `types.ts`
-- `run.ts`
-- `game.ts`
-- `physics.ts`
-- `levels.ts`
-- `transforms.ts`
-- `renderer.ts`
-- `init.ts`
-- score, database, or leaderboard code.
-
-A small test-only import reordering caused by formatter output is acceptable.
-
-## 10. Error Handling
-
-- Direct solver misuse throws before exploration.
-- Candidate parsing failures become `invalid_board`.
-- Missing or multiple start/goal tiles receive dedicated rejection reasons.
-- Truncation always rejects and is distinguishable from a fully explored unsolvable
-  board.
-- Duplicate detection occurs before BFS to avoid wasted solver work.
-- No module logs, touches browser APIs, reads time, reads randomness, or mutates caller
-  row strings.
-- No partial result is converted into a stage definition by these modules.
-
-## 11. Testing Strategy
-
-### 11.1 Solver unit tests
+### Solver tests
 
 Cover:
 
-- one-move solvable board and exact minimum moves;
-- a multi-move Campaign board;
-- unique reachable stop counting;
-- same stop revisited with a different crystal mask;
-- row-major reachable crystal IDs;
-- unreachable crystal exclusion;
-- `collect_all_crystals`, `no_falls`, and `no_reset` feasibility;
-- deterministic repeated results;
-- caller rows unchanged;
-- `maxStates: 1` truncation;
-- invalid cap rejection.
+- one-move and multi-move exact minimums;
+- same stop reached with different crystal masks;
+- row-major crystal reachability and all-crystals-at-goal feasibility;
+- stop and explored-state counts;
+- `collect_all_crystals`, `no_falls`, and `no_reset` semantics;
+- deterministic repeated results and caller-row immutability;
+- invalid boards, crystal ceiling, invalid cap;
+- truncation before and after a goal, including preserved `minMoves`.
 
-The crystal-mask fixture must require returning to the start after collecting a crystal
-before taking the goal direction. A position-only visited key would fail this test.
-
-### 11.2 Quality unit tests
+### Quality tests
 
 Cover:
 
-- empty, jagged, zero-column, and unknown-glyph boards;
-- missing and multiple start;
-- missing and multiple goal;
-- duplicate canonical rows;
+- empty, zero-column, jagged, and unknown-glyph boards;
+- missing/multiple start or goal through `invalid_board` messages;
+- duplicate final rows;
 - impossible goal;
-- par below and above the allowed band;
+- below/above par bands;
 - state-cap truncation;
-- assigned `collect_all_crystals` with an unreachable crystal;
-- assigned `collect_all_crystals` on a no-crystal board;
-- assigned `no_falls` on a no-hazard board;
-- successful validation returning computed par and canonical key;
-- invalid validator constraints throwing `RangeError`.
+- impossible assigned objectives, including unreachable required crystals;
+- accepted result with computed par and canonical key;
+- invalid constraint configuration.
 
-### 11.3 Campaign regression tests
+### Campaign regressions
 
-For every entry in `ICE_SLIDE_LEVELS`:
+For every `ICE_SLIDE_LEVELS` entry:
 
-- the solver is not truncated under a fixed test cap;
+- search is not truncated under a fixed test cap;
 - the board is solvable;
 - `minMoves === level.parMoves`;
-- every authored crystal coordinate appears in `reachableCrystalIds`.
+- all authored crystal coordinate IDs appear in `reachableCrystalIds`.
 
-The duplicated local BFS implementations are removed after these assertions pass.
+The two local BFS implementations in `physics.test.ts` are then removed.
 
-## 12. Performance and Determinism
+## 10. Performance and Determinism
 
-Current Campaign boards are at most 9×9 with at most two crystals, so a queue of cloned
-small grids is sufficient. HPA-486 does not add compact board encodings, object pools,
-heuristics, or path compression.
+Current boards are at most 9×9 with at most two crystals, so cloned small grids are
+sufficient. HPA-486 does not add compact encodings, object pools, heuristics, or caches.
 
-Determinism depends on:
+Determinism depends on row-major crystal indexing, stable direction order, exact state
+keys, exact board serialization, and ordered quality checks. Returned crystal arrays are
+filtered from the original row-major list rather than relying on `Set` iteration order.
 
-- stable row-major crystal indexing;
-- stable `N`, `E`, `S`, `W` transition order;
-- exact state-key encoding;
-- exact canonical row serialization;
-- ordered rejection checks.
+`reachableStopCount` and `exploredStates` remain public because HPA-486 explicitly
+requires them and HPA-489 can use them for bounded generation diagnostics and template
+constraints. No additional diagnostics API is introduced.
 
-The result does not depend on `Set` iteration order for arrays returned to callers;
-reachable crystal IDs are filtered from the original row-major crystal list.
-
-## 13. Acceptance Criteria
+## 11. Acceptance Criteria
 
 HPA-486 is complete when:
 
-1. All eight Campaign levels solve with their current exact `parMoves`.
-2. Every existing Campaign crystal is reported reachable.
-3. Solver output is deterministic and does not mutate caller rows.
-4. Search state distinguishes identical positions with different consumed-crystal
-   masks.
-5. State-cap exhaustion returns `truncated: true`, `solvable: false`, and `minMoves:
-   null`.
-6. Quality validation rejects missing/multiple start or goal, invalid rows, duplicate
-   boards, impossible goals, par-band violations, required unreachable crystals,
-   infeasible assigned objectives, and truncation.
-7. Initial objective contracts are supported for `collect_all_crystals`, `no_falls`,
-   and `no_reset`.
-8. Production gameplay, UI, generation loops, and future tile mechanics are unchanged.
-9. Unit tests and the full repository suite complete under deterministic explicit
-   limits.
+1. all eight Campaign levels retain exact pars;
+2. every authored Campaign crystal remains reachable;
+3. solver output is deterministic and does not mutate caller rows;
+4. state distinguishes identical positions with different crystal masks;
+5. capped searches report truncation, are not accepted as solvable, and preserve a
+   proven `minMoves` when available;
+6. quality validation rejects invalid structure, duplicates, impossible goals,
+   par-band violations, impossible objectives, and truncation;
+7. all three initial objective contracts are supported;
+8. gameplay, UI, generation loops, and future tile mechanics are unchanged;
+9. tests run only under explicit deterministic limits.
 
-## 14. YAGNI Review
+## 12. YAGNI Check
 
-The design removes the following tempting but unnecessary work:
-
-- no generic search abstraction;
-- no path output;
-- no generator retry/fallback code;
-- no dynamic-tile interface;
-- no new persisted IDs;
-- no solver invocation from run validation;
-- no optimization beyond a queue cursor and bounded visited set;
-- no content-validation CLI.
-
-Each excluded feature has a later owner or lacks a current consumer.
-
-## 15. Spec Self-Review
-
-- **Placeholder scan:** no unresolved placeholder or incomplete decision remains.
-- **Consistency:** solver preconditions, validator rejection order, objective
-  eligibility, and truncation semantics agree throughout.
-- **Scope:** the work is limited to four new focused files and one test migration.
-- **Ambiguity resolution:** stop count includes start and goal; crystal IDs are
-  zero-based coordinates; truncation overrides partial solvability; exact final-row
-  serialization defines duplicates.
+The design keeps only the ticket-required result fields and the two justified modules.
+It excludes generic search abstractions, path output, generator orchestration, dynamic
+state plugins, new persisted IDs, runtime validation, optimization work, and a content
+validation CLI.

--- a/docs/superpowers/specs/2026-08-03-ice-slide-production-solver-design.md
+++ b/docs/superpowers/specs/2026-08-03-ice-slide-production-solver-design.md
@@ -1,0 +1,557 @@
+# Ice Slide Production Solver and Stage Quality Validation — Design
+
+- **Date:** 2026-08-03
+- **Status:** Draft for review
+- **Repository:** `cwchanap/cetus`
+- **Linear issue:** [HPA-486 — Extract the Ice Slide production solver and generation quality validator](https://linear.app/cwchanap/issue/HPA-486/extract-the-ice-slide-production-solver-and-generation-quality)
+- **Depends on:** HPA-485, completed in PR #53
+- **Source roadmap:** `docs/superpowers/specs/2026-07-30-ice-slide-replayability-design.md`
+
+## 1. Summary
+
+Ice Slide currently proves Campaign solvability with two breadth-first searches embedded
+inside `physics.test.ts`: one computes each level's minimum move count and another checks
+that every authored crystal is collectable. Daily and Expedition generation need the
+same reasoning as reusable production code, with explicit exploration limits and
+deterministic rejection semantics.
+
+This design extracts that behavior into two focused pure modules:
+
+1. `solver.ts` performs bounded breadth-first search over player position and consumed
+   crystal state.
+2. `quality.ts` validates a materialized candidate board against structural, duplicate,
+   par-band, crystal, and objective requirements.
+
+The design deliberately does not create a generic graph-search framework, generator
+loop, dynamic-tile plugin system, or runtime validation hook. It implements only the
+capability required by HPA-486 and leaves later mechanics to their owning tickets.
+
+## 2. Current State
+
+The merged HPA-485 work provides the boundaries HPA-486 should reuse:
+
+- `IceSlideStageDefinition` contains final materialized rows, objective IDs, par,
+  transform, mutation IDs, and a stable stage signature.
+- `parseGrid()`, `cloneGrid()`, and `slide()` implement pure grid parsing and current
+  movement physics.
+- `serializeBoardRows()` provides an exact dimension-aware canonical key for final rows.
+- `assertValidIceSlideRunDefinition()` validates run and stage structure but intentionally
+  does not solve boards.
+- `IceSlideGame.start(run?)` consumes an already-materialized run and should not perform
+  generation or expensive content validation.
+
+The existing test BFS has four limitations:
+
+1. It is unavailable to production generators.
+2. It uses an arbitrary move-depth guard instead of a state-space cap.
+3. Minimum-move and crystal-reachability searches duplicate traversal logic.
+4. Truncation is not represented explicitly, so future callers could confuse an
+   incomplete search with an unsolvable board.
+
+## 3. Goals
+
+1. Provide a deterministic pure solver for current Ice Slide physics.
+2. Return exact minimum clear moves, reachable stop positions, reachable crystals,
+   objective feasibility, explored-state count, and truncation status.
+3. Model consumed crystals in the visited-state key.
+4. Bound all exploration with an explicit caller-supplied state cap.
+5. Reject truncated searches rather than treating partial results as valid.
+6. Provide a pure candidate-quality validator that future Daily and Expedition
+   generators can call.
+7. Preserve all eight Campaign levels, their exact `parMoves`, and current crystal
+   reachability guarantees.
+8. Leave one clear internal point where collapsed-tile state can later join the search
+   key, without implementing cracked ice now.
+
+## 4. Non-goals
+
+HPA-486 does not include:
+
+- Daily or Expedition generation loops.
+- Candidate retry counts, fallback selection, or diagnostics across seeds.
+- Mutation templates or difficulty calibration.
+- Runtime solver calls from `IceSlideGame`, `init.ts`, or the renderer.
+- Objective progress tracking during gameplay.
+- Snow, cracked ice, collapsed-tile state, Undo, or abilities.
+- Solution-path reconstruction or hint generation.
+- A reusable graph-search or A* package.
+- Persistent crystal IDs or changes to `IceSlideStageDefinition`.
+- Solver caching, worker threads, or cross-board memoization.
+
+## 5. Fixed Design Decisions
+
+### 5.1 Two focused modules
+
+`solver.ts` owns state-space traversal and solver result semantics.
+
+`quality.ts` owns candidate acceptance policy and deterministic rejection reasons.
+
+The modules remain separate because a caller may need raw solver diagnostics without
+applying a generator tier's par band or duplicate set.
+
+### 5.2 Existing physics is the transition function
+
+The solver calls `slide()` for each cardinal direction. It does not duplicate movement
+rules. Every transition operates on a clone of the current state's grid so crystal
+consumption remains isolated.
+
+### 5.3 The state cap is explicit
+
+`solveIceSlideBoard()` requires `maxStates`; there is no hidden unbounded mode and no
+speculative global production default in this ticket. Campaign tests use a fixed local
+cap. HPA-489 may select a generator-specific cap after representative templates exist.
+
+### 5.4 Exact board serialization is the duplicate key
+
+The quality validator uses `serializeBoardRows(finalRows)`. It compares complete final
+materialized boards, not template IDs, hashes alone, or symmetry classes. Symmetry
+deduplication remains the responsibility of HPA-485 transformation utilities before a
+candidate reaches quality validation.
+
+### 5.5 Structural run validation remains cheap
+
+`assertValidIceSlideRunDefinition()` continues to validate serialized contracts only.
+It does not call the solver. Checked-in content tests and generation code explicitly call
+the quality validator.
+
+## 6. Solver Contract
+
+Create `src/lib/games/ice-slide/solver.ts`.
+
+```ts
+import type { IceSlideGridSource } from './physics'
+import type { GridPosition, IceSlideObjectiveId } from './types'
+
+export interface IceSlideSolverLimits {
+    maxStates: number
+}
+
+export interface IceSlideSolveResult {
+    solvable: boolean
+    minMoves: number | null
+    reachableStopCount: number
+    reachableCrystalIds: string[]
+    objectiveFeasibility: Record<IceSlideObjectiveId, boolean>
+    exploredStates: number
+    truncated: boolean
+}
+
+export function solveIceSlideBoard(
+    source: IceSlideGridSource,
+    limits: IceSlideSolverLimits
+): IceSlideSolveResult
+```
+
+`reachableCrystalIds` uses deterministic zero-based row/column IDs:
+
+```text
+<row>,<column>
+```
+
+Examples are `3,2` and `5,6`. This reuses the coordinate identity already present in the
+authored-level tests and avoids adding a new persisted content identifier.
+
+### 6.1 Input preconditions
+
+The solver requires:
+
+- a non-empty rectangular board with at least one column and known glyphs;
+- exactly one start tile;
+- exactly one goal tile;
+- `maxStates` as a positive safe integer.
+
+Invalid solver inputs are programmer/content errors and throw `RangeError` or the
+existing parser error. Generated candidates use `validateIceSlideStageQuality()`, which
+converts candidate failures into bounded rejection results.
+
+### 6.2 Search state
+
+The internal state is:
+
+```ts
+interface SolverState {
+    position: GridPosition
+    moves: number
+    collectedCrystalMask: bigint
+    grid: CellType[][]
+}
+```
+
+Crystals receive row-major indexes during the initial board scan. `bigint` avoids an
+undocumented 31-crystal ceiling while remaining internal to the solver.
+
+The visited key contains:
+
+```text
+player row + player column + collected-crystal mask
+```
+
+Move count is not part of the key because breadth-first search reaches a state at its
+minimum depth first. The grid is not separately encoded because current mutable board
+state is fully determined by consumed crystals.
+
+A private `encodeStateKey()` function is the intentional cracked-ice extension point.
+HPA-493 can add collapsed-tile state to `SolverState` and that key when the physics
+exists. HPA-486 does not add placeholder masks or generic state plugins.
+
+### 6.3 Breadth-first traversal
+
+The solver:
+
+1. Parses the source and records start, goal, and row-major crystal positions.
+2. Converts the start cell in the working grid to ice, matching runtime setup.
+3. Adds the start state to the queue and visited set.
+4. Uses an array plus queue cursor instead of repeated `shift()`.
+5. Tries directions in stable `N`, `E`, `S`, `W` order.
+6. Ignores `noop` and `hazard` outcomes.
+7. Derives the next crystal mask from crystal coordinates crossed in `outcome.path`.
+8. Adds each unseen `(position, crystalMask)` state subject to `maxStates`.
+9. Records goal states but does not expand them.
+10. Continues after finding the first goal so crystal and objective feasibility remain
+    complete.
+
+The first reached goal depth is `minMoves`.
+
+### 6.4 Reachability semantics
+
+`reachableStopCount` counts unique stop coordinates, including:
+
+- the start;
+- ordinary reachable endpoints;
+- the goal.
+
+Different crystal masks at the same coordinate count as one reachable stop but remain
+distinct search states.
+
+`reachableCrystalIds` is the row-major ordered subset of authored crystal coordinates
+that occurs on at least one accepted non-hazard slide from a reachable state. Crystals
+crossed on a slide that ends in a hazard do not count because hazard resolution resets
+the attempt.
+
+### 6.5 Objective feasibility
+
+The result always contains all three initial objective IDs:
+
+- `collect_all_crystals` is feasible only when the board contains at least one crystal
+  and some goal state has consumed every crystal.
+- `no_falls` is feasible only when the board contains at least one hazard and a goal is
+  reachable without taking a hazard transition.
+- `no_reset` is feasible whenever a goal is reachable through normal slides.
+
+The first two rules include the objective eligibility requirements from the replayability
+roadmap. A no-hazard board cannot be assigned `no_falls`; a no-crystal board cannot be
+assigned `collect_all_crystals`.
+
+### 6.6 State-cap semantics
+
+`exploredStates` is the number of unique search states admitted to the visited set,
+including start and terminal goal states.
+
+Before admitting a new unseen state, the solver checks the cap. When admission would
+exceed `maxStates`, it returns:
+
+```ts
+{
+    solvable: false,
+    minMoves: null,
+    truncated: true,
+    exploredStates: maxStates,
+    // partial stop and crystal diagnostics may remain populated
+    objectiveFeasibility: {
+        collect_all_crystals: false,
+        no_falls: false,
+        no_reset: false,
+    },
+}
+```
+
+Truncation dominates any goal found earlier. This prevents callers from accepting a
+candidate when exploration was insufficient to establish all required guarantees.
+
+## 7. Stage Quality Contract
+
+Create `src/lib/games/ice-slide/quality.ts`.
+
+```ts
+import type { IceSlideGridSource } from './physics'
+import type { IceSlideObjectiveId } from './types'
+import type { IceSlideSolveResult } from './solver'
+
+export interface IceSlideStageQualityCandidate
+    extends IceSlideGridSource {
+    objectiveIds: readonly IceSlideObjectiveId[]
+}
+
+export interface IceSlideParBand {
+    minMoves: number
+    maxMoves: number
+}
+
+export interface IceSlideStageQualityConstraints {
+    parBand: IceSlideParBand
+    maxStates: number
+    existingCanonicalKeys?: ReadonlySet<string>
+}
+
+export type IceSlideStageRejectionReason =
+    | 'invalid_board'
+    | 'invalid_start_count'
+    | 'invalid_goal_count'
+    | 'duplicate_board'
+    | 'solver_truncated'
+    | 'unsolvable'
+    | 'par_out_of_band'
+    | 'required_crystal_unreachable'
+    | 'objective_infeasible'
+
+export type IceSlideStageQualityResult =
+    | {
+          accepted: true
+          parMoves: number
+          canonicalKey: string
+          solveResult: IceSlideSolveResult
+      }
+    | {
+          accepted: false
+          reason: IceSlideStageRejectionReason
+          message: string
+          canonicalKey?: string
+          solveResult?: IceSlideSolveResult
+      }
+
+export function validateIceSlideStageQuality(
+    candidate: IceSlideStageQualityCandidate,
+    constraints: IceSlideStageQualityConstraints
+): IceSlideStageQualityResult
+```
+
+### 7.1 Configuration errors versus candidate rejection
+
+Invalid validator configuration throws `RangeError`:
+
+- `maxStates` is not a positive safe integer;
+- `minMoves` or `maxMoves` is not a positive safe integer;
+- `minMoves > maxMoves`.
+
+Candidate failures return `accepted: false`. This distinction prevents generator bugs
+from being silently treated as ordinary rejected content.
+
+### 7.2 Deterministic validation order
+
+The validator evaluates rules in this order:
+
+1. Parse rows; map empty, jagged, zero-column, or unknown-glyph failures to
+   `invalid_board`.
+2. Count starts; require exactly one or return `invalid_start_count`.
+3. Count goals; require exactly one or return `invalid_goal_count`.
+4. Compute `canonicalKey = serializeBoardRows(candidate.rows)`.
+5. Reject a key present in `existingCanonicalKeys` as `duplicate_board`.
+6. Run `solveIceSlideBoard()` with the supplied cap.
+7. Reject `truncated` as `solver_truncated`.
+8. Reject `solvable === false` as `unsolvable`.
+9. Reject `minMoves` outside the inclusive par band as `par_out_of_band`.
+10. When `collect_all_crystals` is assigned, reject if any authored crystal is absent
+    from `reachableCrystalIds` as `required_crystal_unreachable`.
+11. Reject the first assigned objective whose feasibility is false as
+    `objective_infeasible`.
+12. Return the computed par, canonical key, and complete solver result.
+
+The order is part of the contract so the same candidate and constraints always produce
+the same rejection reason.
+
+### 7.3 Rejection messages
+
+Messages are concise developer diagnostics and include stable facts such as observed
+counts or the computed par. Callers must branch on `reason`, not parse message text.
+
+Examples:
+
+```text
+expected exactly one start tile, found 0
+computed par 6 is outside inclusive band 2..5
+objective no_falls is not feasible for this board
+```
+
+Player-facing copy and cross-attempt generation diagnostics remain out of scope.
+
+## 8. Data Flow
+
+Future generator use is intentionally simple:
+
+```text
+materialized candidate rows
+        |
+        v
+validateIceSlideStageQuality(candidate, constraints)
+        |
+        +-- rejected result -> generator records reason and tries another candidate
+        |
+        `-- accepted result -> generator stores returned parMoves and canonicalKey
+```
+
+The game engine receives only accepted materialized stage definitions. It never invokes
+the solver during play.
+
+Campaign content tests call `solveIceSlideBoard()` directly because they verify known
+checked-in boards rather than applying generator quality bands.
+
+## 9. File Boundaries
+
+### Create
+
+- `src/lib/games/ice-slide/solver.ts`
+  - bounded BFS;
+  - solver-specific contracts;
+  - crystal/objective diagnostics.
+
+- `src/lib/games/ice-slide/solver.test.ts`
+  - BFS, state-key, objective, determinism, immutability, and cap behavior.
+
+- `src/lib/games/ice-slide/quality.ts`
+  - candidate policy and bounded rejection union.
+
+- `src/lib/games/ice-slide/quality.test.ts`
+  - structural and quality rejection fixtures.
+
+### Modify
+
+- `src/lib/games/ice-slide/physics.test.ts`
+  - remove embedded BFS helpers;
+  - assert Campaign pars and crystal reachability through the production solver.
+
+### Do not modify
+
+- `types.ts`
+- `run.ts`
+- `game.ts`
+- `physics.ts`
+- `levels.ts`
+- `transforms.ts`
+- `renderer.ts`
+- `init.ts`
+- score, database, or leaderboard code.
+
+A small test-only import reordering caused by formatter output is acceptable.
+
+## 10. Error Handling
+
+- Direct solver misuse throws before exploration.
+- Candidate parsing failures become `invalid_board`.
+- Missing or multiple start/goal tiles receive dedicated rejection reasons.
+- Truncation always rejects and is distinguishable from a fully explored unsolvable
+  board.
+- Duplicate detection occurs before BFS to avoid wasted solver work.
+- No module logs, touches browser APIs, reads time, reads randomness, or mutates caller
+  row strings.
+- No partial result is converted into a stage definition by these modules.
+
+## 11. Testing Strategy
+
+### 11.1 Solver unit tests
+
+Cover:
+
+- one-move solvable board and exact minimum moves;
+- a multi-move Campaign board;
+- unique reachable stop counting;
+- same stop revisited with a different crystal mask;
+- row-major reachable crystal IDs;
+- unreachable crystal exclusion;
+- `collect_all_crystals`, `no_falls`, and `no_reset` feasibility;
+- deterministic repeated results;
+- caller rows unchanged;
+- `maxStates: 1` truncation;
+- invalid cap rejection.
+
+The crystal-mask fixture must require returning to the start after collecting a crystal
+before taking the goal direction. A position-only visited key would fail this test.
+
+### 11.2 Quality unit tests
+
+Cover:
+
+- empty, jagged, zero-column, and unknown-glyph boards;
+- missing and multiple start;
+- missing and multiple goal;
+- duplicate canonical rows;
+- impossible goal;
+- par below and above the allowed band;
+- state-cap truncation;
+- assigned `collect_all_crystals` with an unreachable crystal;
+- assigned `collect_all_crystals` on a no-crystal board;
+- assigned `no_falls` on a no-hazard board;
+- successful validation returning computed par and canonical key;
+- invalid validator constraints throwing `RangeError`.
+
+### 11.3 Campaign regression tests
+
+For every entry in `ICE_SLIDE_LEVELS`:
+
+- the solver is not truncated under a fixed test cap;
+- the board is solvable;
+- `minMoves === level.parMoves`;
+- every authored crystal coordinate appears in `reachableCrystalIds`.
+
+The duplicated local BFS implementations are removed after these assertions pass.
+
+## 12. Performance and Determinism
+
+Current Campaign boards are at most 9×9 with at most two crystals, so a queue of cloned
+small grids is sufficient. HPA-486 does not add compact board encodings, object pools,
+heuristics, or path compression.
+
+Determinism depends on:
+
+- stable row-major crystal indexing;
+- stable `N`, `E`, `S`, `W` transition order;
+- exact state-key encoding;
+- exact canonical row serialization;
+- ordered rejection checks.
+
+The result does not depend on `Set` iteration order for arrays returned to callers;
+reachable crystal IDs are filtered from the original row-major crystal list.
+
+## 13. Acceptance Criteria
+
+HPA-486 is complete when:
+
+1. All eight Campaign levels solve with their current exact `parMoves`.
+2. Every existing Campaign crystal is reported reachable.
+3. Solver output is deterministic and does not mutate caller rows.
+4. Search state distinguishes identical positions with different consumed-crystal
+   masks.
+5. State-cap exhaustion returns `truncated: true`, `solvable: false`, and `minMoves:
+   null`.
+6. Quality validation rejects missing/multiple start or goal, invalid rows, duplicate
+   boards, impossible goals, par-band violations, required unreachable crystals,
+   infeasible assigned objectives, and truncation.
+7. Initial objective contracts are supported for `collect_all_crystals`, `no_falls`,
+   and `no_reset`.
+8. Production gameplay, UI, generation loops, and future tile mechanics are unchanged.
+9. Unit tests and the full repository suite complete under deterministic explicit
+   limits.
+
+## 14. YAGNI Review
+
+The design removes the following tempting but unnecessary work:
+
+- no generic search abstraction;
+- no path output;
+- no generator retry/fallback code;
+- no dynamic-tile interface;
+- no new persisted IDs;
+- no solver invocation from run validation;
+- no optimization beyond a queue cursor and bounded visited set;
+- no content-validation CLI.
+
+Each excluded feature has a later owner or lacks a current consumer.
+
+## 15. Spec Self-Review
+
+- **Placeholder scan:** no unresolved placeholder or incomplete decision remains.
+- **Consistency:** solver preconditions, validator rejection order, objective
+  eligibility, and truncation semantics agree throughout.
+- **Scope:** the work is limited to four new focused files and one test migration.
+- **Ambiguity resolution:** stop count includes start and goal; crystal IDs are
+  zero-based coordinates; truncation overrides partial solvability; exact final-row
+  serialization defines duplicates.


### PR DESCRIPTION
## Summary

Defines the revised design and implementation plan for [HPA-486](https://linear.app/cwchanap/issue/HPA-486/extract-the-ice-slide-production-solver-and-generation-quality).

The implementation extracts the duplicated BFS from `physics.test.ts` into bounded pure production code and adds the stage-quality validator explicitly required by HPA-486.

## Documents

- Design: `docs/superpowers/specs/2026-08-03-ice-slide-production-solver-design.md`
- Plan: `docs/superpowers/plans/2026-08-03-ice-slide-production-solver.md`

## Latest review decisions

Applied:

- solver now returns search facts only; `IceSlideObjectiveId` and objective policy move to `quality.ts`;
- added `reachedGoalWithAllCrystals` as the single objective-related search fact;
- truncation again returns `solvable=false` and `minMoves=null`; no partial par is preserved;
- removed the direction-order-dependent post-goal truncation fixture;
- quality catches solver validation errors instead of duplicating start/goal parsing and messages;
- the 30-crystal mask limit is internal, not exported API;
- explored-state tests assert relationships/cap bounds rather than exact traversal counts;
- process-only diff-scope and prescribed PR-summary steps were removed from the implementation plan.

Retained after review:

- `quality.ts`, because HPA-486 explicitly requires a pure stage-quality validator and canonical duplicate detection;
- `existingCanonicalKeys`, as the minimal input needed for that ticket-required duplicate check;
- `reachableStopCount` and `exploredStates`, because they are explicit HPA-486 outputs;
- per-state grids, because `slide()` mutates crystal cells and reconstructing grids from masks would add logic without a current need.

## Fixed implementation scope

- add `solver.ts` and `solver.test.ts`;
- add `quality.ts` and `quality.test.ts`;
- replace the two Campaign BFS traversals in `physics.test.ts`;
- no runtime, generator-loop, UI, score, database, snow, cracked-ice, Undo, path, or generic-search changes.

## Validation

Documentation-only change. The branch changes only the design and implementation-plan documents.