### PR TITLE
ci: skip runner jobs for draft pull requests

### DIFF
--- a/.github/workflows/ci.yml
+++ b/.github/workflows/ci.yml
@@ -5,9 +5,11 @@ on:
     branches: [main, develop]
   pull_request:
     branches: [main, develop]
+    types: [opened, synchronize, reopened, ready_for_review]
 
 jobs:
   lint-and-format:
+    if: ${{ github.event_name != 'pull_request' || github.event.pull_request.draft == false }}
     name: 🧹 Lint & Format
     runs-on: ubuntu-latest
     steps:
@@ -30,6 +32,7 @@ jobs:
         run: bun run format:check
 
   test:
+    if: ${{ github.event_name != 'pull_request' || github.event.pull_request.draft == false }}
     name: 🧪 Test
     runs-on: ubuntu-latest
     env:

--- a/.github/workflows/e2e-tests.yml
+++ b/.github/workflows/e2e-tests.yml
@@ -19,9 +19,11 @@ on:
     branches: [main]
   pull_request:
     branches: [main]
+    types: [opened, synchronize, reopened, ready_for_review]
 
 jobs:
   e2e-tests:
+    if: ${{ github.event_name != 'pull_request' || github.event.pull_request.draft == false }}
     name: 🎭 End-to-End Tests
     runs-on: ubuntu-latest
     timeout-minutes: 20


### PR DESCRIPTION
## Summary

- skip lint/test roots and E2E while a pull request is draft
- let the dependent build job skip naturally when its required roots are skipped
- preserve pushes and manual E2E dispatch
- add `ready_for_review` to the PR-triggered workflows

## Why

GitHub Actions cannot filter `pull_request` events by draft state. The guards avoid Bun, Turso, and Playwright runner work during draft iteration.

## Validation

- workflow-only changes across two files
- existing dependencies, environment setup, artifacts, and E2E commands are unchanged
