### PR TITLE
fix: correct Bubble Shooter mechanics (HPA-121)

### DIFF
--- a/docs/superpowers/plans/2026-08-10-bubble-shooter-mechanics-correction.md
+++ b/docs/superpowers/plans/2026-08-10-bubble-shooter-mechanics-correction.md
@@ -4,7 +4,7 @@
 
 **Goal:** Correct Bubble Shooter hex geometry, projectile simulation, legal attachment, match resolution, run lifecycle, statistics, and rules in one implementation PR.
 
-**Architecture:** Keep the current `BaseGame` + Pixi renderer + initializer boundaries. Put phase-aware pure geometry in `utils.ts`, board and projectile mechanics in `BubbleShooterGame.ts`, and browser lifecycle/preview behavior in `initFramework.ts`. Do not add a production file, dependency, physics engine, or cross-game abstraction.
+**Architecture:** Keep the existing `BaseGame` + Pixi renderer + initializer boundaries. Extend the Bubble Shooter-specific hex helpers in `utils.ts`, keep state transitions and board algorithms in `BubbleShooterGame.ts`, and keep browser lifecycle/preview behavior in `initFramework.ts`. Do not add a production module, dependency, physics engine, shared grid package, or `BaseGame` lifecycle change.
 
 **Tech Stack:** Astro 5, TypeScript, PixiJS 8, Vitest/jsdom, Playwright, Bun 1.3.1.
 
@@ -13,30 +13,34 @@
 - Deliver every task on branch `agent/hpa-121-bubble-shooter-mechanics` in the same draft PR.
 - Track the work under Linear issue `HPA-121`.
 - Do not change `BaseGame` or unrelated games.
+- Reuse `distance` from `src/lib/games/shared/geometry.ts`; do not reuse the rectangular Bejeweled helpers in `src/lib/games/shared/match3.ts`.
 - Set default `projectileSpeed` to exactly `720` pixels per second.
-- Clamp a projectile update to exactly `50ms`.
-- Limit a projectile substep to at most `bubbleRadius / 2` travel.
+- Clamp one projectile update to exactly `50ms`.
+- Limit one projectile collision substep to at most `bubbleRadius / 2` travel.
 - Keep `MATCH_THRESHOLD = 3`, `POINTS_PER_BUBBLE = 10`, and `ALL_CLEAR_BONUS = 1000`.
 - Count direct matches and ceiling-disconnected drops in score, `bubblesPopped`, and `largestCombo`.
-- Increment `successfulShots` once only when the attached bubble creates a direct same-color group of at least three.
+- Increment `successfulShots` once only when the newly attached bubble creates a direct same-color group of at least three.
 - Preserve the already-previewed current bubble. Reconcile only the future `nextBubble` after board resolution.
-- Initial-grid generation samples a snapshot of `config.colors`.
-- Added-row generation samples one snapshot of currently active board colors before mutating the row.
+- Initial-grid generation samples one snapshot of `config.colors`.
+- Added-row generation samples one snapshot of currently active board colors before mutating the board.
+- Board mutation order is explicit: mutate grid → refresh coordinates if row geometry changed → remove unsupported bubbles when required → synchronize `bubblesRemaining` → only then generate or reconcile queue bubbles.
+- `removeUnsupportedBubbles(constants)` returns `GridPosition[]` and never synchronizes counts itself. Callers own the single `syncBubbleCount()` after the mutation sequence.
+- Every planned commit must compile with its production callers; do not commit an intermediate helper-signature change that knowingly leaves `BubbleShooterGame.ts` broken.
 - Tests must use deterministic state or a stubbed `Math.random`.
 - Remove `rowOffset`; no compatibility layer is required for internal state or helper signatures.
 
 ---
 
-## File map
+## File Map
 
 ### Production
 
 - `src/lib/games/bubble-shooter/types.ts`
   - Add `RowPhase` and `successfulShots`; remove `rowOffset`; document speed units.
 - `src/lib/games/bubble-shooter/utils.ts`
-  - Calculate physical parity, row width, centered coordinates, and neighbors.
+  - Calculate physical parity, row width, centered coordinates, and phase-aware neighbors.
 - `src/lib/games/bubble-shooter/BubbleShooterGame.ts`
-  - Synchronize board state, simulate projectiles, attach legally, resolve matches/drops, choose colors, and calculate stats.
+  - Synchronize board state, simulate projectiles, attach legally, resolve matches/drops, choose colors, and calculate statistics.
 - `src/lib/games/bubble-shooter/initFramework.ts`
   - Reset ended runs and clear preview canvases.
 - `src/pages/bubble-shooter/index.astro`
@@ -49,48 +53,74 @@
 - `src/lib/games/bubble-shooter/initFramework.test.ts`
 - `src/pages/game-board-markup.test.ts`
 
-`BubbleShooterRenderer.ts` remains unchanged; it continues drawing coordinates supplied by game state.
+`BubbleShooterRenderer.ts` remains unchanged; it continues drawing the coordinates supplied by game state.
 
 ---
 
-### Task 1: Add phase-aware centered hex geometry
+### Task 1: Make hex geometry and board state phase-aware in one atomic commit
 
 **Files:**
-- Modify: `src/lib/games/bubble-shooter/types.ts:1-75`
-- Modify: `src/lib/games/bubble-shooter/utils.ts:1-75`
-- Modify: `src/lib/games/bubble-shooter/utils.test.ts:1-160`
+- Modify: `src/lib/games/bubble-shooter/types.ts`
+- Modify: `src/lib/games/bubble-shooter/utils.ts`
+- Modify: `src/lib/games/bubble-shooter/utils.test.ts`
+- Modify: `src/lib/games/bubble-shooter/BubbleShooterGame.ts`
+- Modify: `src/lib/games/bubble-shooter/BubbleShooterGame.test.ts`
 
 **Interfaces:**
-- Produces: `RowPhase = 0 | 1`
-- Produces: `getRowParity(row, rowPhase)`
-- Produces: `getRowColumnCount(row, rowPhase, constants)`
-- Produces: `getBubbleX(col, row, rowPhase, constants)`
-- Produces: `getBubbleY(row, constants)`
-- Produces: `getNeighbors(row, col, rowPhase, constants)`
+- Produces: `RowPhase = 0 | 1`.
+- Produces: `getRowParity(row, rowPhase)`.
+- Produces: `getRowColumnCount(row, rowPhase, constants)`.
+- Produces: `getBubbleX(col, row, rowPhase, constants)`.
+- Produces: `getBubbleY(row, constants)`.
+- Produces: `getNeighbors(row, col, rowPhase, constants)`.
+- Produces: `BubbleShooterState.rowPhase`.
+- Produces: `createEmptyRow(row, constants)`, `refreshBubbleCoordinates(constants)`, and `syncBubbleCount()` private helpers.
 
-- [ ] **Step 1: Write failing geometry tests**
+- [ ] **Step 1: Rewrite the existing geometry tests for the new API**
 
-Add imports for `getRowParity` and `getRowColumnCount`, then add:
+Do not only add a new suite. Delete or rewrite the existing `getBubbleX`, `getBubbleY`, and `getNeighbors` suites that still call the old 3-argument helpers and assert the old left-aligned coordinates.
+
+Use the phase-aware API:
 
 ```ts
+import {
+    pixiColorToHex,
+    getRowParity,
+    getRowColumnCount,
+    getBubbleX,
+    getBubbleY,
+    getNeighbors,
+    drawBubbleOnCanvas,
+} from './utils'
+
 describe('phase-aware hex geometry', () => {
-    it('derives row parity and width from rowPhase', () => {
+    it('derives physical parity and row width from rowPhase', () => {
         expect(getRowParity(0, 0)).toBe(0)
         expect(getRowParity(1, 0)).toBe(1)
         expect(getRowParity(0, 1)).toBe(1)
         expect(getRowParity(1, 1)).toBe(0)
+
         expect(getRowColumnCount(0, 0, constants)).toBe(14)
+        expect(getRowColumnCount(1, 0, constants)).toBe(13)
         expect(getRowColumnCount(0, 1, constants)).toBe(13)
+        expect(getRowColumnCount(1, 1, constants)).toBe(14)
     })
 
-    it('centers both row shapes in the 600px canvas', () => {
+    it('centers full and offset rows in the 600px canvas', () => {
         expect(getBubbleX(0, 0, 0, constants)).toBe(40)
         expect(getBubbleX(13, 0, 0, constants)).toBe(560)
         expect(getBubbleX(0, 0, 1, constants)).toBe(60)
         expect(getBubbleX(12, 0, 1, constants)).toBe(540)
     })
 
-    it('keeps each interior neighbor one diameter away', () => {
+    it('uses row-only vertical geometry', () => {
+        expect(getBubbleY(0, constants)).toBe(20)
+        expect(getBubbleY(1, constants)).toBeCloseTo(
+            20 + 20 * Math.sqrt(3)
+        )
+    })
+
+    it('keeps every interior neighbor one diameter away', () => {
         const origin = { row: 5, col: 5 }
         const originPoint = {
             x: getBubbleX(origin.col, origin.row, 1, constants),
@@ -118,17 +148,115 @@ describe('phase-aware hex geometry', () => {
 })
 ```
 
-Keep the existing color-conversion and canvas-drawing tests.
+Keep the existing color-conversion and canvas-drawing suites unchanged.
 
-- [ ] **Step 2: Verify the test fails**
+- [ ] **Step 2: Add a dense-grid invariant assertion before changing production code**
 
-```bash
-bun run test:run src/lib/games/bubble-shooter/utils.test.ts
+In `BubbleShooterGame.test.ts`, import `RowPhase`, `GridPosition`, and `getRowColumnCount`, and add wrappers:
+
+```ts
+const bubbleX = (
+    col: number,
+    row: number,
+    rowPhase: RowPhase = 0
+): number => getBubbleX(col, row, rowPhase, CONSTANTS)
+
+const bubbleY = (row: number): number => getBubbleY(row, CONSTANTS)
+
+const neighbors = (
+    row: number,
+    col: number,
+    rowPhase: RowPhase = 0
+): GridPosition[] => getNeighbors(row, col, rowPhase, CONSTANTS)
+
+function countGrid(grid: BubbleShooterState['grid']): number {
+    let count = 0
+    for (const row of grid) {
+        for (let col = 0; col < row.length; col++) {
+            if (row[col]) {
+                count++
+            }
+        }
+    }
+    return count
+}
+
+function expectGridInvariant(game: BubbleShooterGame): void {
+    const state = stateOf(game)
+    const constants = game.getConstantsView()
+
+    for (let rowIndex = 0; rowIndex < state.grid.length; rowIndex++) {
+        const row = state.grid[rowIndex]
+        expect(row).toHaveLength(
+            getRowColumnCount(rowIndex, state.rowPhase, constants)
+        )
+
+        for (let col = 0; col < row.length; col++) {
+            expect(col in row).toBe(true)
+            expect(row[col]).not.toBeUndefined()
+
+            const bubble = row[col]
+            if (!bubble) {
+                continue
+            }
+
+            expect(bubble.x).toBe(
+                getBubbleX(
+                    col,
+                    rowIndex,
+                    state.rowPhase,
+                    constants
+                )
+            )
+            expect(bubble.y).toBeCloseTo(
+                getBubbleY(rowIndex, constants)
+            )
+        }
+    }
+
+    expect(state.bubblesRemaining).toBe(countGrid(state.grid))
+}
 ```
 
-Expected: FAIL because phase helpers and signatures do not exist.
+The indexed `col in row` and `row[col] !== undefined` checks are required; `forEach`/`every` alone skip sparse holes and do not prove dense rows.
 
-- [ ] **Step 3: Implement the geometry API**
+- [ ] **Step 3: Add a failing two-row insertion regression**
+
+```ts
+it('preserves dense phase-aware geometry through two inserted rows', () => {
+    vi.spyOn(Math, 'random').mockReturnValue(0)
+    const game = makeGame({ newRowFillChance: 1 })
+    game.start()
+
+    const internal = game as unknown as {
+        addNewRow: (constants: GameConstants) => void
+    }
+    const constants = game.getConstantsView()
+
+    expect(stateOf(game).rowPhase).toBe(0)
+    expectGridInvariant(game)
+
+    internal.addNewRow(constants)
+    expect(stateOf(game).rowPhase).toBe(1)
+    expectGridInvariant(game)
+
+    internal.addNewRow(constants)
+    expect(stateOf(game).rowPhase).toBe(0)
+    expectGridInvariant(game)
+})
+```
+
+- [ ] **Step 4: Run both test files and verify the migration fails before implementation**
+
+```bash
+bun run test:run \
+  src/lib/games/bubble-shooter/utils.test.ts \
+  src/lib/games/bubble-shooter/BubbleShooterGame.test.ts
+```
+
+Expected: FAIL because the new helpers/signatures and `rowPhase` do not exist and row insertion still leaves stale horizontal geometry.
+
+- [ ] **Step 5: Replace the pure geometry API**
 
 In `types.ts`:
 
@@ -227,132 +355,11 @@ export function getNeighbors(
 }
 ```
 
-- [ ] **Step 4: Verify geometry tests pass**
+Remove the old `rowOffset` parameter and left-aligned coordinate behavior.
 
-```bash
-bun run test:run src/lib/games/bubble-shooter/utils.test.ts
-```
+- [ ] **Step 6: Add dense-row and count helpers to `BubbleShooterGame`**
 
-Expected: PASS.
-
-- [ ] **Step 5: Commit**
-
-```bash
-git add src/lib/games/bubble-shooter/types.ts \
-  src/lib/games/bubble-shooter/utils.ts \
-  src/lib/games/bubble-shooter/utils.test.ts
-git commit -m "fix: make bubble shooter grid phase aware"
-```
-
----
-
-### Task 2: Enforce dense grid rows, coordinates, counts, and row phase
-
-**Files:**
-- Modify: `src/lib/games/bubble-shooter/types.ts:30-75`
-- Modify: `src/lib/games/bubble-shooter/BubbleShooterGame.ts:1-620`
-- Modify: `src/lib/games/bubble-shooter/BubbleShooterGame.test.ts:1-700`
-
-**Interfaces:**
-- Consumes: Task 1 geometry helpers.
-- Produces: `BubbleShooterState.rowPhase`.
-- Produces: `refreshBubbleCoordinates(constants)`.
-- Produces: `syncBubbleCount()`.
-- Produces: `randomColor(colors)`.
-
-- [ ] **Step 1: Add test wrappers and a grid invariant assertion**
-
-Import `RowPhase`, `GridPosition`, and `getRowColumnCount`. Add:
-
-```ts
-const bubbleX = (
-    col: number,
-    row: number,
-    rowPhase: RowPhase = 0
-): number => getBubbleX(col, row, rowPhase, CONSTANTS)
-
-const bubbleY = (row: number): number => getBubbleY(row, CONSTANTS)
-
-const neighbors = (
-    row: number,
-    col: number,
-    rowPhase: RowPhase = 0
-): GridPosition[] => getNeighbors(row, col, rowPhase, CONSTANTS)
-
-const countGrid = (grid: BubbleShooterState['grid']): number =>
-    grid.reduce((total, row) => total + row.filter(Boolean).length, 0)
-
-function expectGridInvariant(game: BubbleShooterGame): void {
-    const state = stateOf(game)
-    const constants = game.getConstantsView()
-
-    state.grid.forEach((row, rowIndex) => {
-        expect(row).toHaveLength(
-            getRowColumnCount(rowIndex, state.rowPhase, constants)
-        )
-        expect(row.every(cell => cell === null || cell !== undefined)).toBe(true)
-
-        row.forEach((bubble, colIndex) => {
-            if (!bubble) {
-                return
-            }
-            expect(bubble.x).toBe(
-                getBubbleX(
-                    colIndex,
-                    rowIndex,
-                    state.rowPhase,
-                    constants
-                )
-            )
-            expect(bubble.y).toBeCloseTo(
-                getBubbleY(rowIndex, constants)
-            )
-        })
-    })
-
-    expect(state.bubblesRemaining).toBe(countGrid(state.grid))
-}
-```
-
-Replace old utility call sites in this test file with the wrappers.
-
-- [ ] **Step 2: Add a failing two-row insertion test**
-
-```ts
-it('preserves the physical grid through two inserted rows', () => {
-    vi.spyOn(Math, 'random').mockReturnValue(0)
-    const game = makeGame({ newRowFillChance: 1 })
-    game.start()
-
-    const internal = game as unknown as {
-        addRowAtTop: (constants: GameConstants) => void
-    }
-    const constants = game.getConstantsView()
-
-    expect(stateOf(game).rowPhase).toBe(0)
-    expectGridInvariant(game)
-
-    internal.addRowAtTop(constants)
-    expect(stateOf(game).rowPhase).toBe(1)
-    expectGridInvariant(game)
-
-    internal.addRowAtTop(constants)
-    expect(stateOf(game).rowPhase).toBe(0)
-    expectGridInvariant(game)
-})
-```
-
-- [ ] **Step 3: Verify the game test fails**
-
-```bash
-bun run test:run src/lib/games/bubble-shooter/BubbleShooterGame.test.ts
-```
-
-Expected: FAIL because state lacks `rowPhase`, rows can be sparse, and insertion does not recompute `x`.
-
-- [ ] **Step 4: Add dense-row and count helpers**
-
-Replace `rowOffset` with `rowPhase: RowPhase` in state and initialize `rowPhase: 0`.
+Replace `rowOffset` with `rowPhase: RowPhase` in state and initialize it to `0`.
 
 Add:
 
@@ -380,16 +387,17 @@ private refreshBubbleCoordinates(constants: GameConstants): void {
             this.state.rowPhase,
             constants
         )
-        const previousRow = this.state.grid[row] ?? []
-        const normalizedRow = Array.from(
+        const previous = this.state.grid[row] ?? []
+        const normalized = Array.from(
             { length: columnCount },
-            (_, col) => previousRow[col] ?? null
+            (_, col) => previous[col] ?? null
         )
-        this.state.grid[row] = normalizedRow
+        this.state.grid[row] = normalized
 
-        normalizedRow.forEach((bubble, col) => {
+        for (let col = 0; col < normalized.length; col++) {
+            const bubble = normalized[col]
             if (!bubble) {
-                return
+                continue
             }
             bubble.x = getBubbleX(
                 col,
@@ -398,51 +406,50 @@ private refreshBubbleCoordinates(constants: GameConstants): void {
                 constants
             )
             bubble.y = getBubbleY(row, constants)
-        })
+        }
     }
 }
 
 private syncBubbleCount(): number {
-    const count = this.state.grid.reduce(
-        (total, row) => total + row.filter(Boolean).length,
-        0
-    )
+    let count = 0
+    for (const row of this.state.grid) {
+        for (let col = 0; col < row.length; col++) {
+            if (row[col]) {
+                count++
+            }
+        }
+    }
     this.state.bubblesRemaining = count
     return count
 }
-
-private randomColor(colors: number[]): number {
-    return colors[Math.floor(Math.random() * colors.length)]
-}
 ```
 
-- [ ] **Step 5: Make initialization use a configured-color snapshot**
+- [ ] **Step 7: Migrate every production caller in the same task**
 
-At the beginning of `initializeGrid()`:
+Do not commit after only editing `utils.ts`. In the same working change:
 
-```ts
-const generationColors = [...constants.COLORS]
-this.state.grid = []
+- update `initializeGrid` to build every row with `createEmptyRow`, use the new coordinate signatures, then call `refreshBubbleCoordinates(constants)` and `syncBubbleCount()`;
+- update `findAttachPosition`/`findClosestPosition` candidate geometry to `getRowColumnCount` and phase-aware coordinates;
+- update `isValidAttachPosition` and the current match DFS to phase-aware `getNeighbors`;
+- update all `getBubbleY` calls to the new row-only signature;
+- update all `getBubbleX` calls to pass `this.state.rowPhase`;
+- update all tests in `BubbleShooterGame.test.ts` to use the new wrappers.
+
+Verify no old signatures remain:
+
+```bash
+rg -n "rowOffset|getBubbleX\([^\n]*CONSTANTS\)|getBubbleY\([^\n]*, 0, CONSTANTS\)|getNeighbors\([^\n]*CONSTANTS\)" \
+  src/lib/games/bubble-shooter
 ```
 
-Create every row with `createEmptyRow`, fill initial rows with `randomColor(generationColors)`, then finish with:
+Expected: no `rowOffset`; manually inspect any geometry matches to confirm they use the new signatures.
 
-```ts
-this.refreshBubbleCoordinates(constants)
-this.syncBubbleCount()
-this.state.needsRedraw = true
-```
+- [ ] **Step 8: Make row insertion preserve physical parity**
 
-Update every production geometry call to pass `this.state.rowPhase`.
-
-- [ ] **Step 6: Make row insertion toggle phase and use an active-color snapshot**
-
-Use this structure:
+Keep `addRowAtTop` focused on the board mutation and coordinate refresh:
 
 ```ts
 private addRowAtTop(constants: GameConstants): void {
-    const generationColors = this.getAvailableBubbleColors()
-
     for (let row = constants.GRID_HEIGHT - 1; row > 0; row--) {
         this.state.grid[row] = [...(this.state.grid[row - 1] ?? [])]
     }
@@ -452,56 +459,59 @@ private addRowAtTop(constants: GameConstants): void {
     for (let col = 0; col < topRow.length; col++) {
         if (Math.random() < this.config.newRowFillChance) {
             topRow[col] = {
-                color: this.randomColor(generationColors),
+                color: this.config.colors[
+                    Math.floor(Math.random() * this.config.colors.length)
+                ],
                 x: 0,
                 y: 0,
             }
         }
     }
     this.state.grid[0] = topRow
-
     this.refreshBubbleCoordinates(constants)
-    this.syncBubbleCount()
-    this.state.needsRedraw = true
 }
 ```
 
-For this task, define `getAvailableBubbleColors()` to return `[...config.colors]`; Task 5 replaces it with the active-board scan.
+For this intermediate task, `addNewRow` calls `addRowAtTop(constants)`, then `syncBubbleCount()`, then the existing game-over check. Task 4 changes row-color selection and inserts connectivity normalization before that count sync.
 
-- [ ] **Step 7: Verify geometry and game tests**
+- [ ] **Step 9: Verify the atomic geometry + caller migration**
 
 ```bash
 bun run test:run \
   src/lib/games/bubble-shooter/utils.test.ts \
   src/lib/games/bubble-shooter/BubbleShooterGame.test.ts
+bun run typecheck
 ```
 
-Expected: PASS after updating old coordinate expectations to the centered layout.
+Expected: both test files PASS and typecheck exits successfully. This is the first commit boundary; there is no intentionally broken helper-signature commit.
 
-- [ ] **Step 8: Commit**
+- [ ] **Step 10: Commit**
 
 ```bash
 git add src/lib/games/bubble-shooter/types.ts \
+  src/lib/games/bubble-shooter/utils.ts \
+  src/lib/games/bubble-shooter/utils.test.ts \
   src/lib/games/bubble-shooter/BubbleShooterGame.ts \
   src/lib/games/bubble-shooter/BubbleShooterGame.test.ts
-git commit -m "fix: preserve bubble shooter row geometry"
+git commit -m "fix: make bubble shooter grid phase aware"
 ```
 
 ---
 
-### Task 3: Make projectile movement elapsed-time based
+### Task 2: Make projectile movement elapsed-time based
 
 **Files:**
-- Modify: `src/lib/games/bubble-shooter/types.ts:55-75`
-- Modify: `src/lib/games/bubble-shooter/BubbleShooterGame.ts:20-400`
-- Modify: `src/lib/games/bubble-shooter/BubbleShooterGame.test.ts:220-400`
+- Modify: `src/lib/games/bubble-shooter/types.ts`
+- Modify: `src/lib/games/bubble-shooter/BubbleShooterGame.ts`
+- Modify: `src/lib/games/bubble-shooter/BubbleShooterGame.test.ts`
 
 **Interfaces:**
-- Produces: `updateProjectile(deltaTimeMs: number)`.
+- Produces: `updateProjectile(deltaTimeMs: number): boolean`.
 - Produces: `reflectProjectileOffWalls(constants)`.
-- Changes: `projectileSpeed` and projectile velocity are pixels per second.
+- Produces internally: `ProjectileImpact = { kind: 'ceiling' } | { kind: 'bubble'; anchor: GridPosition }`.
+- Changes: projectile velocity is pixels per second.
 
-- [ ] **Step 1: Write a failing refresh-rate test**
+- [ ] **Step 1: Add a failing refresh-rate regression**
 
 ```ts
 function simulateProjectile(frameCount: number): number {
@@ -537,7 +547,7 @@ function simulateProjectile(frameCount: number): number {
     return stateOf(game).projectile?.y ?? Number.NaN
 }
 
-it('moves equally at 30Hz, 60Hz, and 120Hz', () => {
+it('moves equally over one second at 30Hz, 60Hz, and 120Hz', () => {
     const at30Hz = simulateProjectile(30)
     const at60Hz = simulateProjectile(60)
     const at120Hz = simulateProjectile(120)
@@ -548,7 +558,7 @@ it('moves equally at 30Hz, 60Hz, and 120Hz', () => {
 })
 ```
 
-- [ ] **Step 2: Write a failing reflected-position test**
+- [ ] **Step 2: Add a failing reflected-position regression**
 
 ```ts
 it('keeps the projectile inside the right wall after reflection', () => {
@@ -573,17 +583,23 @@ it('keeps the projectile inside the right wall after reflection', () => {
 })
 ```
 
-- [ ] **Step 3: Verify the tests fail**
+- [ ] **Step 3: Verify the physics tests fail**
 
 ```bash
 bun run test:run src/lib/games/bubble-shooter/BubbleShooterGame.test.ts -t "30Hz|right wall"
 ```
 
-Expected: FAIL because frame time is ignored and position is not reflected inside bounds.
+Expected: FAIL because frame time is ignored and wall handling reverses velocity without reflecting position inside bounds.
 
 - [ ] **Step 4: Convert speed and add bounded substeps**
 
-Set the default to `720` and document `projectileSpeed: number // pixels per second`.
+Set:
+
+```ts
+projectileSpeed: 720,
+```
+
+and document `projectileSpeed: number // pixels per second` in the config type.
 
 Add:
 
@@ -596,7 +612,7 @@ type ProjectileImpact =
     | { kind: 'bubble'; anchor: GridPosition }
 ```
 
-Pass `deltaTime` from `update` to `updateProjectile`.
+Pass the RAF milliseconds already supplied to `update(deltaTime)` into `updateProjectile(deltaTime)`.
 
 Implement:
 
@@ -667,44 +683,40 @@ private reflectProjectileOffWalls(constants: GameConstants): void {
 }
 ```
 
-Temporarily adapt `attachBubble` to the `ProjectileImpact` signature while retaining its current candidate logic; Task 4 replaces that logic.
+Adapt `attachBubble` to accept `ProjectileImpact` while retaining its existing candidate selection until Task 3.
 
-- [ ] **Step 5: Update existing direct calls**
+- [ ] **Step 5: Update existing direct update tests**
 
-Pass `16` to ordinary one-frame `updateProjectile` tests and update movement expectations to velocity multiplied by `0.016`.
+Pass `16` to ordinary one-frame `updateProjectile` tests and change position expectations to velocity multiplied by `0.016`.
 
-- [ ] **Step 6: Verify game tests**
+- [ ] **Step 6: Verify and commit**
 
 ```bash
 bun run test:run src/lib/games/bubble-shooter/BubbleShooterGame.test.ts
-```
-
-Expected: PASS.
-
-- [ ] **Step 7: Commit**
-
-```bash
+bun run typecheck
 git add src/lib/games/bubble-shooter/types.ts \
   src/lib/games/bubble-shooter/BubbleShooterGame.ts \
   src/lib/games/bubble-shooter/BubbleShooterGame.test.ts
 git commit -m "fix: make bubble shooter physics time based"
 ```
 
+Expected: game tests PASS and typecheck exits successfully before the commit.
+
 ---
 
-### Task 4: Restrict attachment to impact-local empty cells
+### Task 3: Restrict attachment to impact-local empty cells
 
 **Files:**
-- Modify: `src/lib/games/bubble-shooter/BubbleShooterGame.ts:300-510`
-- Modify: `src/lib/games/bubble-shooter/BubbleShooterGame.test.ts:350-560`
+- Modify: `src/lib/games/bubble-shooter/BubbleShooterGame.ts`
+- Modify: `src/lib/games/bubble-shooter/BubbleShooterGame.test.ts`
 
 **Interfaces:**
-- Consumes: `ProjectileImpact` from Task 3.
+- Consumes: `ProjectileImpact` from Task 2.
 - Produces: `findAttachPosition(constants, impact)`.
 - Produces: `findClosestEmptyPosition(constants, candidates)`.
 - Removes: global candidate search, `isValidAttachPosition`, and occupied top-center fallback.
 
-- [ ] **Step 1: Write a failing anchor-local attachment test**
+- [ ] **Step 1: Add a failing anchor-local attachment regression**
 
 ```ts
 it('attaches a bubble impact only beside the collided anchor', () => {
@@ -750,7 +762,7 @@ it('attaches a bubble impact only beside the collided anchor', () => {
 })
 ```
 
-- [ ] **Step 2: Write a failing full-board no-overwrite test**
+- [ ] **Step 2: Add a failing full-board no-overwrite regression**
 
 ```ts
 it('ends without overwriting when no legal attachment exists', () => {
@@ -794,15 +806,15 @@ it('ends without overwriting when no legal attachment exists', () => {
 })
 ```
 
-- [ ] **Step 3: Verify the tests fail**
+- [ ] **Step 3: Verify the attachment tests fail**
 
 ```bash
 bun run test:run src/lib/games/bubble-shooter/BubbleShooterGame.test.ts -t "collided anchor|without overwriting"
 ```
 
-Expected: FAIL because the current fallback can search elsewhere or replace row-zero center.
+Expected: FAIL because the current fallback searches unrelated cells and can replace row-zero center.
 
-- [ ] **Step 4: Implement impact-specific candidates**
+- [ ] **Step 4: Implement impact-specific candidates using the existing shared `distance` helper**
 
 ```ts
 private findAttachPosition(
@@ -870,54 +882,47 @@ private findClosestEmptyPosition(
 }
 ```
 
-In `attachBubble(impact)`, if no empty position exists:
+If no legal position exists, clear the projectile, mark redraw, invoke the existing caught `end()` path, and return `true` without touching grid cells or counts.
 
-```ts
-this.state.projectile = null
-this.state.needsRedraw = true
-this.end().catch(error =>
-    console.error('BubbleShooter end failed', error)
-)
-return true
-```
-
-Otherwise, verify the cell is still empty, insert the bubble using phase-aware coordinates, and call `syncBubbleCount()` before match resolution. Remove `isValidAttachPosition` and all whole-board fallback code.
+For a successful insert, synchronize the count immediately after the cell write and again after the current legacy match function until Task 4 replaces match bookkeeping completely.
 
 - [ ] **Step 5: Add delayed-frame tunneling coverage**
 
-Place one occupied bubble 60px above a projectile moving at `-720px/s`, call `updateProjectile(500)`, and assert the projectile attaches to an anchor neighbor. The 500ms input is clamped to 50ms and split into at least four substeps.
+Place one occupied bubble 60px above a projectile moving at `-720px/s`, call `updateProjectile(500)`, and assert the projectile attaches to an anchor neighbor rather than passing through it. The input is clamped to 50ms and split into substeps no longer than 10px for the default radius.
 
-- [ ] **Step 6: Verify game tests**
+- [ ] **Step 6: Verify and commit**
 
 ```bash
 bun run test:run src/lib/games/bubble-shooter/BubbleShooterGame.test.ts
-```
-
-Expected: PASS.
-
-- [ ] **Step 7: Commit**
-
-```bash
+bun run typecheck
 git add src/lib/games/bubble-shooter/BubbleShooterGame.ts \
   src/lib/games/bubble-shooter/BubbleShooterGame.test.ts
 git commit -m "fix: restrict bubble shooter attachment cells"
 ```
 
+Expected: game tests PASS and typecheck exits successfully.
+
 ---
 
-### Task 5: Drop unsupported clusters, use active colors, and calculate true accuracy
+### Task 4: Normalize connectivity before queue generation, drop clusters, use active colors, and calculate true accuracy
 
 **Files:**
-- Modify: `src/lib/games/bubble-shooter/types.ts:20-80`
-- Modify: `src/lib/games/bubble-shooter/BubbleShooterGame.ts:80-650`
-- Modify: `src/lib/games/bubble-shooter/BubbleShooterGame.test.ts:70-750`
+- Modify: `src/lib/games/bubble-shooter/types.ts`
+- Modify: `src/lib/games/bubble-shooter/BubbleShooterGame.ts`
+- Modify: `src/lib/games/bubble-shooter/BubbleShooterGame.test.ts`
 
 **Interfaces:**
 - Produces: `successfulShots` in state, end stats, and game data.
 - Produces: `ShotResolution`.
-- Produces: `collectColorCluster`, `collectCeilingConnected`, `removeUnsupportedBubbles`, `resolveMatches`, `getAvailableBubbleColors`, and `reconcileNextBubbleColor`.
+- Produces: `collectColorCluster(start, constants): GridPosition[]`.
+- Produces: `collectCeilingConnected(constants): Set<string>`.
+- Produces: `removeUnsupportedBubbles(constants): GridPosition[]` with no count synchronization side effect.
+- Produces: `resolveMatches(attached, constants): ShotResolution`.
+- Produces: `getAvailableBubbleColors(): number[]` and `reconcileNextBubbleColor(): void`.
+- Changes startup order to `initializeGrid → removeUnsupportedBubbles → syncBubbleCount → generateBubble → generateNextBubble`.
+- Changes added-row order to `snapshot active colors → addRowAtTop → removeUnsupportedBubbles → syncBubbleCount → later reconcile nextBubble`.
 
-- [ ] **Step 1: Write a failing direct-match-plus-drop test**
+- [ ] **Step 1: Add a failing direct-match-plus-drop regression**
 
 ```ts
 it('scores a direct match and bubbles disconnected from the ceiling', () => {
@@ -962,7 +967,60 @@ it('scores a direct match and bubbles disconnected from the ceiling', () => {
 })
 ```
 
-- [ ] **Step 2: Write failing active-color and accuracy tests**
+- [ ] **Step 2: Add a failing opening-queue ordering regression**
+
+This test pins the high-cost sequencing contract: a color present only on a floating startup bubble must be removed before current/next generation samples active colors.
+
+```ts
+it('removes floating-only colors before generating the opening queue', () => {
+    const game = makeGame({ colors: [0xff0000, 0x0000ff] })
+    const grid = Array.from(
+        { length: CONSTANTS.GRID_HEIGHT },
+        (_, row) =>
+            Array.from(
+                {
+                    length: getRowColumnCount(row, 0, CONSTANTS),
+                },
+                () => null
+            )
+    )
+
+    grid[0][0] = {
+        color: 0xff0000,
+        x: bubbleX(0, 0),
+        y: bubbleY(0),
+    }
+    grid[1][2] = {
+        color: 0x0000ff,
+        x: bubbleX(2, 1),
+        y: bubbleY(1),
+    }
+
+    const internal = game as unknown as {
+        initializeGrid: () => void
+        onGameStart: () => void
+    }
+    vi.spyOn(internal, 'initializeGrid').mockImplementation(() => {
+        setState(game, {
+            grid,
+            rowPhase: 0,
+            bubblesRemaining: 2,
+            currentBubble: null,
+            nextBubble: null,
+        })
+    })
+    vi.spyOn(Math, 'random').mockReturnValue(0)
+
+    internal.onGameStart()
+
+    expect(stateOf(game).grid[1][2]).toBeNull()
+    expect(stateOf(game).bubblesRemaining).toBe(1)
+    expect(stateOf(game).currentBubble?.color).toBe(0xff0000)
+    expect(stateOf(game).nextBubble?.color).toBe(0xff0000)
+})
+```
+
+- [ ] **Step 3: Add failing active-color and successful-shot accuracy regressions**
 
 ```ts
 it('reports accuracy from successful shots rather than popped bubbles', () => {
@@ -996,34 +1054,40 @@ it('returns active colors and falls back after an all-clear', () => {
 })
 ```
 
-- [ ] **Step 3: Verify the tests fail**
+- [ ] **Step 4: Verify the new mechanics tests fail**
 
 ```bash
-bun run test:run src/lib/games/bubble-shooter/BubbleShooterGame.test.ts -t "disconnected|successful shots|active colors"
+bun run test:run src/lib/games/bubble-shooter/BubbleShooterGame.test.ts -t "disconnected|opening queue|successful shots|active colors"
 ```
 
-Expected: FAIL because unsupported bubbles remain, accuracy uses pop count, and available colors are not scanned.
+Expected: FAIL because unsupported bubbles are not removed, startup queue generation happens before maintenance cleanup, and accuracy/colors still use the old behavior.
 
-- [ ] **Step 4: Add state and stat contracts**
+- [ ] **Step 5: Add successful-shot state and stats**
 
-Add `successfulShots: number` to `BubbleShooterState`, `BubbleShooterEndGameStats`, and `BubbleShooterStats`. Initialize it to zero and include it in `getGameData()`.
+Add `successfulShots: number` to `BubbleShooterState`, `BubbleShooterEndGameStats`, and `BubbleShooterStats`; initialize it to zero and include it in `getGameData()`.
 
 Use:
 
 ```ts
 const accuracy =
-    shotsFired > 0
-        ? (this.state.successfulShots / shotsFired) * 100
+    this.state.shotsFired > 0
+        ? (this.state.successfulShots / this.state.shotsFired) * 100
         : 0
 ```
 
 Return `successfulShots` and `accuracy` from `getGameStats()`.
 
-- [ ] **Step 5: Implement direct-cluster and ceiling-connectivity traversal**
+- [ ] **Step 6: Implement the traversal contracts with one owner for count synchronization**
 
-Use iterative DFS/BFS and phase-aware `getNeighbors`.
+Reuse the existing hex-neighbor logic; do not use `shared/match3.ts`.
 
 ```ts
+interface ShotResolution {
+    directMatches: GridPosition[]
+    dropped: GridPosition[]
+    removedCount: number
+}
+
 private collectColorCluster(
     start: GridPosition,
     constants: GameConstants
@@ -1064,17 +1128,38 @@ private collectColorCluster(
 }
 ```
 
-Implement `collectCeilingConnected(constants)` with the same traversal, seeded by every occupied row-zero cell and without a color predicate. Implement `removeUnsupportedBubbles(constants)` by nulling each occupied cell not present in the connected-key set and then calling `syncBubbleCount()`.
+Implement `collectCeilingConnected(constants): Set<string>` with the same iterative traversal, seeded by every occupied row-zero cell and without a color predicate.
 
-- [ ] **Step 6: Replace `checkMatches` with one shot resolution**
+Implement `removeUnsupportedBubbles` with this exact contract:
 
 ```ts
-interface ShotResolution {
-    directMatches: GridPosition[]
-    dropped: GridPosition[]
-    removedCount: number
-}
+private removeUnsupportedBubbles(
+    constants: GameConstants
+): GridPosition[] {
+    const connected = this.collectCeilingConnected(constants)
+    const dropped: GridPosition[] = []
 
+    for (let row = 0; row < this.state.grid.length; row++) {
+        for (let col = 0; col < this.state.grid[row].length; col++) {
+            if (
+                this.state.grid[row][col] &&
+                !connected.has(`${row},${col}`)
+            ) {
+                dropped.push({ row, col })
+                this.state.grid[row][col] = null
+            }
+        }
+    }
+
+    return dropped
+}
+```
+
+It does **not** call `syncBubbleCount()`. That side effect belongs to the caller after the complete mutation sequence.
+
+- [ ] **Step 7: Replace `checkMatches` with a single shot resolution**
+
+```ts
 private resolveMatches(
     attached: GridPosition,
     constants: GameConstants
@@ -1086,8 +1171,9 @@ private resolveMatches(
 
     this.removeBubbles(directMatches)
     const dropped = this.removeUnsupportedBubbles(constants)
-    const removedCount = directMatches.length + dropped.length
+    this.syncBubbleCount()
 
+    const removedCount = directMatches.length + dropped.length
     this.addScore(removedCount * POINTS_PER_BUBBLE, 'bubble_pop')
     this.state.successfulShots++
     this.state.bubblesPopped += removedCount
@@ -1095,7 +1181,6 @@ private resolveMatches(
         this.state.largestCombo,
         removedCount
     )
-    this.syncBubbleCount()
 
     if (this.state.bubblesRemaining === 0) {
         this.addScore(ALL_CLEAR_BONUS, 'all_clear')
@@ -1106,15 +1191,33 @@ private resolveMatches(
 }
 ```
 
-Call this after attachment. After initialization and after row insertion, call `removeUnsupportedBubbles(constants)` without score/stat changes so retained bubbles always connect to row zero.
+`resolveMatches` owns exactly one `syncBubbleCount()` after direct and unsupported removals.
 
-- [ ] **Step 7: Implement active-color selection without generation feedback**
+- [ ] **Step 8: Make startup normalize the board before queue generation**
+
+Rewrite the existing start hook explicitly:
+
+```ts
+protected onGameStart(): void {
+    const constants = this.getConstantsView()
+    this.initializeGrid()
+    this.removeUnsupportedBubbles(constants)
+    this.syncBubbleCount()
+    this.generateBubble()
+    this.generateNextBubble()
+}
+```
+
+This order is required. `generateBubble()` and `generateNextBubble()` must never sample colors from bubbles that the startup connectivity pass is about to remove.
+
+- [ ] **Step 9: Implement active-color selection and row-generation snapshotting**
 
 ```ts
 private getAvailableBubbleColors(): number[] {
     const colors = new Set<number>()
     for (const row of this.state.grid) {
-        for (const bubble of row) {
+        for (let col = 0; col < row.length; col++) {
+            const bubble = row[col]
             if (bubble) {
                 colors.add(bubble.color)
             }
@@ -1130,47 +1233,87 @@ private reconcileNextBubbleColor(): void {
         !colors.includes(this.state.nextBubble.color)
     ) {
         this.state.nextBubble = {
-            color: this.randomColor(colors),
+            color: colors[Math.floor(Math.random() * colors.length)],
         }
     }
 }
 ```
 
-Use `randomColor(this.getAvailableBubbleColors())` in `generateBubble()` and `generateNextBubble()`.
+Use active colors in `generateBubble()` and `generateNextBubble()`.
 
-Keep these separate generation snapshots:
+Keep initial-grid generation independent of its own partially generated board:
 
-- `initializeGrid`: `const generationColors = [...config.colors]` before filling any cell.
-- `addRowAtTop`: `const generationColors = getAvailableBubbleColors()` before shifting or creating row zero.
+```ts
+const generationColors = [...this.config.colors]
+```
 
-After shot resolution and any interval row insertion, call `reconcileNextBubbleColor()`. Never reroll `currentBubble`.
+before filling the initial grid.
 
-- [ ] **Step 8: Verify game tests**
+For an added row, snapshot active colors **before** row mutation. Change the row insertion API to accept that snapshot:
+
+```ts
+private addRowAtTop(
+    constants: GameConstants,
+    generationColors: number[]
+): void {
+    // shift rows, toggle rowPhase, fill row zero from generationColors,
+    // then refreshBubbleCoordinates(constants)
+}
+```
+
+Use this final ordering in `addNewRow`:
+
+```ts
+private addNewRow(constants: GameConstants): void {
+    const generationColors = this.getAvailableBubbleColors()
+    this.addRowAtTop(constants, generationColors)
+    this.removeUnsupportedBubbles(constants)
+    this.syncBubbleCount()
+
+    if (this.checkGameOverCondition(constants)) {
+        this.state.needsRedraw = true
+    }
+}
+```
+
+Do not touch `currentBubble` or `nextBubble` inside `addRowAtTop`/`addNewRow`. In `attachBubble`, after match resolution and any interval row insertion have completed, call `reconcileNextBubbleColor()` exactly once. That guarantees row mutation and maintenance normalization finish before queue reconciliation.
+
+- [ ] **Step 10: Verify board-mutation ordering explicitly**
+
+Add one row-insertion test where a color exists only on a cluster that becomes unsupported after the new row. Stub the generated top row so that cluster is disconnected, fire the interval attachment path, and assert:
+
+```ts
+expect(stateOf(game).grid.flat().some(
+    bubble => bubble?.color === isolatedColor
+)).toBe(false)
+expect(stateOf(game).bubblesRemaining).toBe(countGrid(stateOf(game).grid))
+expect(stateOf(game).nextBubble?.color).not.toBe(isolatedColor)
+```
+
+This pins `addRowAtTop → connectivity cleanup → count sync → nextBubble reconciliation`.
+
+- [ ] **Step 11: Verify and commit**
 
 ```bash
 bun run test:run src/lib/games/bubble-shooter/BubbleShooterGame.test.ts
-```
-
-Expected: PASS, including revised all-clear and accuracy cases.
-
-- [ ] **Step 9: Commit**
-
-```bash
+bun run typecheck
 git add src/lib/games/bubble-shooter/types.ts \
   src/lib/games/bubble-shooter/BubbleShooterGame.ts \
   src/lib/games/bubble-shooter/BubbleShooterGame.test.ts
 git commit -m "fix: resolve bubble shooter clusters and stats"
 ```
 
+Expected: game tests PASS and typecheck exits successfully.
+
 ---
 
-### Task 6: Reset ended runs, clear previews, and align rules
+### Task 5: Reset ended runs, clear previews, and align rules
 
 **Files:**
-- Modify: `src/lib/games/bubble-shooter/initFramework.ts:70-550`
-- Modify: `src/lib/games/bubble-shooter/initFramework.test.ts:1-700`
-- Modify: `src/pages/bubble-shooter/index.astro:1-140`
-- Modify: `src/pages/game-board-markup.test.ts:1-70`
+- Modify: `src/lib/games/bubble-shooter/initFramework.ts`
+- Modify: `src/lib/games/bubble-shooter/initFramework.test.ts`
+- Modify: `src/pages/bubble-shooter/index.astro`
+- Modify: `src/pages/game-board-markup.test.ts`
 
 **Interfaces:**
 - Consumes: `rowPhase` and `successfulShots` in initializer state.
@@ -1188,7 +1331,7 @@ successfulShots: 0,
 
 Keep all existing pointer and RAF mock behavior.
 
-- [ ] **Step 2: Write a failing ended-run Start test**
+- [ ] **Step 2: Add a failing ended-run Start regression**
 
 ```ts
 it('resets an ended run before starting again', async () => {
@@ -1213,9 +1356,9 @@ it('resets an ended run before starting again', async () => {
 })
 ```
 
-- [ ] **Step 3: Write a failing null-preview test**
+- [ ] **Step 3: Add a failing null-preview regression**
 
-Invoke the captured `onStateChange` first with current/next colors and then with both values null. Assert each preview context's `fillRect` runs twice while `drawBubbleOnCanvas` runs only for the colored state.
+Invoke the captured `onStateChange` once with current/next colors and then once with both values null. Assert each preview context's `fillRect` runs for both states while `drawBubbleOnCanvas` runs only for the colored state.
 
 - [ ] **Step 4: Verify the initializer tests fail**
 
@@ -1223,9 +1366,9 @@ Invoke the captured `onStateChange` first with current/next colors and then with
 bun run test:run src/lib/games/bubble-shooter/initFramework.test.ts -t "ended run|preview"
 ```
 
-Expected: FAIL because Start does not reset and undefined colors return before clearing.
+Expected: FAIL because Start does not reset and undefined colors return before clearing the preview canvas.
 
-- [ ] **Step 5: Consolidate preview drawing**
+- [ ] **Step 5: Consolidate preview drawing and reset cached colors**
 
 ```ts
 const drawBubblePreview = (
@@ -1256,7 +1399,7 @@ const drawBubblePreview = (
 }
 ```
 
-Track `number | undefined` colors. Add:
+Track cached colors as `number | undefined` and add:
 
 ```ts
 const resetPreviewState = (): void => {
@@ -1269,18 +1412,9 @@ const resetPreviewState = (): void => {
 
 Call `drawBubblePreview` whenever a defined or undefined color differs from its cached value. Call `resetPreviewState()` from reset, restart, returned `restart()`, and ended-run Start.
 
-- [ ] **Step 6: Reset before starting a previous run**
+- [ ] **Step 6: Reset locally before restarting an ended run**
 
-Pass `resetPreviewState` into `setupButtonHandlers`:
-
-```ts
-function setupButtonHandlers(
-    game: BubbleShooterGame,
-    resetPreviews: () => void
-): () => void
-```
-
-Use:
+Pass `resetPreviewState` into `setupButtonHandlers` and use:
 
 ```ts
 const startHandler = (): void => {
@@ -1294,9 +1428,9 @@ const startHandler = (): void => {
 }
 ```
 
-Reset and restart handlers call `game.reset()`, `resetPreviews()`, and `resetButtonVisibility()` in that order.
+Reset and restart handlers call `game.reset()`, `resetPreviews()`, and `resetButtonVisibility()` in that order. Do not change `BaseGame.start()`.
 
-- [ ] **Step 7: Update and test rules copy**
+- [ ] **Step 7: Update rules from the configured interval**
 
 In Astro frontmatter:
 
@@ -1306,7 +1440,7 @@ import { DEFAULT_BUBBLE_SHOOTER_CONFIG } from '@/lib/games/bubble-shooter/Bubble
 const rowAddInterval = DEFAULT_BUBBLE_SHOOTER_CONFIG.rowAddInterval
 ```
 
-Use:
+Render:
 
 ```astro
 <p>• Match 3+ bubbles of the same color</p>
@@ -1316,21 +1450,15 @@ Use:
 <p>• Accuracy counts shots that clear bubbles</p>
 ```
 
-In `game-board-markup.test.ts`, load the Bubble Shooter page and assert those source strings plus absence of `New row appears after each shot`.
+In `game-board-markup.test.ts`, load the Bubble Shooter source and assert the configured interpolation plus absence of the stale text `New row appears after each shot`.
 
-- [ ] **Step 8: Verify initializer and page tests**
+- [ ] **Step 8: Verify and commit**
 
 ```bash
 bun run test:run \
   src/lib/games/bubble-shooter/initFramework.test.ts \
   src/pages/game-board-markup.test.ts
-```
-
-Expected: PASS with existing pointerdown-before-shoot and RAF tests still green.
-
-- [ ] **Step 9: Commit**
-
-```bash
+bun run typecheck
 git add src/lib/games/bubble-shooter/initFramework.ts \
   src/lib/games/bubble-shooter/initFramework.test.ts \
   src/pages/bubble-shooter/index.astro \
@@ -1338,19 +1466,21 @@ git add src/lib/games/bubble-shooter/initFramework.ts \
 git commit -m "fix: reset bubble shooter runs and rules"
 ```
 
+Expected: initializer/page tests PASS and typecheck exits successfully.
+
 ---
 
-### Task 7: Verify the complete single-PR change
+### Task 6: Verify the complete single-PR implementation
 
 **Files:**
-- Review: every file in the file map.
-- Modify only when a command exposes a concrete defect.
+- Review every production and test file in the file map.
+- Modify only when a verification command exposes a concrete defect.
 
 **Interfaces:**
 - Verifies: `docs/superpowers/specs/2026-08-10-bubble-shooter-mechanics-correction-design.md`.
-- Produces: no new scope.
+- Produces: no new feature scope.
 
-- [ ] **Step 1: Run focused tests**
+- [ ] **Step 1: Run focused Bubble Shooter tests**
 
 ```bash
 bun run test:run \
@@ -1363,91 +1493,122 @@ bun run test:run \
 
 Expected: PASS.
 
-- [ ] **Step 2: Search for stale state and signatures**
+- [ ] **Step 2: Search for stale state, signatures, and obsolete fallbacks**
 
 ```bash
-rg -n "rowOffset" src/lib/games/bubble-shooter
+rg -n "rowOffset|isValidAttachPosition" src/lib/games/bubble-shooter
 rg -n "getBubbleX|getBubbleY|getNeighbors" src/lib/games/bubble-shooter
 ```
 
-Expected: no `rowOffset`; manually confirm every geometry call has the Task 1 signature.
+Expected: no `rowOffset` or `isValidAttachPosition`; manually confirm every geometry call uses the phase-aware signatures.
 
-- [ ] **Step 3: Run the full unit suite**
+- [ ] **Step 3: Re-check the critical ordering contracts in code**
+
+Confirm `onGameStart` is exactly:
+
+```text
+initialize grid
+→ remove unsupported bubbles
+→ sync bubble count
+→ generate current bubble
+→ generate next bubble
+```
+
+Confirm the interval-row path is exactly:
+
+```text
+snapshot active colors
+→ shift/toggle/fill row
+→ refresh coordinates
+→ remove unsupported bubbles
+→ sync bubble count
+→ reconcile next bubble after row handling returns
+```
+
+Confirm `removeUnsupportedBubbles` returns dropped positions and does not call `syncBubbleCount`.
+
+- [ ] **Step 4: Run the full unit suite**
 
 ```bash
 bun run test:run
 ```
 
-Expected: PASS.
+Expected: PASS with zero failed tests.
 
-- [ ] **Step 4: Run type, lint, format, and diff checks**
+- [ ] **Step 5: Run typecheck**
 
 ```bash
 bun run typecheck
-bun run lint
-bun run format:check
-git diff --check
 ```
 
-Expected: all commands exit successfully with no new errors.
+Expected: exit code 0.
 
-- [ ] **Step 5: Run the production build**
+- [ ] **Step 6: Run lint**
+
+```bash
+bun run lint
+```
+
+Expected: zero lint errors.
+
+- [ ] **Step 7: Run formatting check**
+
+```bash
+bun run format:check
+```
+
+Expected: exit code 0.
+
+- [ ] **Step 8: Run the production build**
 
 ```bash
 bun run build
 ```
 
-Expected: successful Astro production build.
+Expected: exit code 0.
 
-- [ ] **Step 6: Run existing game E2E coverage**
-
-```bash
-bun run test:e2e -- e2e/games/play-coverage.spec.ts
-```
-
-Expected: Bubble Shooter start, interaction, end, and restart path passes. If the browser or local database service is unavailable, record the exact command and error in the PR body rather than claiming success.
-
-- [ ] **Step 7: Review the diff against invariants**
+- [ ] **Step 9: Run existing game happy-path E2E coverage**
 
 ```bash
-git diff main...HEAD -- \
-  src/lib/games/bubble-shooter \
-  src/pages/bubble-shooter/index.astro \
-  src/pages/game-board-markup.test.ts
+bun run test:e2e e2e/games/play-coverage.spec.ts
 ```
 
-Confirm:
+Expected: the play-coverage spec passes, including Bubble Shooter start/play/end/restart behavior.
 
-- row phase toggles on insertion,
-- rows contain explicit `null` cells rather than sparse holes,
-- initial and added rows use fixed color snapshots,
-- all geometry calls use row phase,
-- projectile movement uses elapsed time and bounded substeps,
-- reflected positions remain inside walls,
-- impact candidates are local and empty,
-- blocked attachment cannot mutate the grid,
-- `bubblesRemaining` equals occupied cells,
-- successful direct matches drop unsupported bubbles,
-- maintenance connectivity cleanup does not score,
-- future colors come from active board colors,
-- accuracy uses successful shots,
-- ended runs reset before Start,
-- previews clear when colors become null,
-- rules match configured behavior.
+- [ ] **Step 10: Review the final diff against HPA-121 acceptance criteria**
 
-- [ ] **Step 8: Commit only verification fixes**
+Check that the PR contains only the planned Bubble Shooter production/test changes plus the two planning documents. Confirm there is no `BaseGame`, shared `match3`, renderer-architecture, dependency, or unrelated-game change.
 
-If verification changed files:
+- [ ] **Step 11: Commit only verification-driven fixes, if any**
+
+If Steps 1-10 required a concrete correction, stage only those files and use:
 
 ```bash
-git add src/lib/games/bubble-shooter \
-  src/pages/bubble-shooter/index.astro \
-  src/pages/game-board-markup.test.ts
-git commit -m "chore: finalize bubble shooter mechanics fix"
+git commit -m "test: finish bubble shooter mechanics correction"
 ```
 
-Do not create an empty commit.
+If no verification-driven code change exists, do not create an empty commit.
 
-- [ ] **Step 9: Update tracking state**
+---
 
-Add command results to the PR body. Keep `HPA-121` in `In Progress` while implementation is underway, move it to `In Review` only after required checks pass and the PR is marked ready, and move it to `Done` only after merge.
+## Review Checklist
+
+Before marking PR #57 ready for review:
+
+- [ ] Existing `utils.test.ts` geometry suites use only the phase-aware centered API.
+- [ ] No commit leaves changed helper signatures with broken production callers.
+- [ ] Grid rows are dense arrays with explicit `null` empty cells; indexed tests prove no sparse holes.
+- [ ] `rowPhase` preserves physical parity through repeated row insertion.
+- [ ] Projectile motion is elapsed-time based, 50ms-clamped, and substepped at `radius / 2` maximum travel.
+- [ ] Attachment is impact-local and never overwrites an occupied cell.
+- [ ] `removeUnsupportedBubbles(constants): GridPosition[]` has no hidden count-sync side effect.
+- [ ] `resolveMatches` synchronizes count once after direct and unsupported removal.
+- [ ] Startup removes unsupported bubbles before current/next colors are generated.
+- [ ] Added-row mutation and maintenance cleanup complete before `nextBubble` reconciliation.
+- [ ] `bubblesRemaining` equals occupied grid cells after every completed board mutation.
+- [ ] Opening and future queue colors cannot depend on colors that maintenance cleanup removes.
+- [ ] Accuracy is `successfulShots / shotsFired`.
+- [ ] Ended-run Start uses local `reset()` before `start()` without modifying `BaseGame`.
+- [ ] Preview canvases clear when colors become null/undefined.
+- [ ] Rules copy reflects the configured row interval and implemented drop/accuracy behavior.
+- [ ] Focused tests, full unit suite, typecheck, lint, format check, build, and play-coverage E2E have fresh passing evidence.

--- a/docs/superpowers/plans/2026-08-10-bubble-shooter-mechanics-correction.md
+++ b/docs/superpowers/plans/2026-08-10-bubble-shooter-mechanics-correction.md
@@ -4,86 +4,70 @@
 
 **Goal:** Correct Bubble Shooter hex geometry, projectile simulation, legal attachment, cluster removal, queue/stat semantics, restart behavior, previews, and rules in one implementation PR.
 
-**Architecture:** Keep Bubble Shooter geometry and mechanics local to its existing module, reuse the shared `distance` helper, and leave the Pixi renderer coordinate-driven. Make two narrowly shared framework corrections in `BaseGame`: an ended-run `start()` resets before starting the next run, and `update(deltaTime)` is explicitly measured in seconds. No physics engine, shared hex-grid package, renderer rewrite, persistence migration, or compatibility layer is added.
+**Architecture:** Keep hex geometry and game rules local to Bubble Shooter, reuse the existing shared `distance` helper, and leave the Pixi renderer coordinate-driven. Make only two narrow framework changes: `BaseGame.start()` resets a completed run before starting the next one, and `BaseGame.update(deltaTime)` explicitly uses elapsed seconds.
 
 **Tech Stack:** Astro 5, TypeScript, PixiJS 8, Vitest/jsdom, Playwright, Bun 1.3.1.
 
 ## Global Constraints
 
-- Deliver all tasks on branch `agent/hpa-121-bubble-shooter-mechanics` in draft PR #57.
-- Track the work under Linear issue `HPA-121`.
+- Use branch `agent/hpa-121-bubble-shooter-mechanics` and draft PR #57.
+- Track under Linear `HPA-121`.
 - Reuse `distance` from `src/lib/games/shared/geometry.ts`.
-- Do not reuse `src/lib/games/shared/match3.ts`; it models rectangular run matching/gravity, not hex connectivity.
-- Do not add a physics engine, shared grid/graph package, new production module, animation, sound, asset, power-up, level, or difficulty feature.
-- `BaseGame.update(deltaTime)` uses elapsed **seconds**.
-- Set Bubble Shooter default `projectileSpeed` to exactly `720` pixels per second.
-- Clamp one Bubble Shooter projectile update to exactly `0.05` seconds.
-- Limit one Bubble Shooter projectile substep to at most `bubbleRadius / 2` travel.
-- Keep `MATCH_THRESHOLD = 3`, `POINTS_PER_BUBBLE = 10`, and `ALL_CLEAR_BONUS = 1000`.
-- Bubble collision is evaluated before ceiling collision on every projectile substep.
-- A blocked impact consumes the projectile but is not a game-over condition by itself; `checkGameOverCondition()` remains the gameplay game-over authority.
-- Count direct matches and ceiling-disconnected drops in score, `bubblesPopped`, and `largestCombo`.
-- Increment `successfulShots` once only when the newly attached bubble creates a direct same-color cluster of at least three.
-- Preserve the already-previewed current bubble; only reconcile future `nextBubble` after all board mutation/cleanup for the shot.
-- Initial-grid generation samples one snapshot of `config.colors`.
-- Added-row generation samples one snapshot of currently active board colors before mutating the board.
-- Board mutation ordering is explicit: mutate grid → refresh coordinates if row geometry changed → remove unsupported bubbles when required → synchronize `bubblesRemaining` → reconcile future queue.
-- `removeUnsupportedBubbles(constants)` returns `GridPosition[]` and does not call `syncBubbleCount()`.
-- Every planned commit must compile with all production callers; no intentionally broken signature-migration commit is allowed.
-- Tests use deterministic board state or stubbed `Math.random`.
-- Remove `rowOffset`; no compatibility layer is required for internal state/helper signatures.
-- Do not remove existing initializer-level restart guards from other games in this PR; the shared BaseGame fix makes them redundant but harmless.
+- Do not reuse rectangular `src/lib/games/shared/match3.ts`.
+- Do not add a physics engine, shared hex/grid package, renderer refactor, new production module, asset, animation, sound, power-up, level, or difficulty feature.
+- `BaseGame.update(deltaTime)` means elapsed **seconds**.
+- Bubble Shooter `projectileSpeed` default becomes exactly `720` pixels/second.
+- Clamp one Bubble Shooter physics update to exactly `0.05` seconds.
+- Each collision substep travels at most `bubbleRadius / 2`.
+- Keep `MATCH_THRESHOLD = 3`, `POINTS_PER_BUBBLE = 10`, `ALL_CLEAR_BONUS = 1000`.
+- Check bubble collision before ceiling collision on every substep.
+- A locally blocked impact consumes the shot but cannot end the run by itself; danger-zone detection remains the game-over authority.
+- Score direct matches and ceiling-disconnected drops; one direct match increments `successfulShots` once.
+- Preserve `currentBubble`; only reconcile future `nextBubble` after board mutation/cleanup.
+- `removeUnsupportedBubbles(constants): GridPosition[]` removes cells and returns positions but never synchronizes `bubblesRemaining`.
+- Every commit must typecheck; do not commit a helper-signature migration with broken callers.
+- Use deterministic board state or stubbed `Math.random` in tests.
+- Remove `rowOffset` without a compatibility shim.
+- Leave existing 2048/Evader/Reflex/Sudoku initializer restart guards in place; they become redundant but harmless.
 
 ---
 
 ## File Map
 
-### Shared framework
+**Shared framework**
+- Modify `src/lib/games/core/BaseGame.ts`
+- Modify `src/lib/games/core/core.test.ts`
 
-- `src/lib/games/core/BaseGame.ts`
-  - Reset a completed run inside `start()` before beginning the next run.
-  - Document `update(deltaTime)` as elapsed seconds.
-- `src/lib/games/core/core.test.ts`
-  - Regression coverage for ended-run restart and active-start no-op.
+**Bubble Shooter production**
+- Modify `src/lib/games/bubble-shooter/types.ts`
+- Modify `src/lib/games/bubble-shooter/utils.ts`
+- Modify `src/lib/games/bubble-shooter/BubbleShooterGame.ts`
+- Modify `src/lib/games/bubble-shooter/initFramework.ts`
+- Modify `src/pages/bubble-shooter/index.astro`
 
-### Bubble Shooter production
+**Tests**
+- Modify `src/lib/games/bubble-shooter/utils.test.ts`
+- Modify `src/lib/games/bubble-shooter/BubbleShooterGame.test.ts`
+- Modify `src/lib/games/bubble-shooter/initFramework.test.ts`
+- Modify `src/pages/game-board-markup.test.ts`
 
-- `src/lib/games/bubble-shooter/types.ts`
-  - Add `RowPhase` and `successfulShots`; remove `rowOffset`; document speed units.
-- `src/lib/games/bubble-shooter/utils.ts`
-  - Physical parity, row width, centered coordinates, and phase-aware neighbors.
-- `src/lib/games/bubble-shooter/BubbleShooterGame.ts`
-  - Dense board normalization, projectile substeps, wall reflection, impact-local attachment, count sync, cluster/drop resolution, active colors, scoring/statistics.
-- `src/lib/games/bubble-shooter/initFramework.ts`
-  - Convert RAF milliseconds to seconds; clear preview canvases on null/reset.
-- `src/pages/bubble-shooter/index.astro`
-  - Render configured row interval and corrected rules.
-
-### Bubble Shooter tests
-
-- `src/lib/games/bubble-shooter/utils.test.ts`
-- `src/lib/games/bubble-shooter/BubbleShooterGame.test.ts`
-- `src/lib/games/bubble-shooter/initFramework.test.ts`
-- `src/pages/game-board-markup.test.ts`
-
-`src/lib/games/bubble-shooter/BubbleShooterRenderer.ts` remains unchanged.
+`BubbleShooterRenderer.ts` remains unchanged.
 
 ---
 
-### Task 1: Fix shared ended-run restart semantics and define delta-time units
+### Task 1: Fix completed-run restart semantics and define `deltaTime`
 
 **Files:**
 - Modify: `src/lib/games/core/BaseGame.ts`
-- Modify: `src/lib/games/core/core.test.ts`
+- Test: `src/lib/games/core/core.test.ts`
 
-**Interfaces:**
-- Produces: `BaseGame.start()` resets when `state.gameStarted && state.isGameOver` before setting new-run flags.
-- Produces: `BaseGame.update(deltaTime)` contract = elapsed seconds.
-- Preserves: calling `start()` while already active is a no-op.
+**Produces:**
+- `start()` resets an ended run before new-run flags/hooks.
+- `update(deltaTime)` is documented as elapsed seconds.
 
-- [ ] **Step 1: Add a failing ended-run restart regression**
+- [ ] **Step 1: Add the failing restart regression**
 
-Inside the existing `BaseGame default hooks` suite, add:
+Inside the existing `BaseGame default hooks` suite:
 
 ```ts
 it('resets state and score before starting after game over', async () => {
@@ -117,9 +101,7 @@ it('resets state and score before starting after game over', async () => {
 })
 ```
 
-- [ ] **Step 2: Add/retain active-start no-op coverage**
-
-Add a focused assertion if the existing test does not already pin `reset()`:
+- [ ] **Step 2: Pin the active-start guard**
 
 ```ts
 it('does not reset when start is called while already active', () => {
@@ -142,17 +124,15 @@ it('does not reset when start is called while already active', () => {
 })
 ```
 
-- [ ] **Step 3: Verify the ended-run test fails**
+- [ ] **Step 3: Verify red**
 
 ```bash
 bun run test:run src/lib/games/core/core.test.ts -t "resets state and score|already active"
 ```
 
-Expected: ended-run test FAILS because `start()` currently flips flags without resetting `ScoreManager`/state; active-start test passes.
+Expected: ended-run test fails because current `start()` preserves prior score/state.
 
-- [ ] **Step 4: Implement the minimal shared restart fix**
-
-In `BaseGame.start()` keep the active guard first, then reset completed runs:
+- [ ] **Step 4: Implement the shared restart guard**
 
 ```ts
 start(): void {
@@ -181,11 +161,7 @@ start(): void {
 }
 ```
 
-Do not remove the existing reset-before-start guards from 2048/Evader/Reflex/Sudoku in this PR. Their explicit `reset()` changes `gameStarted` back to false, so the BaseGame guard is a no-op when `start()` follows.
-
-- [ ] **Step 5: Document seconds on the abstract update contract**
-
-Replace the bare abstract declaration with:
+- [ ] **Step 5: Document the update unit**
 
 ```ts
 /**
@@ -194,71 +170,56 @@ Replace the bare abstract declaration with:
 abstract update(deltaTime: number): void
 ```
 
-- [ ] **Step 6: Verify core tests and typecheck**
+- [ ] **Step 6: Verify green and commit**
 
 ```bash
 bun run test:run src/lib/games/core/core.test.ts
 bun run typecheck
-```
-
-Expected: PASS and typecheck exits 0.
-
-- [ ] **Step 7: Commit**
-
-```bash
 git add src/lib/games/core/BaseGame.ts src/lib/games/core/core.test.ts
 git commit -m "fix: reset completed BaseGame runs on start"
 ```
 
+Expected: test file passes and typecheck exits 0.
+
 ---
 
-### Task 2: Make hex geometry and board state phase-aware in one atomic commit
+### Task 2: Make geometry and board state phase-aware atomically
 
 **Files:**
 - Modify: `src/lib/games/bubble-shooter/types.ts`
 - Modify: `src/lib/games/bubble-shooter/utils.ts`
-- Modify: `src/lib/games/bubble-shooter/utils.test.ts`
 - Modify: `src/lib/games/bubble-shooter/BubbleShooterGame.ts`
-- Modify: `src/lib/games/bubble-shooter/BubbleShooterGame.test.ts`
+- Test: `src/lib/games/bubble-shooter/utils.test.ts`
+- Test: `src/lib/games/bubble-shooter/BubbleShooterGame.test.ts`
 
-**Interfaces:**
-- Produces: `RowPhase = 0 | 1`.
-- Produces: `getRowParity(row, rowPhase): RowPhase`.
-- Produces: `getRowColumnCount(row, rowPhase, constants): number`.
-- Produces: `getBubbleX(col, row, rowPhase, constants): number`.
-- Produces: `getBubbleY(row, constants): number`.
-- Produces: `getNeighbors(row, col, rowPhase, constants): GridPosition[]`.
-- Produces: `BubbleShooterState.rowPhase`.
-- Produces private `createEmptyRow`, `refreshBubbleCoordinates`, `syncBubbleCount`.
+**Produces:**
+- `RowPhase = 0 | 1`
+- `getRowParity(row, rowPhase)`
+- `getRowColumnCount(row, rowPhase, constants)`
+- `getBubbleX(col, row, rowPhase, constants)`
+- `getBubbleY(row, constants)`
+- `getNeighbors(row, col, rowPhase, constants)`
+- dense rows, `rowPhase`, coordinate refresh, authoritative count sync.
 
-- [ ] **Step 1: Rewrite the existing geometry suites, not just add new tests**
+- [ ] **Step 1: Rewrite the existing geometry suites**
 
-Replace the current `getBubbleX`, `getBubbleY`, and `getNeighbors` suites that call the old API. Keep color conversion and canvas-drawing tests.
-
-Use:
+Delete/rewrite the old 3-argument/`rowOffset` geometry tests; keep color/canvas tests.
 
 ```ts
 describe('phase-aware hex geometry', () => {
-    it('derives physical parity and row width from rowPhase', () => {
+    it('derives row parity and row width', () => {
         expect(getRowParity(0, 0)).toBe(0)
         expect(getRowParity(1, 0)).toBe(1)
         expect(getRowParity(0, 1)).toBe(1)
-        expect(getRowParity(1, 1)).toBe(0)
-
         expect(getRowColumnCount(0, 0, constants)).toBe(14)
-        expect(getRowColumnCount(1, 0, constants)).toBe(13)
         expect(getRowColumnCount(0, 1, constants)).toBe(13)
-        expect(getRowColumnCount(1, 1, constants)).toBe(14)
     })
 
-    it('centers full and offset rows inside projectile wall bounds', () => {
+    it('centers the full row exactly inside wall bounds', () => {
         expect(getBubbleX(0, 0, 0, constants)).toBe(40)
         expect(getBubbleX(13, 0, 0, constants)).toBe(560)
-        expect(getBubbleX(0, 0, 1, constants)).toBe(60)
-        expect(getBubbleX(12, 0, 1, constants)).toBe(540)
-
-        expect(getBubbleX(0, 0, 0, constants) - constants.BUBBLE_RADIUS).toBe(20)
-        expect(getBubbleX(13, 0, 0, constants) + constants.BUBBLE_RADIUS).toBe(580)
+        expect(getBubbleX(0, 0, 0, constants) - 20).toBe(20)
+        expect(getBubbleX(13, 0, 0, constants) + 20).toBe(580)
     })
 
     it('uses row-only vertical spacing', () => {
@@ -268,37 +229,26 @@ describe('phase-aware hex geometry', () => {
         )
     })
 
-    it('keeps every interior neighbor one diameter away', () => {
+    it('keeps each interior neighbor one bubble diameter away', () => {
         const origin = { row: 5, col: 5 }
-        const originPoint = {
-            x: getBubbleX(origin.col, origin.row, 1, constants),
-            y: getBubbleY(origin.row, constants),
-        }
+        const originX = getBubbleX(5, 5, 1, constants)
+        const originY = getBubbleY(5, constants)
 
-        for (const neighbor of getNeighbors(
-            origin.row,
-            origin.col,
-            1,
-            constants
-        )) {
-            const point = {
-                x: getBubbleX(neighbor.col, neighbor.row, 1, constants),
-                y: getBubbleY(neighbor.row, constants),
-            }
-            expect(
-                Math.hypot(
-                    point.x - originPoint.x,
-                    point.y - originPoint.y
-                )
-            ).toBeCloseTo(constants.BUBBLE_RADIUS * 2)
+        for (const neighbor of getNeighbors(5, 5, 1, constants)) {
+            const x = getBubbleX(
+                neighbor.col,
+                neighbor.row,
+                1,
+                constants
+            )
+            const y = getBubbleY(neighbor.row, constants)
+            expect(Math.hypot(x - originX, y - originY)).toBeCloseTo(40)
         }
     })
 })
 ```
 
-- [ ] **Step 2: Add test wrappers and a dense-grid invariant**
-
-In `BubbleShooterGame.test.ts` add:
+- [ ] **Step 2: Add dense-grid test helpers**
 
 ```ts
 const bubbleX = (
@@ -319,9 +269,7 @@ function countGrid(grid: BubbleShooterState['grid']): number {
     let count = 0
     for (const row of grid) {
         for (let col = 0; col < row.length; col++) {
-            if (row[col]) {
-                count++
-            }
+            if (row[col]) count++
         }
     }
     return count
@@ -340,22 +288,13 @@ function expectGridInvariant(game: BubbleShooterGame): void {
         for (let col = 0; col < row.length; col++) {
             expect(col in row).toBe(true)
             expect(row[col]).not.toBeUndefined()
-
             const bubble = row[col]
-            if (!bubble) {
-                continue
-            }
+            if (!bubble) continue
+
             expect(bubble.x).toBe(
-                getBubbleX(
-                    col,
-                    rowIndex,
-                    state.rowPhase,
-                    constants
-                )
+                getBubbleX(col, rowIndex, state.rowPhase, constants)
             )
-            expect(bubble.y).toBeCloseTo(
-                getBubbleY(rowIndex, constants)
-            )
+            expect(bubble.y).toBeCloseTo(getBubbleY(rowIndex, constants))
         }
     }
 
@@ -363,12 +302,10 @@ function expectGridInvariant(game: BubbleShooterGame): void {
 }
 ```
 
-Indexed checks are required because `Array.forEach`/`every` skip sparse holes.
-
-- [ ] **Step 3: Add a failing two-row insertion regression**
+- [ ] **Step 3: Add the two-row insertion regression**
 
 ```ts
-it('preserves dense phase-aware geometry through two inserted rows', () => {
+it('preserves dense geometry through two inserted rows', () => {
     vi.spyOn(Math, 'random').mockReturnValue(0)
     const game = makeGame({ newRowFillChance: 1 })
     game.start()
@@ -378,20 +315,17 @@ it('preserves dense phase-aware geometry through two inserted rows', () => {
     }
     const constants = game.getConstantsView()
 
-    expect(stateOf(game).rowPhase).toBe(0)
     expectGridInvariant(game)
-
     internal.addRowAtTop(constants, CONSTANTS.COLORS)
     expect(stateOf(game).rowPhase).toBe(1)
     expectGridInvariant(game)
-
     internal.addRowAtTop(constants, CONSTANTS.COLORS)
     expect(stateOf(game).rowPhase).toBe(0)
     expectGridInvariant(game)
 })
 ```
 
-- [ ] **Step 4: Verify migration tests fail before production changes**
+- [ ] **Step 4: Verify red**
 
 ```bash
 bun run test:run \
@@ -399,23 +333,14 @@ bun run test:run \
   src/lib/games/bubble-shooter/BubbleShooterGame.test.ts
 ```
 
-Expected: FAIL because phase helpers/signatures/state do not exist and current insertion leaves stale x/parity.
+Expected: helper signatures/state are missing and current insertion leaves stale x/parity.
 
-- [ ] **Step 5: Add RowPhase and replace geometry helpers**
-
-In `types.ts`:
+- [ ] **Step 5: Implement phase-aware helpers**
 
 ```ts
 export type RowPhase = 0 | 1
-```
 
-Replace geometry functions in `utils.ts` with:
-
-```ts
-export function getRowParity(
-    row: number,
-    rowPhase: RowPhase
-): RowPhase {
+export function getRowParity(row: number, rowPhase: RowPhase): RowPhase {
     return ((row + rowPhase) % 2) as RowPhase
 }
 
@@ -434,85 +359,41 @@ export function getBubbleX(
     constants: GameConstants
 ): number {
     const diameter = constants.BUBBLE_RADIUS * 2
-    const boardWidth = constants.GRID_WIDTH * diameter
-    const boardLeft = (constants.GAME_WIDTH - boardWidth) / 2
-    const parity = getRowParity(row, rowPhase)
-
+    const boardLeft =
+        (constants.GAME_WIDTH - constants.GRID_WIDTH * diameter) / 2
     return (
         boardLeft +
         constants.BUBBLE_RADIUS +
-        parity * constants.BUBBLE_RADIUS +
+        getRowParity(row, rowPhase) * constants.BUBBLE_RADIUS +
         col * diameter
     )
 }
 
-export function getBubbleY(
-    row: number,
-    constants: GameConstants
-): number {
+export function getBubbleY(row: number, constants: GameConstants): number {
     return (
         constants.BUBBLE_RADIUS +
         row * constants.BUBBLE_RADIUS * Math.sqrt(3)
     )
 }
-
-export function getNeighbors(
-    row: number,
-    col: number,
-    rowPhase: RowPhase,
-    constants: GameConstants
-): GridPosition[] {
-    const offsets =
-        getRowParity(row, rowPhase) === 0
-            ? [
-                  [-1, -1],
-                  [-1, 0],
-                  [0, -1],
-                  [0, 1],
-                  [1, -1],
-                  [1, 0],
-              ]
-            : [
-                  [-1, 0],
-                  [-1, 1],
-                  [0, -1],
-                  [0, 1],
-                  [1, 0],
-                  [1, 1],
-              ]
-
-    return offsets.flatMap(([rowDelta, colDelta]) => {
-        const neighborRow = row + rowDelta
-        const neighborCol = col + colDelta
-        if (
-            neighborRow < 0 ||
-            neighborRow >= constants.GRID_HEIGHT ||
-            neighborCol < 0 ||
-            neighborCol >=
-                getRowColumnCount(neighborRow, rowPhase, constants)
-        ) {
-            return []
-        }
-        return [{ row: neighborRow, col: neighborCol }]
-    })
-}
 ```
 
-- [ ] **Step 6: Replace `rowOffset` with dense phase-aware state**
+Implement `getNeighbors` with the existing even/odd offset sets, but derive parity with `getRowParity()` and bounds with `getRowColumnCount()`.
 
-In `BubbleShooterState` replace `rowOffset` with:
+- [ ] **Step 6: Replace `rowOffset` and make rows dense**
+
+State:
 
 ```ts
 rowPhase: RowPhase
 ```
 
-Initialize:
+Initial value:
 
 ```ts
 rowPhase: 0,
 ```
 
-Add:
+Helpers:
 
 ```ts
 private createEmptyRow(
@@ -533,23 +414,16 @@ private createEmptyRow(
 
 private refreshBubbleCoordinates(constants: GameConstants): void {
     for (let row = 0; row < constants.GRID_HEIGHT; row++) {
-        const count = getRowColumnCount(
-            row,
-            this.state.rowPhase,
-            constants
+        const width = getRowColumnCount(row, this.state.rowPhase, constants)
+        const oldRow = this.state.grid[row] ?? []
+        this.state.grid[row] = Array.from(
+            { length: width },
+            (_, col) => oldRow[col] ?? null
         )
-        const previous = this.state.grid[row] ?? []
-        const dense = Array.from(
-            { length: count },
-            (_, col) => previous[col] ?? null
-        )
-        this.state.grid[row] = dense
 
-        for (let col = 0; col < dense.length; col++) {
-            const bubble = dense[col]
-            if (!bubble) {
-                continue
-            }
+        for (let col = 0; col < width; col++) {
+            const bubble = this.state.grid[row][col]
+            if (!bubble) continue
             bubble.x = getBubbleX(
                 col,
                 row,
@@ -565,9 +439,7 @@ private syncBubbleCount(): number {
     let count = 0
     for (const row of this.state.grid) {
         for (let col = 0; col < row.length; col++) {
-            if (row[col]) {
-                count++
-            }
+            if (row[col]) count++
         }
     }
     this.state.bubblesRemaining = count
@@ -575,19 +447,11 @@ private syncBubbleCount(): number {
 }
 ```
 
-- [ ] **Step 7: Migrate all production callers in the same commit**
+- [ ] **Step 7: Migrate all callers in the same commit**
 
-`initializeGrid()` creates every row with `createEmptyRow()`, fills the first `initialRows` from a fixed `const generationColors = [...this.config.colors]`, then calls:
+`initializeGrid()` uses dense rows and `const generationColors = [...this.config.colors]`, then calls `refreshBubbleCoordinates()` and `syncBubbleCount()`.
 
-```ts
-this.refreshBubbleCoordinates(constants)
-this.syncBubbleCount()
-this.state.needsRedraw = true
-```
-
-Change every `getBubbleX/getBubbleY/getNeighbors` call in `BubbleShooterGame.ts` to the new signatures.
-
-Change row insertion to accept a color snapshot and preserve physical parity:
+`addRowAtTop()` becomes:
 
 ```ts
 private addRowAtTop(
@@ -618,9 +482,9 @@ private addRowAtTop(
 }
 ```
 
-For this task, `addNewRow()` may pass `[...this.config.colors]`; active-color snapshotting replaces that in Task 6.
+For this commit only, `addNewRow()` passes `[...this.config.colors]`; Task 6 replaces it with active colors.
 
-- [ ] **Step 8: Verify no old signatures remain and commit**
+- [ ] **Step 8: Verify green and commit**
 
 ```bash
 rg -n "rowOffset" src/lib/games/bubble-shooter
@@ -628,11 +492,6 @@ bun run test:run \
   src/lib/games/bubble-shooter/utils.test.ts \
   src/lib/games/bubble-shooter/BubbleShooterGame.test.ts
 bun run typecheck
-```
-
-Expected: no `rowOffset`, both test files PASS, typecheck exits 0.
-
-```bash
 git add src/lib/games/bubble-shooter/types.ts \
   src/lib/games/bubble-shooter/utils.ts \
   src/lib/games/bubble-shooter/utils.test.ts \
@@ -641,24 +500,26 @@ git add src/lib/games/bubble-shooter/types.ts \
 git commit -m "fix: make bubble shooter grid phase aware"
 ```
 
+Expected: no `rowOffset`, focused tests pass, typecheck exits 0.
+
 ---
 
-### Task 3: Standardize Bubble Shooter on seconds and add collision-safe projectile substeps
+### Task 3: Use elapsed seconds and collision-safe projectile substeps
 
 **Files:**
 - Modify: `src/lib/games/bubble-shooter/types.ts`
 - Modify: `src/lib/games/bubble-shooter/BubbleShooterGame.ts`
-- Modify: `src/lib/games/bubble-shooter/BubbleShooterGame.test.ts`
 - Modify: `src/lib/games/bubble-shooter/initFramework.ts`
-- Modify: `src/lib/games/bubble-shooter/initFramework.test.ts`
+- Test: `src/lib/games/bubble-shooter/BubbleShooterGame.test.ts`
+- Test: `src/lib/games/bubble-shooter/initFramework.test.ts`
 
-**Interfaces:**
-- Produces: `updateProjectile(deltaTimeSeconds: number): boolean`.
-- Produces: `reflectProjectileOffWalls(constants): void`.
-- Produces: `ProjectileImpact` union used by Task 4.
-- Changes Bubble Shooter RAF call to pass elapsed seconds.
+**Produces:**
+- `updateProjectile(deltaTimeSeconds)`
+- wall-position reflection
+- `ProjectileImpact`
+- RAF milliseconds → seconds conversion.
 
-- [ ] **Step 1: Add a failing refresh-rate independence test**
+- [ ] **Step 1: Add refresh-rate regression**
 
 ```ts
 function simulateProjectile(frameCount: number): number {
@@ -679,9 +540,7 @@ function simulateProjectile(frameCount: number): number {
             { length: CONSTANTS.GRID_HEIGHT },
             (_, row) =>
                 Array.from(
-                    {
-                        length: getRowColumnCount(row, 0, CONSTANTS),
-                    },
+                    { length: getRowColumnCount(row, 0, CONSTANTS) },
                     () => null
                 )
         ),
@@ -695,38 +554,29 @@ function simulateProjectile(frameCount: number): number {
 }
 
 it('moves equally for one second at 30Hz 60Hz and 120Hz', () => {
-    const at30Hz = simulateProjectile(30)
-    const at60Hz = simulateProjectile(60)
-    const at120Hz = simulateProjectile(120)
-
-    expect(at30Hz).toBeCloseTo(4_280, 5)
-    expect(at60Hz).toBeCloseTo(at30Hz, 5)
-    expect(at120Hz).toBeCloseTo(at30Hz, 5)
+    const at30 = simulateProjectile(30)
+    const at60 = simulateProjectile(60)
+    const at120 = simulateProjectile(120)
+    expect(at30).toBeCloseTo(4_280, 5)
+    expect(at60).toBeCloseTo(at30, 5)
+    expect(at120).toBeCloseTo(at30, 5)
 })
 ```
 
-- [ ] **Step 2: Add a failing high-speed tunneling test that requires substeps**
-
-Use a speed where one clamped frame can cross multiple bubble diameters:
+- [ ] **Step 2: Add a substep-sensitive tunneling regression**
 
 ```ts
-it('does not tunnel through a bubble at high configured speed', () => {
+it('does not tunnel at 4000 pixels per second', () => {
     const game = makeGame({ projectileSpeed: 4_000 })
     const grid = Array.from(
         { length: CONSTANTS.GRID_HEIGHT },
         (_, row) =>
             Array.from(
-                {
-                    length: getRowColumnCount(row, 0, CONSTANTS),
-                },
+                { length: getRowColumnCount(row, 0, CONSTANTS) },
                 () => null
             )
     )
-    grid[8][6] = {
-        color: 0x00ff00,
-        x: 300,
-        y: 300,
-    }
+    grid[8][6] = { color: 0x00ff00, x: 300, y: 300 }
 
     setState(game, {
         grid,
@@ -741,21 +591,20 @@ it('does not tunnel through a bubble at high configured speed', () => {
     })
 
     game.updateProjectile(0.05)
-
     expect(stateOf(game).projectile).toBeNull()
 })
 ```
 
-The projectile travels 200px in 50ms. Without substeps it ends 100px beyond the bubble and misses the 40px collision diameter; with 10px-or-smaller substeps it resolves the collision.
+A single unsplit 50ms step travels 200px and misses the bubble after crossing it; the substep loop must catch it.
 
-- [ ] **Step 3: Add a wall-reflection test**
+- [ ] **Step 3: Add wall and RAF-unit regressions**
 
 ```ts
-it('reflects position back inside the right wall', () => {
+it('reflects back inside the right wall', () => {
     const game = makeGame({ projectileSpeed: 720 })
     setState(game, {
         projectile: {
-            x: CONSTANTS.GAME_WIDTH - CONSTANTS.BUBBLE_RADIUS - 2,
+            x: 578,
             y: 400,
             vx: 720,
             vy: 0,
@@ -763,46 +612,30 @@ it('reflects position back inside the right wall', () => {
         },
         grid: [],
     })
-
     game.updateProjectile(0.016)
-
-    expect(stateOf(game).projectile?.x).toBeLessThanOrEqual(
-        CONSTANTS.GAME_WIDTH - CONSTANTS.BUBBLE_RADIUS
-    )
+    expect(stateOf(game).projectile?.x).toBeLessThanOrEqual(580)
     expect(stateOf(game).projectile?.vx).toBeLessThan(0)
 })
 ```
 
-- [ ] **Step 4: Add a failing initializer delta-unit test**
-
-In the RAF test, invoke the loop once to establish time and once 16ms later; assert:
+In `initFramework.test.ts`, stub two RAF timestamps 16ms apart and assert the second update receives:
 
 ```ts
 expect(gameMock.update).toHaveBeenLastCalledWith(0.016)
 ```
 
-Use `performance.now` stubbing consistent with the existing test setup so the assertion is deterministic.
-
-- [ ] **Step 5: Verify the new tests fail**
+- [ ] **Step 4: Verify red**
 
 ```bash
 bun run test:run \
   src/lib/games/bubble-shooter/BubbleShooterGame.test.ts \
   src/lib/games/bubble-shooter/initFramework.test.ts \
-  -t "one second|tunnel|right wall|delta"
+  -t "one second|4000|right wall|delta"
 ```
 
-Expected: FAIL because Bubble Shooter ignores delta, uses per-frame velocity, and the initializer passes milliseconds.
+Expected: failures because delta is ignored/passed as milliseconds.
 
-- [ ] **Step 6: Convert speed and implement bounded substeps**
-
-In config/types:
-
-```ts
-projectileSpeed: 720, // pixels per second
-```
-
-In `BubbleShooterGame.ts`:
+- [ ] **Step 5: Implement seconds, clamp, and substeps**
 
 ```ts
 const MAX_PROJECTILE_FRAME_SECONDS = 0.05
@@ -813,16 +646,14 @@ type ProjectileImpact =
     | { kind: 'bubble'; anchor: GridPosition }
 ```
 
-Change `update(deltaTime)` to call `updateProjectile(deltaTime)`.
+Set default `projectileSpeed: 720`.
 
-Implement:
+Core loop:
 
 ```ts
 updateProjectile(deltaTimeSeconds: number): boolean {
     const projectile = this.state.projectile
-    if (!projectile) {
-        return false
-    }
+    if (!projectile) return false
 
     const constants = this.getConstantsView()
     const elapsed = Math.min(
@@ -830,8 +661,7 @@ updateProjectile(deltaTimeSeconds: number): boolean {
         MAX_PROJECTILE_FRAME_SECONDS
     )
     const speed = Math.hypot(projectile.vx, projectile.vy)
-    const maxStepDistance =
-        constants.BUBBLE_RADIUS * MAX_PROJECTILE_SUBSTEP_RATIO
+    const maxStepDistance = constants.BUBBLE_RADIUS / 2
     const stepCount = Math.max(
         1,
         Math.ceil((speed * elapsed) / maxStepDistance)
@@ -844,82 +674,38 @@ updateProjectile(deltaTimeSeconds: number): boolean {
         this.reflectProjectileOffWalls(constants)
 
         const anchor = this.checkBubbleCollision()
-        if (anchor) {
-            return this.attachBubble({ kind: 'bubble', anchor })
-        }
+        if (anchor) return this.attachBubble({ kind: 'bubble', anchor })
         if (projectile.y <= constants.BUBBLE_RADIUS) {
             return this.attachBubble({ kind: 'ceiling' })
         }
     }
 
-    if (elapsed > 0) {
-        this.state.needsRedraw = true
-    }
+    if (elapsed > 0) this.state.needsRedraw = true
     return false
 }
 ```
 
-Bubble collision stays before ceiling collision.
+Wall reflection mirrors overshoot back inside `[radius, gameWidth-radius]` and flips `vx` toward the board.
 
-Implement wall reflection:
-
-```ts
-private reflectProjectileOffWalls(constants: GameConstants): void {
-    const projectile = this.state.projectile
-    if (!projectile) {
-        return
-    }
-
-    const minX = constants.BUBBLE_RADIUS
-    const maxX = constants.GAME_WIDTH - constants.BUBBLE_RADIUS
-
-    if (projectile.x < minX) {
-        projectile.x = minX + (minX - projectile.x)
-        projectile.vx = Math.abs(projectile.vx)
-    } else if (projectile.x > maxX) {
-        projectile.x = maxX - (projectile.x - maxX)
-        projectile.vx = -Math.abs(projectile.vx)
-    }
-
-    projectile.x = Math.min(maxX, Math.max(minX, projectile.x))
-}
-```
-
-Temporarily adapt `attachBubble` to accept `ProjectileImpact` while retaining its current candidate behavior; Task 4 removes the global fallback.
-
-- [ ] **Step 7: Convert the RAF loop from milliseconds to seconds**
-
-In `initFramework.ts`:
+- [ ] **Step 6: Convert RAF delta to seconds**
 
 ```ts
 const now = performance.now()
-if (lastFrame === 0) {
-    lastFrame = now
-}
+if (lastFrame === 0) lastFrame = now
 const deltaTimeSeconds = (now - lastFrame) / 1_000
 lastFrame = now
-
 game.update(deltaTimeSeconds)
 ```
 
-Do not clamp here; the game owns its 0.05s clamp.
+The game, not the initializer, owns the 0.05s clamp.
 
-- [ ] **Step 8: Update old projectile test call sites and verify**
-
-Replace old one-frame test calls with values such as `0.016`, and update expectations to `velocity * 0.016` where applicable.
+- [ ] **Step 7: Verify green and commit**
 
 ```bash
 bun run test:run \
   src/lib/games/bubble-shooter/BubbleShooterGame.test.ts \
   src/lib/games/bubble-shooter/initFramework.test.ts
 bun run typecheck
-```
-
-Expected: PASS and typecheck exits 0.
-
-- [ ] **Step 9: Commit**
-
-```bash
 git add src/lib/games/bubble-shooter/types.ts \
   src/lib/games/bubble-shooter/BubbleShooterGame.ts \
   src/lib/games/bubble-shooter/BubbleShooterGame.test.ts \
@@ -930,85 +716,30 @@ git commit -m "fix: make bubble shooter physics time based"
 
 ---
 
-### Task 4: Restrict attachment to impact-local cells without spurious game over
+### Task 4: Restrict attachment locally; blocked impact is not loss
 
 **Files:**
 - Modify: `src/lib/games/bubble-shooter/BubbleShooterGame.ts`
-- Modify: `src/lib/games/bubble-shooter/BubbleShooterGame.test.ts`
+- Test: `src/lib/games/bubble-shooter/BubbleShooterGame.test.ts`
 
-**Interfaces:**
-- Consumes: `ProjectileImpact` from Task 3.
-- Produces: `findAttachPosition(constants, impact): GridPosition | null`.
-- Produces: `findClosestEmptyPosition(constants, candidates): GridPosition | null`.
-- Removes: whole-board candidate search, `isValidAttachPosition`, and forced row-zero fallback.
+**Produces:** impact-local candidate selection, no whole-board fallback, no occupied overwrite.
 
-- [ ] **Step 1: Add an anchor-local attachment regression**
+- [ ] **Step 1: Add blocked/local regressions**
 
 ```ts
-it('attaches a bubble impact only beside the collided anchor', () => {
-    const game = makeGame({ rowAddInterval: 99 })
-    const anchor = { row: 4, col: 4 }
-    const grid = Array.from(
-        { length: CONSTANTS.GRID_HEIGHT },
-        (_, row) =>
-            Array.from(
-                {
-                    length: getRowColumnCount(row, 0, CONSTANTS),
-                },
-                () => null
-            )
-    )
-    grid[anchor.row][anchor.col] = {
-        color: 0x00ff00,
-        x: bubbleX(anchor.col, anchor.row),
-        y: bubbleY(anchor.row),
-    }
-
-    setState(game, {
-        grid,
-        rowPhase: 0,
-        projectile: {
-            x: bubbleX(anchor.col, anchor.row) + 5,
-            y: bubbleY(anchor.row) + 30,
-            vx: 0,
-            vy: -720,
-            color: 0xff0000,
-        },
-        bubblesRemaining: 1,
-    })
-
-    game.attachBubble({ kind: 'bubble', anchor })
-
-    expect(
-        neighbors(anchor.row, anchor.col).filter(
-            ({ row, col }) =>
-                stateOf(game).grid[row][col]?.color === 0xff0000
-        )
-    ).toHaveLength(1)
-})
-```
-
-- [ ] **Step 2: Add the partial-block regression that distinguishes blocked impact from loss**
-
-Construct one reachable impact with every legal candidate filled but no bubble near the danger zone:
-
-```ts
-it('consumes a locally blocked shot without ending the run', () => {
+it('consumes a locally blocked impact without ending the run', () => {
     const game = makeGame({ rowAddInterval: 99 })
     const anchor = { row: 2, col: 5 }
     const grid = Array.from(
         { length: CONSTANTS.GRID_HEIGHT },
         (_, row) =>
             Array.from(
-                {
-                    length: getRowColumnCount(row, 0, CONSTANTS),
-                },
+                { length: getRowColumnCount(row, 0, CONSTANTS) },
                 () => null
             )
     )
 
-    const occupied = [anchor, ...neighbors(anchor.row, anchor.col)]
-    for (const position of occupied) {
+    for (const position of [anchor, ...neighbors(2, 5)]) {
         grid[position.row][position.col] = {
             color: 0x00ff00,
             x: bubbleX(position.col, position.row),
@@ -1023,8 +754,8 @@ it('consumes a locally blocked shot without ending the run', () => {
         grid,
         rowPhase: 0,
         projectile: {
-            x: bubbleX(anchor.col, anchor.row),
-            y: bubbleY(anchor.row) + 30,
+            x: bubbleX(5, 2),
+            y: bubbleY(2) + 30,
             vx: 0,
             vy: -720,
             color: 0xff0000,
@@ -1040,112 +771,66 @@ it('consumes a locally blocked shot without ending the run', () => {
 })
 ```
 
-- [ ] **Step 3: Verify the attachment regressions fail**
+Also retain/add the anchor-neighbor test asserting a normal bubble impact inserts only within `getNeighbors(anchor...)`.
+
+- [ ] **Step 2: Pin bubble-before-ceiling priority with defined values**
+
+```ts
+it('prefers bubble collision when the projectile is also at the ceiling', () => {
+    const game = makeGame()
+    const targetCol = 6
+    const grid = Array.from(
+        { length: CONSTANTS.GRID_HEIGHT },
+        (_, row) =>
+            Array.from(
+                { length: getRowColumnCount(row, 0, CONSTANTS) },
+                () => null
+            )
+    )
+    grid[0][targetCol] = {
+        color: 0x00ff00,
+        x: bubbleX(targetCol, 0),
+        y: bubbleY(0),
+    }
+    setState(game, {
+        grid,
+        rowPhase: 0,
+        projectile: {
+            x: bubbleX(targetCol, 0),
+            y: CONSTANTS.BUBBLE_RADIUS,
+            vx: 0,
+            vy: -720,
+            color: 0xff0000,
+        },
+    })
+    const attachSpy = vi
+        .spyOn(game, 'attachBubble')
+        .mockReturnValue(false)
+
+    game.updateProjectile(0)
+
+    expect(attachSpy).toHaveBeenCalledWith({
+        kind: 'bubble',
+        anchor: { row: 0, col: targetCol },
+    })
+})
+```
+
+- [ ] **Step 3: Verify red**
 
 ```bash
-bun run test:run src/lib/games/bubble-shooter/BubbleShooterGame.test.ts -t "collided anchor|locally blocked"
+bun run test:run src/lib/games/bubble-shooter/BubbleShooterGame.test.ts -t "locally blocked|also at the ceiling"
 ```
 
-Expected: FAIL because current fallback searches the whole board and the previous plan's blocked behavior would end the run.
+- [ ] **Step 4: Implement candidate selection**
 
-- [ ] **Step 4: Implement impact-specific candidates using shared `distance`**
+For bubble impact candidates use only `getNeighbors(anchor...)`; for ceiling use only row-zero cells. Filter occupied cells and choose the nearest center with shared `distance`. Delete global candidate search, `isValidAttachPosition`, and fixed fallback.
 
-```ts
-private findAttachPosition(
-    constants: GameConstants,
-    impact: ProjectileImpact
-): GridPosition | null {
-    if (!this.state.projectile) {
-        return null
-    }
+- [ ] **Step 5: Finalize every resolved projectile without forced loss**
 
-    const candidates =
-        impact.kind === 'bubble'
-            ? getNeighbors(
-                  impact.anchor.row,
-                  impact.anchor.col,
-                  this.state.rowPhase,
-                  constants
-              )
-            : Array.from(
-                  {
-                      length: getRowColumnCount(
-                          0,
-                          this.state.rowPhase,
-                          constants
-                      ),
-                  },
-                  (_, col) => ({ row: 0, col })
-              )
-
-    return this.findClosestEmptyPosition(constants, candidates)
-}
-
-private findClosestEmptyPosition(
-    constants: GameConstants,
-    candidates: GridPosition[]
-): GridPosition | null {
-    const projectile = this.state.projectile
-    if (!projectile) {
-        return null
-    }
-
-    let best: GridPosition | null = null
-    let bestDistance = Number.POSITIVE_INFINITY
-
-    for (const candidate of candidates) {
-        if (this.state.grid[candidate.row]?.[candidate.col]) {
-            continue
-        }
-
-        const candidateDistance = distance(projectile, {
-            x: getBubbleX(
-                candidate.col,
-                candidate.row,
-                this.state.rowPhase,
-                constants
-            ),
-            y: getBubbleY(candidate.row, constants),
-        })
-        if (candidateDistance < bestDistance) {
-            best = candidate
-            bestDistance = candidateDistance
-        }
-    }
-
-    return best
-}
-```
-
-Delete `isValidAttachPosition` and the whole-board/fixed-cell fallback.
-
-- [ ] **Step 5: Make blocked impact a consumed normal shot**
-
-Structure `attachBubble` so row-interval bookkeeping and danger-zone checking run for both attached and blocked resolved projectiles:
+After optional insertion/matching:
 
 ```ts
-const attachPos = this.findAttachPosition(constants, impact)
-
-if (attachPos) {
-    if (this.state.grid[attachPos.row]?.[attachPos.col]) {
-        throw new Error('Bubble Shooter attach target must be empty')
-    }
-
-    this.state.grid[attachPos.row][attachPos.col] = {
-        color: this.state.projectile.color,
-        x: getBubbleX(
-            attachPos.col,
-            attachPos.row,
-            this.state.rowPhase,
-            constants
-        ),
-        y: getBubbleY(attachPos.row, constants),
-    }
-    this.syncBubbleCount()
-    this.checkMatches(attachPos.row, attachPos.col)
-    this.syncBubbleCount()
-}
-
 this.state.shotCount++
 if (
     this.state.bubblesRemaining > 0 &&
@@ -1166,29 +851,13 @@ if (this.checkGameOverCondition(constants)) {
 return false
 ```
 
-The blocked path writes no cell and creates no successful match. It still consumes a row-interval shot, and only the danger-zone check can end the run.
+If `findAttachPosition()` returns null, skip grid write/match entirely and proceed through this same finalization. The shot is consumed, `successfulShots` does not change, and only danger-zone checking can end the run.
 
-- [ ] **Step 6: Pin bubble-before-ceiling impact priority**
-
-Add a test with a row-zero bubble and a projectile substep that crosses both the bubble collision threshold and ceiling threshold. Spy on `attachBubble` and assert the impact is:
-
-```ts
-expect(attachSpy).toHaveBeenCalledWith({
-    kind: 'bubble',
-    anchor: { row: 0, col: targetCol },
-})
-```
-
-- [ ] **Step 7: Verify and commit**
+- [ ] **Step 6: Verify green and commit**
 
 ```bash
 bun run test:run src/lib/games/bubble-shooter/BubbleShooterGame.test.ts
 bun run typecheck
-```
-
-Expected: PASS and typecheck exits 0.
-
-```bash
 git add src/lib/games/bubble-shooter/BubbleShooterGame.ts \
   src/lib/games/bubble-shooter/BubbleShooterGame.test.ts
 git commit -m "fix: restrict bubble shooter attachment cells"
@@ -1196,198 +865,95 @@ git commit -m "fix: restrict bubble shooter attachment cells"
 
 ---
 
-### Task 5: Add ceiling-connectivity drops and one authoritative match resolution
+### Task 5: Add ceiling-connectivity drops
 
 **Files:**
 - Modify: `src/lib/games/bubble-shooter/types.ts`
 - Modify: `src/lib/games/bubble-shooter/BubbleShooterGame.ts`
-- Modify: `src/lib/games/bubble-shooter/BubbleShooterGame.test.ts`
+- Test: `src/lib/games/bubble-shooter/BubbleShooterGame.test.ts`
 
-**Interfaces:**
-- Produces: `successfulShots` state/stat field for Task 6 accuracy.
-- Produces: `ShotResolution`.
-- Produces: `collectColorCluster(start, constants): GridPosition[]`.
-- Produces: `collectCeilingConnected(constants): Set<string>`.
-- Produces: `removeUnsupportedBubbles(constants): GridPosition[]` with no count-sync side effect.
-- Produces: `resolveMatches(attached, constants): ShotResolution`.
+**Produces:** `successfulShots`, `ShotResolution`, direct hex cluster traversal, ceiling connectivity, exact drop contract.
 
-- [ ] **Step 1: Add a failing direct-match-plus-drop regression**
+- [ ] **Step 1: Add direct-match/drop regression**
+
+Use a dense grid with two top red bubbles, one blue supported only by the red cluster, and a red projectile attaching as the third red. Assert after attachment:
 
 ```ts
-it('scores a direct match and bubbles disconnected from the ceiling', () => {
-    const game = makeGame({ rowAddInterval: 99 })
+expect(countGrid(stateOf(game).grid)).toBe(0)
+expect(stateOf(game).bubblesPopped).toBe(4)
+expect(stateOf(game).largestCombo).toBe(4)
+expect(stateOf(game).successfulShots).toBe(1)
+expect(stateOf(game).score).toBe(1_040)
+```
+
+The committed test must build the exact positions with `bubbleX/bubbleY`, as in the current match tests.
+
+- [ ] **Step 2: Add exact maintenance-drop contract regression**
+
+```ts
+it('returns dropped positions without score or count side effects', () => {
+    const game = makeGame()
     const grid = Array.from(
         { length: CONSTANTS.GRID_HEIGHT },
         (_, row) =>
             Array.from(
-                {
-                    length: getRowColumnCount(row, 0, CONSTANTS),
-                },
+                { length: getRowColumnCount(row, 0, CONSTANTS) },
                 () => null
             )
     )
-
-    grid[0][0] = { color: 0xff0000, x: bubbleX(0, 0), y: bubbleY(0) }
-    grid[0][1] = { color: 0xff0000, x: bubbleX(1, 0), y: bubbleY(0) }
-    grid[1][0] = { color: 0x0000ff, x: bubbleX(0, 1), y: bubbleY(1) }
-
+    const isolated = { row: 3, col: 5 }
+    grid[0][0] = {
+        color: 0xff0000,
+        x: bubbleX(0, 0),
+        y: bubbleY(0),
+    }
+    grid[isolated.row][isolated.col] = {
+        color: 0x0000ff,
+        x: bubbleX(isolated.col, isolated.row),
+        y: bubbleY(isolated.row),
+    }
     setState(game, {
         grid,
         rowPhase: 0,
-        projectile: {
-            x: bubbleX(2, 0),
-            y: bubbleY(0),
-            vx: 0,
-            vy: -720,
-            color: 0xff0000,
-        },
-        bubblesRemaining: 3,
-        shotsFired: 1,
-        successfulShots: 0,
+        bubblesRemaining: 2,
         score: 0,
+        successfulShots: 0,
     })
 
-    game.attachBubble({ kind: 'ceiling' })
-
-    expect(countGrid(stateOf(game).grid)).toBe(0)
-    expect(stateOf(game).bubblesPopped).toBe(4)
-    expect(stateOf(game).largestCombo).toBe(4)
-    expect(stateOf(game).successfulShots).toBe(1)
-    expect(stateOf(game).score).toBe(1_040)
-})
-```
-
-- [ ] **Step 2: Add a failing contract test for maintenance cleanup**
-
-```ts
-it('returns unsupported positions without changing score or successfulShots', () => {
-    const game = makeGame()
-    // Build one top-connected red bubble and one isolated blue bubble.
-    // Use a dense grid and sync bubblesRemaining before invoking the helper.
     const internal = game as unknown as {
         removeUnsupportedBubbles: (
             constants: GameConstants
         ) => GridPosition[]
     }
-    const beforeScore = stateOf(game).score
-    const beforeSuccessfulShots = stateOf(game).successfulShots
-
     const dropped = internal.removeUnsupportedBubbles(
         game.getConstantsView()
     )
 
-    expect(dropped).toEqual([{ row: isolatedRow, col: isolatedCol }])
-    expect(stateOf(game).score).toBe(beforeScore)
-    expect(stateOf(game).successfulShots).toBe(beforeSuccessfulShots)
+    expect(dropped).toEqual([isolated])
+    expect(stateOf(game).grid[3][5]).toBeNull()
+    expect(stateOf(game).bubblesRemaining).toBe(2)
+    expect(stateOf(game).score).toBe(0)
+    expect(stateOf(game).successfulShots).toBe(0)
 })
 ```
 
-Use concrete `isolatedRow`/`isolatedCol` constants in the actual test setup; do not leave symbolic placeholders in committed code.
+`bubblesRemaining` intentionally remains 2 here, proving the helper does not sync counts.
 
-- [ ] **Step 3: Verify tests fail**
+- [ ] **Step 3: Verify red**
 
 ```bash
-bun run test:run src/lib/games/bubble-shooter/BubbleShooterGame.test.ts -t "disconnected from the ceiling|unsupported positions"
+bun run test:run src/lib/games/bubble-shooter/BubbleShooterGame.test.ts -t "disconnected|dropped positions"
 ```
 
-Expected: FAIL because unsupported bubbles are not removed and the helper contracts do not exist.
+- [ ] **Step 4: Add state and traversal contracts**
 
-- [ ] **Step 4: Add successful-shot state contracts**
+Add `successfulShots: number` to state/end stats/runtime stats; initialize to zero.
 
-Add `successfulShots: number` to `BubbleShooterState`, `BubbleShooterEndGameStats`, and `BubbleShooterStats`. Initialize:
+Implement iterative `collectColorCluster()` using phase-aware `getNeighbors()`.
 
-```ts
-successfulShots: 0,
-```
+Implement `collectCeilingConnected()` seeded by every occupied row-zero cell, ignoring color.
 
-Do not switch accuracy yet; Task 6 does that with the queue/stat semantics commit.
-
-- [ ] **Step 5: Implement local iterative hex traversals**
-
-```ts
-interface ShotResolution {
-    directMatches: GridPosition[]
-    dropped: GridPosition[]
-    removedCount: number
-}
-
-private collectColorCluster(
-    start: GridPosition,
-    constants: GameConstants
-): GridPosition[] {
-    const startBubble = this.state.grid[start.row]?.[start.col]
-    if (!startBubble) {
-        return []
-    }
-
-    const visited = new Set<string>()
-    const pending: GridPosition[] = [start]
-    const result: GridPosition[] = []
-
-    while (pending.length > 0) {
-        const current = pending.pop()!
-        const key = `${current.row},${current.col}`
-        if (visited.has(key)) {
-            continue
-        }
-        visited.add(key)
-
-        const bubble = this.state.grid[current.row]?.[current.col]
-        if (!bubble || bubble.color !== startBubble.color) {
-            continue
-        }
-        result.push(current)
-        pending.push(
-            ...getNeighbors(
-                current.row,
-                current.col,
-                this.state.rowPhase,
-                constants
-            )
-        )
-    }
-
-    return result
-}
-```
-
-Implement ceiling traversal seeded by every occupied row-zero cell:
-
-```ts
-private collectCeilingConnected(
-    constants: GameConstants
-): Set<string> {
-    const connected = new Set<string>()
-    const pending: GridPosition[] = []
-
-    for (let col = 0; col < this.state.grid[0].length; col++) {
-        if (this.state.grid[0][col]) {
-            pending.push({ row: 0, col })
-        }
-    }
-
-    while (pending.length > 0) {
-        const current = pending.pop()!
-        const key = `${current.row},${current.col}`
-        if (connected.has(key) || !this.state.grid[current.row]?.[current.col]) {
-            continue
-        }
-        connected.add(key)
-        pending.push(
-            ...getNeighbors(
-                current.row,
-                current.col,
-                this.state.rowPhase,
-                constants
-            )
-        )
-    }
-
-    return connected
-}
-```
-
-Implement the exact drop contract:
+Implement exactly:
 
 ```ts
 private removeUnsupportedBubbles(
@@ -1407,16 +973,19 @@ private removeUnsupportedBubbles(
             }
         }
     }
-
     return dropped
 }
 ```
 
-It must not call `syncBubbleCount()`.
-
-- [ ] **Step 6: Replace `checkMatches` with one resolution owner**
+- [ ] **Step 5: Replace match bookkeeping with one resolution**
 
 ```ts
+interface ShotResolution {
+    directMatches: GridPosition[]
+    dropped: GridPosition[]
+    removedCount: number
+}
+
 private resolveMatches(
     attached: GridPosition,
     constants: GameConstants
@@ -1429,8 +998,8 @@ private resolveMatches(
     this.removeBubbles(directMatches)
     const dropped = this.removeUnsupportedBubbles(constants)
     this.syncBubbleCount()
-
     const removedCount = directMatches.length + dropped.length
+
     this.addScore(removedCount * POINTS_PER_BUBBLE, 'bubble_pop')
     this.state.successfulShots++
     this.state.bubblesPopped += removedCount
@@ -1438,21 +1007,17 @@ private resolveMatches(
         this.state.largestCombo,
         removedCount
     )
-
     if (this.state.bubblesRemaining === 0) {
         this.addScore(ALL_CLEAR_BONUS, 'all_clear')
     }
-    this.state.needsRedraw = true
 
     return { directMatches, dropped, removedCount }
 }
 ```
 
-`resolveMatches` owns exactly one count sync after direct + unsupported removals.
+- [ ] **Step 6: Normalize maintenance boards before queue work**
 
-- [ ] **Step 7: Normalize connectivity after startup and row insertion**
-
-Rewrite startup maintenance before queue generation:
+Startup:
 
 ```ts
 protected onGameStart(): void {
@@ -1465,32 +1030,13 @@ protected onGameStart(): void {
 }
 ```
 
-Change `addNewRow()` to clean unsupported cells after the row mutation and then sync once:
+After row insertion, remove unsupported bubbles and call `syncBubbleCount()` once. Task 6 changes the row color snapshot and next-bubble reconciliation.
 
-```ts
-private addNewRow(constants: GameConstants): void {
-    this.addRowAtTop(constants, [...this.config.colors])
-    this.removeUnsupportedBubbles(constants)
-    this.syncBubbleCount()
-
-    if (this.checkGameOverCondition(constants)) {
-        this.state.needsRedraw = true
-    }
-}
-```
-
-Task 6 replaces the row-generation palette with an active-color snapshot and adds queue reconciliation.
-
-- [ ] **Step 8: Verify and commit**
+- [ ] **Step 7: Verify green and commit**
 
 ```bash
 bun run test:run src/lib/games/bubble-shooter/BubbleShooterGame.test.ts
 bun run typecheck
-```
-
-Expected: PASS and typecheck exits 0.
-
-```bash
 git add src/lib/games/bubble-shooter/types.ts \
   src/lib/games/bubble-shooter/BubbleShooterGame.ts \
   src/lib/games/bubble-shooter/BubbleShooterGame.test.ts
@@ -1499,132 +1045,110 @@ git commit -m "fix: drop unsupported bubble clusters"
 
 ---
 
-### Task 6: Generate playable future colors and switch to successful-shot accuracy
+### Task 6: Use active colors and successful-shot accuracy
 
 **Files:**
 - Modify: `src/lib/games/bubble-shooter/BubbleShooterGame.ts`
-- Modify: `src/lib/games/bubble-shooter/BubbleShooterGame.test.ts`
+- Test: `src/lib/games/bubble-shooter/BubbleShooterGame.test.ts`
 
-**Interfaces:**
-- Consumes: `successfulShots` and connectivity cleanup from Task 5.
-- Produces: `getAvailableBubbleColors(): number[]`.
-- Produces: `reconcileNextBubbleColor(): void`.
-- Changes: opening/current/next generation samples active board colors after maintenance cleanup.
-- Changes: accuracy = `successfulShots / shotsFired`.
+**Produces:** playable opening/future colors, post-row ordering, true hit-rate accuracy.
 
-- [ ] **Step 1: Add the floating-only opening-color regression**
+- [ ] **Step 1: Add floating-only opening-color regression**
+
+Use config colors red/blue. Stub `initializeGrid()` to produce a top-connected red bubble and isolated blue bubble, then call `onGameStart()` with `Math.random=0`. Assert cleanup removes blue before queue generation and both current/next are red.
+
+Concrete final assertions:
 
 ```ts
-it('removes floating-only colors before generating the opening queue', () => {
-    const game = makeGame({ colors: [0xff0000, 0x0000ff] })
+expect(stateOf(game).grid[2][5]).toBeNull()
+expect(stateOf(game).bubblesRemaining).toBe(1)
+expect(stateOf(game).currentBubble?.color).toBe(0xff0000)
+expect(stateOf(game).nextBubble?.color).toBe(0xff0000)
+```
+
+- [ ] **Step 2: Add exact post-row cleanup/reconcile regression**
+
+```ts
+it('drops an unsupported color before reconciling nextBubble', () => {
+    const game = makeGame({
+        colors: [0xff0000, 0x0000ff],
+        rowAddInterval: 5,
+        newRowFillChance: 0.5,
+    })
     const grid = Array.from(
         { length: CONSTANTS.GRID_HEIGHT },
         (_, row) =>
             Array.from(
-                {
-                    length: getRowColumnCount(row, 0, CONSTANTS),
-                },
+                { length: getRowColumnCount(row, 0, CONSTANTS) },
                 () => null
             )
     )
+    grid[0][0] = { color: 0xff0000, x: bubbleX(0, 0), y: bubbleY(0) }
+    grid[0][12] = { color: 0x0000ff, x: bubbleX(12, 0), y: bubbleY(0) }
 
-    grid[0][0] = {
-        color: 0xff0000,
-        x: bubbleX(0, 0),
-        y: bubbleY(0),
-    }
-    grid[2][5] = {
-        color: 0x0000ff,
-        x: bubbleX(5, 2),
-        y: bubbleY(2),
-    }
-
-    const internal = game as unknown as {
-        initializeGrid: () => void
-        onGameStart: () => void
-    }
-    vi.spyOn(internal, 'initializeGrid').mockImplementation(() => {
-        setState(game, {
-            grid,
-            rowPhase: 0,
-            bubblesRemaining: 2,
-            currentBubble: null,
-            nextBubble: null,
-        })
+    setState(game, {
+        grid,
+        rowPhase: 0,
+        bubblesRemaining: 2,
+        shotCount: 4,
+        projectile: {
+            x: bubbleX(1, 0),
+            y: bubbleY(0),
+            vx: 0,
+            vy: -720,
+            color: 0xff0000,
+        },
+        nextBubble: { color: 0x0000ff },
     })
-    vi.spyOn(Math, 'random').mockReturnValue(0)
 
-    internal.onGameStart()
+    let randomCall = 0
+    vi.spyOn(Math, 'random').mockImplementation(() => {
+        randomCall++
+        if (randomCall === 1 || randomCall === 2 || randomCall === 15) {
+            return 0
+        }
+        return 1
+    })
 
-    expect(stateOf(game).grid[2][5]).toBeNull()
-    expect(stateOf(game).bubblesRemaining).toBe(1)
-    expect(stateOf(game).currentBubble?.color).toBe(0xff0000)
+    game.attachBubble({ kind: 'ceiling' })
+
+    expect(
+        stateOf(game).grid.flat().some(
+            bubble => bubble?.color === 0x0000ff
+        )
+    ).toBe(false)
+    expect(stateOf(game).bubblesRemaining).toBe(
+        countGrid(stateOf(game).grid)
+    )
     expect(stateOf(game).nextBubble?.color).toBe(0xff0000)
 })
 ```
 
-- [ ] **Step 2: Add active-color and accuracy regressions**
+The random sequence fills only new top-row col 0 red, leaves all other new top cells empty, then selects red when nextBubble is rerolled.
+
+- [ ] **Step 3: Add active-color and accuracy regressions**
 
 ```ts
-it('returns active colors and falls back to config on an empty board', () => {
-    const game = makeGame()
-    const internal = game as unknown as {
-        getAvailableBubbleColors: () => number[]
-    }
-
-    setState(game, {
-        grid: [[
-            { color: 0xff0000, x: bubbleX(0, 0), y: bubbleY(0) },
-            { color: 0x00ff00, x: bubbleX(1, 0), y: bubbleY(0) },
-        ]],
-    })
-    expect(internal.getAvailableBubbleColors().sort()).toEqual(
-        [0xff0000, 0x00ff00].sort()
-    )
-
-    setState(game, { grid: [] })
-    expect(internal.getAvailableBubbleColors()).toEqual(CONSTANTS.COLORS)
-})
-
-it('reports accuracy from successful shots', () => {
+it('reports successful-shot accuracy', () => {
     const game = makeGame()
     setState(game, {
         shotsFired: 10,
         successfulShots: 6,
         bubblesPopped: 18,
     })
-
     expect(game.getGameStats().accuracy).toBe(60)
 })
 ```
 
-- [ ] **Step 3: Add the post-row cleanup/reconcile ordering regression**
+Also assert `getAvailableBubbleColors()` returns unique board colors and falls back to `config.colors` on an empty grid.
 
-Create a deterministic interval-shot board where a color becomes unsupported after row mutation/cleanup. Assert after resolution:
-
-```ts
-expect(
-    stateOf(game).grid.flat().some(
-        bubble => bubble?.color === isolatedColor
-    )
-).toBe(false)
-expect(stateOf(game).bubblesRemaining).toBe(
-    countGrid(stateOf(game).grid)
-)
-expect(stateOf(game).nextBubble?.color).not.toBe(isolatedColor)
-```
-
-Use a concrete `const isolatedColor = 0x0000ff` in the committed test.
-
-- [ ] **Step 4: Verify tests fail**
+- [ ] **Step 4: Verify red**
 
 ```bash
-bun run test:run src/lib/games/bubble-shooter/BubbleShooterGame.test.ts -t "opening queue|active colors|accuracy|reconcile"
+bun run test:run src/lib/games/bubble-shooter/BubbleShooterGame.test.ts -t "opening|reconciling|successful-shot"
 ```
 
-Expected: FAIL because generation still uses the full configured palette and accuracy still uses popped bubbles.
-
-- [ ] **Step 5: Implement active-board color selection**
+- [ ] **Step 5: Implement active colors**
 
 ```ts
 private getAvailableBubbleColors(): number[] {
@@ -1632,9 +1156,7 @@ private getAvailableBubbleColors(): number[] {
     for (const row of this.state.grid) {
         for (let col = 0; col < row.length; col++) {
             const bubble = row[col]
-            if (bubble) {
-                colors.add(bubble.color)
-            }
+            if (bubble) colors.add(bubble.color)
         }
     }
     return colors.size > 0 ? [...colors] : [...this.config.colors]
@@ -1650,47 +1172,16 @@ private reconcileNextBubbleColor(): void {
         !this.state.nextBubble ||
         !colors.includes(this.state.nextBubble.color)
     ) {
-        this.state.nextBubble = {
-            color: this.randomColor(colors),
-        }
+        this.state.nextBubble = { color: this.randomColor(colors) }
     }
 }
 ```
 
-Use `randomColor(this.getAvailableBubbleColors())` in `generateBubble()` and `generateNextBubble()`.
+`generateBubble()`/`generateNextBubble()` use active colors. `initializeGrid()` still uses one fixed `config.colors` snapshot.
 
-`initializeGrid()` continues using `const generationColors = [...this.config.colors]` so partially generated cells do not feed back into initial generation.
+`addNewRow()` snapshots `getAvailableBubbleColors()` before calling `addRowAtTop()`, then performs connectivity cleanup/count sync. `attachBubble()` calls `reconcileNextBubbleColor()` exactly once after match resolution and any row insertion.
 
-- [ ] **Step 6: Snapshot active colors before added-row mutation**
-
-Change `addNewRow()` to:
-
-```ts
-private addNewRow(constants: GameConstants): void {
-    const generationColors = this.getAvailableBubbleColors()
-    this.addRowAtTop(constants, generationColors)
-    this.removeUnsupportedBubbles(constants)
-    this.syncBubbleCount()
-
-    if (this.checkGameOverCondition(constants)) {
-        this.state.needsRedraw = true
-    }
-}
-```
-
-Do not reconcile queue state inside `addRowAtTop()` or `addNewRow()`.
-
-At the end of `attachBubble`, after direct/drop resolution and any interval row insertion, call:
-
-```ts
-this.reconcileNextBubbleColor()
-```
-
-exactly once before final redraw/game-over completion. Never reroll `currentBubble`.
-
-- [ ] **Step 7: Switch statistics to successful-shot accuracy**
-
-In `getGameStats()`:
+- [ ] **Step 6: Switch accuracy and game data**
 
 ```ts
 const accuracy =
@@ -1699,18 +1190,13 @@ const accuracy =
         : 0
 ```
 
-Return `successfulShots` and include it in `getGameData()`.
+Include `successfulShots` in returned stats and `getGameData()`.
 
-- [ ] **Step 8: Verify and commit**
+- [ ] **Step 7: Verify green and commit**
 
 ```bash
 bun run test:run src/lib/games/bubble-shooter/BubbleShooterGame.test.ts
 bun run typecheck
-```
-
-Expected: PASS and typecheck exits 0.
-
-```bash
 git add src/lib/games/bubble-shooter/BubbleShooterGame.ts \
   src/lib/games/bubble-shooter/BubbleShooterGame.test.ts
 git commit -m "fix: keep bubble shooter colors and stats playable"
@@ -1718,37 +1204,48 @@ git commit -m "fix: keep bubble shooter colors and stats playable"
 
 ---
 
-### Task 7: Clear previews and align Bubble Shooter rules
+### Task 7: Clear previews and align rules
 
 **Files:**
 - Modify: `src/lib/games/bubble-shooter/initFramework.ts`
-- Modify: `src/lib/games/bubble-shooter/initFramework.test.ts`
 - Modify: `src/pages/bubble-shooter/index.astro`
-- Modify: `src/pages/game-board-markup.test.ts`
+- Test: `src/lib/games/bubble-shooter/initFramework.test.ts`
+- Test: `src/pages/game-board-markup.test.ts`
 
-**Interfaces:**
-- Consumes: BaseGame restart behavior from Task 1; no Bubble Shooter start-handler reset workaround is added.
-- Produces: null-aware preview drawing and `resetPreviewState()`.
-- Changes: page rules use configured `rowAddInterval`.
+**Produces:** null-safe preview canvases and accurate rules copy. No Bubble Shooter-local ended-run start workaround.
 
-- [ ] **Step 1: Extend initializer mock state**
+- [ ] **Step 1: Give preview canvases separate test contexts**
 
-Add:
+In `initFramework.test.ts`, replace the shared context with:
 
 ```ts
-rowPhase: 0,
-successfulShots: 0,
+const currentBubbleCtx = {
+    fillRect: vi.fn(),
+    fillStyle: '',
+}
+const nextBubbleCtx = {
+    fillRect: vi.fn(),
+    fillStyle: '',
+}
+
+Object.defineProperty(currentBubble, 'getContext', {
+    value: vi.fn(() => currentBubbleCtx),
+    writable: true,
+})
+Object.defineProperty(nextBubble, 'getContext', {
+    value: vi.fn(() => nextBubbleCtx),
+    writable: true,
+})
 ```
 
-Keep existing pointer/RAF mock behavior.
+Expose/store those two objects in the test setup scope so assertions can reference them directly.
 
-- [ ] **Step 2: Add a failing null-preview regression**
+- [ ] **Step 2: Add null-preview regression**
 
-Capture `onStateChange`, invoke it once with colors and once with both colors null. Assert each preview canvas is cleared for both states while bubble drawing only occurs for the colored state.
-
-A concrete assertion pattern:
+After initialization, capture the constructor callbacks and call:
 
 ```ts
+const baseState = gameMock.getState()
 callbacksArg.onStateChange({
     ...baseState,
     currentBubble: { x: 300, y: 700, color: 0xff0000 },
@@ -1760,21 +1257,17 @@ callbacksArg.onStateChange({
     nextBubble: null,
 })
 
-expect(currentContext.fillRect).toHaveBeenCalledTimes(2)
-expect(nextContext.fillRect).toHaveBeenCalledTimes(2)
+expect(currentBubbleCtx.fillRect).toHaveBeenCalledTimes(2)
+expect(nextBubbleCtx.fillRect).toHaveBeenCalledTimes(2)
 ```
 
-Use separate mocked contexts for current/next canvases so the assertions are not ambiguous.
-
-- [ ] **Step 3: Verify preview test fails**
+- [ ] **Step 3: Verify red**
 
 ```bash
 bun run test:run src/lib/games/bubble-shooter/initFramework.test.ts -t "preview"
 ```
 
-Expected: FAIL because undefined colors currently return before clearing the canvas.
-
-- [ ] **Step 4: Consolidate preview drawing**
+- [ ] **Step 4: Consolidate null-aware preview drawing**
 
 ```ts
 const drawBubblePreview = (
@@ -1782,15 +1275,11 @@ const drawBubblePreview = (
     context: CanvasRenderingContext2D | null,
     color: number | undefined
 ): void => {
-    if (!context) {
-        return
-    }
+    if (!context) return
 
     context.fillStyle = 'rgba(0, 0, 0, 0.1)'
     context.fillRect(0, 0, canvas.width, canvas.height)
-    if (color === undefined) {
-        return
-    }
+    if (color === undefined) return
 
     const centerX = canvas.width / 2
     const centerY = canvas.height / 2
@@ -1805,30 +1294,18 @@ const drawBubblePreview = (
 }
 ```
 
-Track cached colors as `number | undefined`. Add:
+Cache colors as `number | undefined`; clear/redraw when defined or undefined changes. Explicit reset/restart handlers clear both preview caches/canvases. Do not alter `startHandler` for ended runs; Task 1 owns that behavior.
 
-```ts
-const resetPreviewState = (): void => {
-    lastCurrentColor = undefined
-    lastNextColor = undefined
-    drawBubblePreview(currentBubbleCanvas, currentBubbleCtx, undefined)
-    drawBubblePreview(nextBubbleCanvas, nextBubbleCtx, undefined)
-}
-```
+- [ ] **Step 5: Render rules from configuration**
 
-Call it from explicit reset/restart handlers and the returned `restart()` function. Do not add reset logic to `startHandler`; Task 1 makes `BaseGame.start()` own ended-run reset.
-
-- [ ] **Step 5: Update rules from the configured interval**
-
-In Astro frontmatter:
+Astro frontmatter:
 
 ```astro
 import { DEFAULT_BUBBLE_SHOOTER_CONFIG } from '@/lib/games/bubble-shooter/BubbleShooterGame'
-
 const rowAddInterval = DEFAULT_BUBBLE_SHOOTER_CONFIG.rowAddInterval
 ```
 
-Render:
+Rules:
 
 ```astro
 <p>• Match 3+ bubbles of the same color</p>
@@ -1838,9 +1315,7 @@ Render:
 <p>• Accuracy counts shots that clear bubbles</p>
 ```
 
-- [ ] **Step 6: Pin rule-source markup**
-
-In `game-board-markup.test.ts`, load `src/pages/bubble-shooter/index.astro` and assert:
+- [ ] **Step 6: Pin rule source**
 
 ```ts
 expect(bubbleShooterMarkup).toContain(
@@ -1854,18 +1329,13 @@ expect(bubbleShooterMarkup).not.toContain(
 )
 ```
 
-- [ ] **Step 7: Verify and commit**
+- [ ] **Step 7: Verify green and commit**
 
 ```bash
 bun run test:run \
   src/lib/games/bubble-shooter/initFramework.test.ts \
   src/pages/game-board-markup.test.ts
 bun run typecheck
-```
-
-Expected: PASS and typecheck exits 0.
-
-```bash
 git add src/lib/games/bubble-shooter/initFramework.ts \
   src/lib/games/bubble-shooter/initFramework.test.ts \
   src/pages/bubble-shooter/index.astro \
@@ -1875,17 +1345,11 @@ git commit -m "fix: align bubble shooter previews and rules"
 
 ---
 
-### Task 8: Verify the complete single-PR implementation
+### Task 8: Verify the complete PR
 
-**Files:**
-- Review every file in the File Map.
-- Modify only when a verification command exposes a concrete defect.
+**Files:** Review every file in the File Map; change only concrete defects found by verification.
 
-**Interfaces:**
-- Verifies: `docs/superpowers/specs/2026-08-10-bubble-shooter-mechanics-correction-design.md`.
-- Produces: no new feature scope.
-
-- [ ] **Step 1: Run focused Bubble Shooter and core tests**
+- [ ] **Step 1: Focused tests**
 
 ```bash
 bun run test:run \
@@ -1899,16 +1363,16 @@ bun run test:run \
 
 Expected: PASS.
 
-- [ ] **Step 2: Search for stale state/signatures/fallbacks**
+- [ ] **Step 2: Stale-contract search**
 
 ```bash
 rg -n "rowOffset|isValidAttachPosition" src/lib/games/bubble-shooter
 rg -n "getBubbleX|getBubbleY|getNeighbors" src/lib/games/bubble-shooter
 ```
 
-Expected: no `rowOffset` or `isValidAttachPosition`; manually confirm every geometry call uses the phase-aware signatures.
+Expected: first command returns no matches; every helper call uses the new signatures.
 
-- [ ] **Step 3: Verify the critical lifecycle and unit contracts**
+- [ ] **Step 3: Framework/unit contract search**
 
 ```bash
 rg -n "gameStarted && this.state.isGameOver|elapsed time in seconds" \
@@ -1917,65 +1381,38 @@ rg -n "deltaTimeSeconds|/ 1_000" \
   src/lib/games/bubble-shooter/initFramework.ts
 ```
 
-Expected: BaseGame contains the ended-run reset guard and seconds documentation; Bubble Shooter RAF converts milliseconds to seconds.
+Expected: restart guard + seconds documentation exist; Bubble Shooter RAF converts milliseconds to seconds.
 
-- [ ] **Step 4: Run full unit suite**
+- [ ] **Step 4: Full unit suite**
 
 ```bash
 bun run test:run
 ```
 
-Expected: PASS with zero failed tests.
+Expected: zero failed tests.
 
-- [ ] **Step 5: Run typecheck**
+- [ ] **Step 5: Static validation**
 
 ```bash
 bun run typecheck
-```
-
-Expected: exit 0.
-
-- [ ] **Step 6: Run lint**
-
-```bash
 bun run lint
-```
-
-Expected: zero lint errors.
-
-- [ ] **Step 7: Run format check**
-
-```bash
 bun run format:check
-```
-
-Expected: exit 0.
-
-- [ ] **Step 8: Run production build**
-
-```bash
 bun run build
 ```
 
-Expected: exit 0.
+Expected: all commands exit 0; lint has zero errors.
 
-- [ ] **Step 9: Run existing Bubble Shooter happy-path E2E coverage**
-
-```bash
-bunx playwright test e2e/games/play-coverage.spec.ts --grep "bubble-shooter|Bubble Shooter"
-```
-
-If the shared play-coverage suite does not expose a title matching that grep, run the complete file instead:
+- [ ] **Step 6: Existing game E2E coverage**
 
 ```bash
 bunx playwright test e2e/games/play-coverage.spec.ts
 ```
 
-Expected: Bubble Shooter start → play → end/restart path passes.
+Expected: shared game happy-path suite passes, including Bubble Shooter.
 
-- [ ] **Step 10: Review score-era impact without adding migration scope**
+- [ ] **Step 7: Confirm score-era disclosure in PR body**
 
-Confirm the PR description notes:
+Add/retain this note:
 
 ```text
 Bubble Shooter now awards points for dropped unsupported bubbles and reports
@@ -1983,49 +1420,33 @@ successful-shot accuracy, so historical and new leaderboard rows may represent
 different scoring/stat semantics. No score migration/versioning is included.
 ```
 
-- [ ] **Step 11: Inspect final diff against scope**
+- [ ] **Step 8: Final scope diff**
 
 ```bash
 git diff --stat main...HEAD
 git diff --name-only main...HEAD
 ```
 
-Expected production changes are limited to:
+Expected production/test files are exactly the File Map plus the existing design/plan documents. `BubbleShooterRenderer.ts` should not appear.
 
-```text
-src/lib/games/core/BaseGame.ts
-src/lib/games/core/core.test.ts
-src/lib/games/bubble-shooter/types.ts
-src/lib/games/bubble-shooter/utils.ts
-src/lib/games/bubble-shooter/utils.test.ts
-src/lib/games/bubble-shooter/BubbleShooterGame.ts
-src/lib/games/bubble-shooter/BubbleShooterGame.test.ts
-src/lib/games/bubble-shooter/initFramework.ts
-src/lib/games/bubble-shooter/initFramework.test.ts
-src/pages/bubble-shooter/index.astro
-src/pages/game-board-markup.test.ts
-```
+- [ ] **Step 9: Update draft PR validation**
 
-plus the existing design/plan documents.
-
-- [ ] **Step 12: Update the draft PR validation checklist**
-
-Mark checks complete only from the fresh outputs above. Keep the PR draft until every required check passes.
+Mark checklist items complete only from the fresh command outputs above. Keep the PR draft until all required checks pass.
 
 ---
 
 ## Plan Self-Review
 
-- Every design requirement maps to a task: core restart/time units (Task 1), geometry/counts (Task 2), physics (Task 3), attachment (Task 4), connectivity/drops (Task 5), colors/accuracy (Task 6), previews/rules (Task 7), full verification (Task 8).
-- Existing geometry tests are explicitly rewritten in Task 2; no obsolete helper signatures survive that commit.
-- The phase-aware helper migration and all production callers are one atomic commit, so per-commit CI is compile-safe.
-- `removeUnsupportedBubbles(constants): GridPosition[]` has one unambiguous contract and no count-sync side effect.
-- Dense-array invariants use indexed checks rather than callbacks that skip holes.
-- Opening queue generation occurs only after startup connectivity cleanup.
-- Added-row queue reconciliation occurs only after row mutation, connectivity cleanup, and count sync.
-- Blocked attachment consumes a shot but cannot trigger game over except through the existing danger-zone condition.
-- The substep regression uses 4000px/s so it fails without substeps; it does not merely test the 50ms clamp.
-- Bubble Shooter uses seconds, matching the shared `BaseGame.update` contract and Evader precedent.
-- Connectivity/drop work is separate from active-color/accuracy work for cleaner review boundaries.
-- Scoring-era comparability is documented as a risk; no migration scope is added.
-- No `TBD`, `TODO`, compatibility shim, shared hex abstraction, or unrelated refactor is planned.
+- F1: restart behavior is owned by `BaseGame.start()`; no fifth Bubble Shooter initializer workaround.
+- F2: blocked impact consumes the projectile and interval shot but only danger-zone detection can end the run.
+- F3: tunneling test uses 4000px/s × 0.05s = 200px, so it fails without substeps.
+- F4: shared `deltaTime` unit is seconds; Bubble Shooter converts RAF milliseconds to seconds and clamps inside game logic.
+- Existing geometry suites are rewritten in the same atomic commit as helper/caller migration.
+- Dense rows are checked by index, so sparse holes cannot silently pass.
+- `removeUnsupportedBubbles()` has one exact return contract and no count-sync side effect.
+- Startup cleanup precedes active-color opening queue generation.
+- Added-row cleanup/count sync precedes next-bubble reconciliation.
+- Connectivity/drops are a separate commit from colors/accuracy.
+- Board centering is explicitly tested against projectile wall bounds.
+- Score-era comparability is disclosed without adding migration scope.
+- No `TBD`, `TODO`, undefined symbolic test variables, compatibility shim, shared hex abstraction, or unrelated refactor remains in the plan.

--- a/docs/superpowers/plans/2026-08-10-bubble-shooter-mechanics-correction.md
+++ b/docs/superpowers/plans/2026-08-10-bubble-shooter-mechanics-correction.md
@@ -1,0 +1,1740 @@
+# HPA-121 Bubble Shooter Mechanics Correction Implementation Plan
+
+> **For agentic workers:** REQUIRED SUB-SKILL: Use superpowers:subagent-driven-development (recommended) or superpowers:executing-plans to implement this plan task-by-task. Steps use checkbox (`- [ ]`) syntax for tracking.
+
+**Goal:** Correct Bubble Shooter hex geometry, projectile simulation, legal attachment, match resolution, run lifecycle, statistics, and rules in one implementation PR.
+
+**Architecture:** Keep the current `BaseGame` + Pixi renderer + initializer boundaries. Add phase-aware pure geometry helpers in `utils.ts`; keep state transitions and board algorithms in `BubbleShooterGame.ts`; keep DOM lifecycle and preview behavior in `initFramework.ts`. No new production module or dependency is required.
+
+**Tech Stack:** Astro 5, TypeScript, PixiJS 8, Vitest/jsdom, Playwright, Bun 1.3.1.
+
+## Global Constraints
+
+- Deliver every task on branch `agent/hpa-121-bubble-shooter-mechanics` in the same draft PR.
+- Track the work under Linear issue `HPA-121`.
+- Do not modify `BaseGame` behavior or unrelated games.
+- Do not add a physics engine, grid dependency, source abstraction, animation, asset, sound, power-up, level, or difficulty feature.
+- Treat `projectileSpeed` as pixels per second and set the default to exactly `720`.
+- Clamp one projectile update to exactly `50ms` and limit one collision substep to at most `bubbleRadius / 2` travel.
+- Keep `MATCH_THRESHOLD = 3`, `POINTS_PER_BUBBLE = 10`, and `ALL_CLEAR_BONUS = 1000`.
+- Count both direct matches and ceiling-disconnected drops in shot score, `bubblesPopped`, and `largestCombo`.
+- Count one `successfulShot` only when the newly attached bubble creates a direct same-color match of at least three.
+- Preserve the already-previewed current bubble; only reconcile future `nextBubble` colors after board resolution.
+- Use deterministic grids or stubbed `Math.random` in tests.
+- Do not preserve backward compatibility for the internal `rowOffset` state field or old utility signatures.
+
+---
+
+## File map
+
+### Production files
+
+- `src/lib/games/bubble-shooter/types.ts`
+  - Add `RowPhase` and `successfulShots`.
+  - Remove `rowOffset`.
+  - Clarify that `projectileSpeed` is pixels per second.
+- `src/lib/games/bubble-shooter/utils.ts`
+  - Own physical row parity, row width, centered coordinates, and phase-aware neighbors.
+- `src/lib/games/bubble-shooter/BubbleShooterGame.ts`
+  - Own coordinate synchronization, projectile substeps, legal attachment, board counts, ceiling connectivity, match resolution, active colors, score, and statistics.
+- `src/lib/games/bubble-shooter/initFramework.ts`
+  - Own clean ended-run start behavior and null-aware preview clearing.
+- `src/pages/bubble-shooter/index.astro`
+  - Render the configured row interval and corrected rules.
+
+### Test files
+
+- `src/lib/games/bubble-shooter/utils.test.ts`
+  - Cover phase-aware geometry and neighbor invariants.
+- `src/lib/games/bubble-shooter/BubbleShooterGame.test.ts`
+  - Cover row insertion, physics, legal attachment, match/drop behavior, colors, counts, and statistics.
+- `src/lib/games/bubble-shooter/initFramework.test.ts`
+  - Cover ended-run reset and preview clearing while retaining pointer/RAF tests.
+- `src/pages/game-board-markup.test.ts`
+  - Pin Bubble Shooter rule-copy wiring.
+
+No change is planned for `BubbleShooterRenderer.ts`; it should continue rendering state coordinates without calculating grid geometry.
+
+---
+
+### Task 1: Introduce phase-aware centered hex geometry
+
+**Files:**
+- Modify: `src/lib/games/bubble-shooter/types.ts:1-75`
+- Modify: `src/lib/games/bubble-shooter/utils.ts:1-75`
+- Modify: `src/lib/games/bubble-shooter/utils.test.ts:1-150`
+
+**Interfaces:**
+- Produces: `RowPhase = 0 | 1`
+- Produces: `getRowParity(row: number, rowPhase: RowPhase): RowPhase`
+- Produces: `getRowColumnCount(row: number, rowPhase: RowPhase, constants: GameConstants): number`
+- Produces: `getBubbleX(col: number, row: number, rowPhase: RowPhase, constants: GameConstants): number`
+- Produces: `getBubbleY(row: number, constants: GameConstants): number`
+- Produces: `getNeighbors(row: number, col: number, rowPhase: RowPhase, constants: GameConstants): GridPosition[]`
+
+- [ ] **Step 1: Write failing geometry tests**
+
+Update imports in `utils.test.ts` to include `getRowParity` and `getRowColumnCount`, then replace the old coordinate/neighbor cases with phase-aware assertions. Keep the existing color and canvas-drawing tests.
+
+```ts
+import {
+    pixiColorToHex,
+    getRowParity,
+    getRowColumnCount,
+    getBubbleX,
+    getBubbleY,
+    getNeighbors,
+    drawBubbleOnCanvas,
+} from './utils'
+
+describe('phase-aware hex geometry', () => {
+    it('alternates physical parity from the top-row phase', () => {
+        expect(getRowParity(0, 0)).toBe(0)
+        expect(getRowParity(1, 0)).toBe(1)
+        expect(getRowParity(0, 1)).toBe(1)
+        expect(getRowParity(1, 1)).toBe(0)
+    })
+
+    it('uses fourteen cells for full rows and thirteen for offset rows', () => {
+        expect(getRowColumnCount(0, 0, constants)).toBe(14)
+        expect(getRowColumnCount(1, 0, constants)).toBe(13)
+        expect(getRowColumnCount(0, 1, constants)).toBe(13)
+        expect(getRowColumnCount(1, 1, constants)).toBe(14)
+    })
+
+    it('centers both row shapes in the 600px board', () => {
+        expect(getBubbleX(0, 0, 0, constants)).toBe(40)
+        expect(getBubbleX(13, 0, 0, constants)).toBe(560)
+        expect(getBubbleX(0, 0, 1, constants)).toBe(60)
+        expect(getBubbleX(12, 0, 1, constants)).toBe(540)
+    })
+
+    it('keeps every neighbor exactly one diameter away', () => {
+        const origin = { row: 5, col: 5 }
+        const originPoint = {
+            x: getBubbleX(origin.col, origin.row, 1, constants),
+            y: getBubbleY(origin.row, constants),
+        }
+
+        for (const neighbor of getNeighbors(
+            origin.row,
+            origin.col,
+            1,
+            constants
+        )) {
+            const neighborPoint = {
+                x: getBubbleX(neighbor.col, neighbor.row, 1, constants),
+                y: getBubbleY(neighbor.row, constants),
+            }
+            expect(
+                Math.hypot(
+                    neighborPoint.x - originPoint.x,
+                    neighborPoint.y - originPoint.y
+                )
+            ).toBeCloseTo(constants.BUBBLE_RADIUS * 2)
+        }
+    })
+})
+```
+
+- [ ] **Step 2: Run the geometry test and verify it fails**
+
+Run:
+
+```bash
+bun run test:run src/lib/games/bubble-shooter/utils.test.ts
+```
+
+Expected: FAIL because `getRowParity` and `getRowColumnCount` do not exist and the old helper signatures do not accept `rowPhase`.
+
+- [ ] **Step 3: Add `RowPhase` and replace geometry helpers**
+
+In `types.ts`, add:
+
+```ts
+export type RowPhase = 0 | 1
+```
+
+In `utils.ts`, import `RowPhase` and implement:
+
+```ts
+import type { GameConstants, GridPosition, RowPhase } from './types'
+
+export function getRowParity(
+    row: number,
+    rowPhase: RowPhase
+): RowPhase {
+    return ((row + rowPhase) % 2) as RowPhase
+}
+
+export function getRowColumnCount(
+    row: number,
+    rowPhase: RowPhase,
+    constants: GameConstants
+): number {
+    return constants.GRID_WIDTH - getRowParity(row, rowPhase)
+}
+
+export function getBubbleX(
+    col: number,
+    row: number,
+    rowPhase: RowPhase,
+    constants: GameConstants
+): number {
+    const diameter = constants.BUBBLE_RADIUS * 2
+    const boardWidth = constants.GRID_WIDTH * diameter
+    const boardLeft = (constants.GAME_WIDTH - boardWidth) / 2
+    const parity = getRowParity(row, rowPhase)
+
+    return (
+        boardLeft +
+        constants.BUBBLE_RADIUS +
+        parity * constants.BUBBLE_RADIUS +
+        col * diameter
+    )
+}
+
+export function getBubbleY(
+    row: number,
+    constants: GameConstants
+): number {
+    return (
+        constants.BUBBLE_RADIUS +
+        row * constants.BUBBLE_RADIUS * Math.sqrt(3)
+    )
+}
+
+export function getNeighbors(
+    row: number,
+    col: number,
+    rowPhase: RowPhase,
+    constants: GameConstants
+): GridPosition[] {
+    const parity = getRowParity(row, rowPhase)
+    const offsets =
+        parity === 0
+            ? [
+                  [-1, -1],
+                  [-1, 0],
+                  [0, -1],
+                  [0, 1],
+                  [1, -1],
+                  [1, 0],
+              ]
+            : [
+                  [-1, 0],
+                  [-1, 1],
+                  [0, -1],
+                  [0, 1],
+                  [1, 0],
+                  [1, 1],
+              ]
+
+    return offsets.flatMap(([rowDelta, colDelta]) => {
+        const neighborRow = row + rowDelta
+        const neighborCol = col + colDelta
+        if (
+            neighborRow < 0 ||
+            neighborRow >= constants.GRID_HEIGHT ||
+            neighborCol < 0 ||
+            neighborCol >=
+                getRowColumnCount(neighborRow, rowPhase, constants)
+        ) {
+            return []
+        }
+        return [{ row: neighborRow, col: neighborCol }]
+    })
+}
+```
+
+Keep `pixiColorToHex` and `drawBubbleOnCanvas` unchanged.
+
+- [ ] **Step 4: Run the geometry test and verify it passes**
+
+Run:
+
+```bash
+bun run test:run src/lib/games/bubble-shooter/utils.test.ts
+```
+
+Expected: PASS.
+
+- [ ] **Step 5: Commit the geometry unit**
+
+```bash
+git add src/lib/games/bubble-shooter/types.ts \
+  src/lib/games/bubble-shooter/utils.ts \
+  src/lib/games/bubble-shooter/utils.test.ts
+git commit -m "fix: make bubble shooter grid phase aware"
+```
+
+---
+
+### Task 2: Make grid state and row insertion obey geometry invariants
+
+**Files:**
+- Modify: `src/lib/games/bubble-shooter/types.ts:35-70`
+- Modify: `src/lib/games/bubble-shooter/BubbleShooterGame.ts:1-610`
+- Modify: `src/lib/games/bubble-shooter/BubbleShooterGame.test.ts:1-650`
+
+**Interfaces:**
+- Consumes: all Task 1 geometry helpers.
+- Produces: `BubbleShooterState.rowPhase: RowPhase`.
+- Produces: `refreshBubbleCoordinates(constants: GameConstants): void`.
+- Produces: `syncBubbleCount(): number`.
+- Preserves: `grid` as the authoritative board representation.
+
+- [ ] **Step 1: Add failing row-insertion and count-invariant tests**
+
+Add test helpers near `stateOf` in `BubbleShooterGame.test.ts`:
+
+```ts
+function expectedOccupiedCount(state: BubbleShooterState): number {
+    return state.grid.reduce(
+        (total, row) => total + row.filter(Boolean).length,
+        0
+    )
+}
+
+function expectGridCoordinatesToMatchState(
+    game: BubbleShooterGame
+): void {
+    const state = stateOf(game)
+    const constants = game.getConstantsView()
+
+    state.grid.forEach((row, rowIndex) => {
+        expect(row).toHaveLength(
+            getRowColumnCount(rowIndex, state.rowPhase, constants)
+        )
+        row.forEach((bubble, colIndex) => {
+            if (!bubble) {
+                return
+            }
+            expect(bubble.x).toBe(
+                getBubbleX(
+                    colIndex,
+                    rowIndex,
+                    state.rowPhase,
+                    constants
+                )
+            )
+            expect(bubble.y).toBeCloseTo(
+                getBubbleY(rowIndex, constants)
+            )
+        })
+    })
+    expect(state.bubblesRemaining).toBe(expectedOccupiedCount(state))
+}
+```
+
+Add deterministic insertion coverage:
+
+```ts
+it('preserves physical layout through two inserted rows', () => {
+    vi.spyOn(Math, 'random').mockReturnValue(0)
+    const game = makeGame({ newRowFillChance: 1 })
+    game.start()
+
+    const internal = game as unknown as {
+        addRowAtTop: (constants: GameConstants) => void
+    }
+    const constants = game.getConstantsView()
+
+    expect(stateOf(game).rowPhase).toBe(0)
+    expectGridCoordinatesToMatchState(game)
+
+    internal.addRowAtTop(constants)
+    expect(stateOf(game).rowPhase).toBe(1)
+    expectGridCoordinatesToMatchState(game)
+
+    internal.addRowAtTop(constants)
+    expect(stateOf(game).rowPhase).toBe(0)
+    expectGridCoordinatesToMatchState(game)
+})
+```
+
+- [ ] **Step 2: Update test call sites to the Task 1 signatures**
+
+Add local wrappers to reduce repeated phase arguments:
+
+```ts
+const bubbleX = (
+    col: number,
+    row: number,
+    rowPhase: RowPhase = 0
+): number => getBubbleX(col, row, rowPhase, CONSTANTS)
+
+const bubbleY = (row: number): number => getBubbleY(row, CONSTANTS)
+
+const neighbors = (
+    row: number,
+    col: number,
+    rowPhase: RowPhase = 0
+): GridPosition[] => getNeighbors(row, col, rowPhase, CONSTANTS)
+```
+
+Replace all old direct calls in `BubbleShooterGame.test.ts` with these wrappers. Verify no stale signatures remain:
+
+```bash
+rg -n "getBubbleX\([^,]+,[^,]+, CONSTANTS|getBubbleY\([^,]+, 0, CONSTANTS|getNeighbors\([^,]+,[^,]+, CONSTANTS" src/lib/games/bubble-shooter
+```
+
+Expected: no matches.
+
+- [ ] **Step 3: Run the game tests and verify the new invariant test fails**
+
+```bash
+bun run test:run src/lib/games/bubble-shooter/BubbleShooterGame.test.ts
+```
+
+Expected: FAIL because state lacks `rowPhase`, coordinates still use logical `row % 2`, and row lengths are not normalized after insertion.
+
+- [ ] **Step 4: Add row phase and authoritative synchronization**
+
+In `types.ts`, replace `rowOffset` with:
+
+```ts
+rowPhase: RowPhase
+```
+
+In `createInitialState()` initialize:
+
+```ts
+rowPhase: 0,
+```
+
+Add these private methods in `BubbleShooterGame.ts`:
+
+```ts
+private refreshBubbleCoordinates(constants: GameConstants): void {
+    for (let row = 0; row < constants.GRID_HEIGHT; row++) {
+        const columnCount = getRowColumnCount(
+            row,
+            this.state.rowPhase,
+            constants
+        )
+        const gridRow = this.state.grid[row] ?? []
+        gridRow.length = columnCount
+        this.state.grid[row] = gridRow
+
+        for (let col = 0; col < columnCount; col++) {
+            const bubble = gridRow[col]
+            if (!bubble) {
+                continue
+            }
+            bubble.x = getBubbleX(
+                col,
+                row,
+                this.state.rowPhase,
+                constants
+            )
+            bubble.y = getBubbleY(row, constants)
+        }
+    }
+}
+
+private syncBubbleCount(): number {
+    const count = this.state.grid.reduce(
+        (total, row) => total + row.filter(Boolean).length,
+        0
+    )
+    this.state.bubblesRemaining = count
+    return count
+}
+```
+
+Update `initializeGrid()` to use `getRowColumnCount`, the new coordinate signatures, and finish with:
+
+```ts
+this.refreshBubbleCoordinates(constants)
+this.syncBubbleCount()
+this.state.needsRedraw = true
+```
+
+Update every production call to `getBubbleX`, `getBubbleY`, and `getNeighbors` to pass `this.state.rowPhase`.
+
+Replace `addRowAtTop()` with phase-aware shifting:
+
+```ts
+private addRowAtTop(constants: GameConstants): void {
+    for (let row = constants.GRID_HEIGHT - 1; row > 0; row--) {
+        this.state.grid[row] = this.state.grid[row - 1]
+            ? [...this.state.grid[row - 1]]
+            : []
+    }
+
+    this.state.rowPhase = this.state.rowPhase === 0 ? 1 : 0
+    const columnCount = getRowColumnCount(
+        0,
+        this.state.rowPhase,
+        constants
+    )
+    this.state.grid[0] = Array.from({ length: columnCount }, () => {
+        if (Math.random() >= this.config.newRowFillChance) {
+            return null
+        }
+        return {
+            color: this.randomAvailableColor(),
+            x: 0,
+            y: 0,
+        }
+    })
+
+    this.refreshBubbleCoordinates(constants)
+    this.syncBubbleCount()
+    this.state.needsRedraw = true
+}
+```
+
+At this task, implement `randomAvailableColor()` as a private helper that chooses from `config.colors`; Task 5 will change its source to active board colors:
+
+```ts
+private randomAvailableColor(): number {
+    const colors = this.config.colors
+    return colors[Math.floor(Math.random() * colors.length)]
+}
+```
+
+- [ ] **Step 5: Run geometry and game tests**
+
+```bash
+bun run test:run \
+  src/lib/games/bubble-shooter/utils.test.ts \
+  src/lib/games/bubble-shooter/BubbleShooterGame.test.ts
+```
+
+Expected: PASS after updating existing expectations for centered coordinates and `rowPhase`.
+
+- [ ] **Step 6: Commit the board invariant unit**
+
+```bash
+git add src/lib/games/bubble-shooter/types.ts \
+  src/lib/games/bubble-shooter/BubbleShooterGame.ts \
+  src/lib/games/bubble-shooter/BubbleShooterGame.test.ts
+git commit -m "fix: preserve bubble shooter row geometry"
+```
+
+---
+
+### Task 3: Make projectile movement elapsed-time based and collision safe
+
+**Files:**
+- Modify: `src/lib/games/bubble-shooter/types.ts:55-70`
+- Modify: `src/lib/games/bubble-shooter/BubbleShooterGame.ts:20-380`
+- Modify: `src/lib/games/bubble-shooter/BubbleShooterGame.test.ts:220-360`
+
+**Interfaces:**
+- Produces: `updateProjectile(deltaTimeMs: number): boolean`.
+- Produces: `reflectProjectileOffWalls(constants: GameConstants): void`.
+- Changes: `BubbleShooterConfig.projectileSpeed` is pixels per second.
+- Keeps: projectile `vx` and `vy` in pixels per second.
+
+- [ ] **Step 1: Write failing refresh-rate and wall-bound tests**
+
+Add a deterministic simulation helper:
+
+```ts
+function simulateProjectileForOneSecond(frameCount: number): number {
+    const game = makeGame({
+        gameHeight: 12_000,
+        shooterY: 10_000,
+        projectileSpeed: 720,
+    })
+    setState(game, {
+        projectile: {
+            x: 300,
+            y: 5_000,
+            vx: 0,
+            vy: -720,
+            color: 0xff0000,
+        },
+        grid: Array.from({ length: CONSTANTS.GRID_HEIGHT }, () => []),
+    })
+
+    for (let frame = 0; frame < frameCount; frame++) {
+        game.updateProjectile(1_000 / frameCount)
+    }
+    return stateOf(game).projectile?.y ?? Number.NaN
+}
+
+it('moves the same distance at 30Hz, 60Hz, and 120Hz', () => {
+    const at30Hz = simulateProjectileForOneSecond(30)
+    const at60Hz = simulateProjectileForOneSecond(60)
+    const at120Hz = simulateProjectileForOneSecond(120)
+
+    expect(at30Hz).toBeCloseTo(4_280, 5)
+    expect(at60Hz).toBeCloseTo(at30Hz, 5)
+    expect(at120Hz).toBeCloseTo(at30Hz, 5)
+})
+
+it('reflects position and velocity inside the right wall', () => {
+    const game = makeGame({ projectileSpeed: 720 })
+    setState(game, {
+        projectile: {
+            x: CONSTANTS.GAME_WIDTH - CONSTANTS.BUBBLE_RADIUS - 2,
+            y: 400,
+            vx: 720,
+            vy: 0,
+            color: 0xff0000,
+        },
+        grid: Array.from({ length: CONSTANTS.GRID_HEIGHT }, () => []),
+    })
+
+    game.updateProjectile(16)
+
+    const projectile = stateOf(game).projectile
+    expect(projectile?.x).toBeLessThanOrEqual(
+        CONSTANTS.GAME_WIDTH - CONSTANTS.BUBBLE_RADIUS
+    )
+    expect(projectile?.vx).toBeLessThan(0)
+})
+```
+
+- [ ] **Step 2: Run the focused tests and verify they fail**
+
+```bash
+bun run test:run src/lib/games/bubble-shooter/BubbleShooterGame.test.ts -t "30Hz|right wall"
+```
+
+Expected: FAIL because `updateProjectile` ignores elapsed time and can leave `x` outside the legal range.
+
+- [ ] **Step 3: Convert speed and implement bounded substeps**
+
+Update the default:
+
+```ts
+projectileSpeed: 720,
+```
+
+Update the config comment in `types.ts`:
+
+```ts
+projectileSpeed: number // pixels per second
+```
+
+Add constants near the scoring constants:
+
+```ts
+const MAX_PROJECTILE_FRAME_MS = 50
+const MAX_PROJECTILE_SUBSTEP_RATIO = 0.5
+```
+
+Pass RAF time through `update`:
+
+```ts
+update(deltaTime: number): void {
+    if (
+        !this.state.isActive ||
+        this.state.isPaused ||
+        this.state.isGameOver
+    ) {
+        return
+    }
+
+    this.updateProjectile(deltaTime)
+
+    if (this.state.needsRedraw) {
+        this.emitStateChange()
+    }
+}
+```
+
+Implement substeps:
+
+```ts
+updateProjectile(deltaTimeMs: number): boolean {
+    const projectile = this.state.projectile
+    if (!projectile) {
+        return false
+    }
+
+    const constants = this.getConstantsView()
+    const clampedMs = Math.min(
+        Math.max(deltaTimeMs, 0),
+        MAX_PROJECTILE_FRAME_MS
+    )
+    const elapsedSeconds = clampedMs / 1_000
+    const speed = Math.hypot(projectile.vx, projectile.vy)
+    const maxSubstepDistance =
+        constants.BUBBLE_RADIUS * MAX_PROJECTILE_SUBSTEP_RATIO
+    const substepCount = Math.max(
+        1,
+        Math.ceil((speed * elapsedSeconds) / maxSubstepDistance)
+    )
+    const substepSeconds = elapsedSeconds / substepCount
+
+    for (let step = 0; step < substepCount; step++) {
+        projectile.x += projectile.vx * substepSeconds
+        projectile.y += projectile.vy * substepSeconds
+        this.reflectProjectileOffWalls(constants)
+
+        const anchor = this.checkBubbleCollision()
+        if (anchor) {
+            return this.attachBubble({ kind: 'bubble', anchor })
+        }
+        if (projectile.y <= constants.BUBBLE_RADIUS) {
+            return this.attachBubble({ kind: 'ceiling' })
+        }
+    }
+
+    if (clampedMs > 0) {
+        this.state.needsRedraw = true
+    }
+    return false
+}
+```
+
+Task 4 defines the final `ProjectileImpact` type and `attachBubble` signature. During this task, add the union type and adapt the existing attachment function without changing candidate behavior yet so the physics commit compiles.
+
+Add wall reflection:
+
+```ts
+private reflectProjectileOffWalls(constants: GameConstants): void {
+    const projectile = this.state.projectile
+    if (!projectile) {
+        return
+    }
+
+    const minX = constants.BUBBLE_RADIUS
+    const maxX = constants.GAME_WIDTH - constants.BUBBLE_RADIUS
+
+    if (projectile.x < minX) {
+        projectile.x = minX + (minX - projectile.x)
+        projectile.vx = Math.abs(projectile.vx)
+    } else if (projectile.x > maxX) {
+        projectile.x = maxX - (projectile.x - maxX)
+        projectile.vx = -Math.abs(projectile.vx)
+    }
+
+    projectile.x = Math.min(maxX, Math.max(minX, projectile.x))
+}
+```
+
+- [ ] **Step 4: Update existing projectile tests to pass milliseconds**
+
+Every direct call must pass an elapsed time. Use `16` for one nominal frame unless a test explicitly exercises another rate:
+
+```ts
+game.updateProjectile(16)
+```
+
+Update expected one-frame travel from raw velocity to velocity multiplied by `0.016`.
+
+- [ ] **Step 5: Run Bubble Shooter game tests**
+
+```bash
+bun run test:run src/lib/games/bubble-shooter/BubbleShooterGame.test.ts
+```
+
+Expected: PASS.
+
+- [ ] **Step 6: Commit the physics unit**
+
+```bash
+git add src/lib/games/bubble-shooter/types.ts \
+  src/lib/games/bubble-shooter/BubbleShooterGame.ts \
+  src/lib/games/bubble-shooter/BubbleShooterGame.test.ts
+git commit -m "fix: make bubble shooter physics time based"
+```
+
+---
+
+### Task 4: Restrict attachment to legal impact-local cells
+
+**Files:**
+- Modify: `src/lib/games/bubble-shooter/BubbleShooterGame.ts:300-500`
+- Modify: `src/lib/games/bubble-shooter/BubbleShooterGame.test.ts:360-520`
+
+**Interfaces:**
+- Consumes: `ProjectileImpact` introduced in Task 3.
+- Produces: `attachBubble(impact: ProjectileImpact): boolean`.
+- Produces: `findAttachPosition(constants: GameConstants, impact: ProjectileImpact): GridPosition | null`.
+- Produces: `findClosestEmptyPosition(constants: GameConstants, candidates: GridPosition[]): GridPosition | null`.
+- Removes: whole-board candidate search, `isValidAttachPosition`, and occupied top-center fallback.
+
+- [ ] **Step 1: Write failing legal-attachment tests**
+
+Add these cases:
+
+```ts
+it('attaches a bubble impact only beside its anchor', () => {
+    const game = makeGame()
+    const anchor = { row: 4, col: 4 }
+    const grid = Array.from(
+        { length: CONSTANTS.GRID_HEIGHT },
+        () => [] as BubbleShooterState['grid'][number]
+    )
+    grid[anchor.row] = Array(
+        getRowColumnCount(anchor.row, 0, CONSTANTS)
+    ).fill(null)
+    grid[anchor.row][anchor.col] = {
+        color: 0x00ff00,
+        x: bubbleX(anchor.col, anchor.row),
+        y: bubbleY(anchor.row),
+    }
+
+    setState(game, {
+        grid,
+        rowPhase: 0,
+        projectile: {
+            x: bubbleX(anchor.col, anchor.row) + 5,
+            y: bubbleY(anchor.row) + 30,
+            vx: 0,
+            vy: -720,
+            color: 0xff0000,
+        },
+        bubblesRemaining: 1,
+    })
+
+    game.attachBubble({ kind: 'bubble', anchor })
+
+    const redCells = neighbors(anchor.row, anchor.col).filter(
+        ({ row, col }) => stateOf(game).grid[row]?.[col]?.color === 0xff0000
+    )
+    expect(redCells).toHaveLength(1)
+})
+
+it('never overwrites a full board when no legal cell exists', () => {
+    const game = makeGame()
+    const grid = Array.from(
+        { length: CONSTANTS.GRID_HEIGHT },
+        (_, row) =>
+            Array.from(
+                {
+                    length: getRowColumnCount(row, 0, CONSTANTS),
+                },
+                (_, col) => ({
+                    color: 0xff0000,
+                    x: bubbleX(col, row),
+                    y: bubbleY(row),
+                })
+            )
+    )
+    const before = JSON.stringify(grid)
+    const endSpy = vi.spyOn(game, 'end').mockResolvedValue(undefined)
+
+    setState(game, {
+        isActive: true,
+        grid,
+        rowPhase: 0,
+        projectile: {
+            x: 300,
+            y: CONSTANTS.BUBBLE_RADIUS,
+            vx: 0,
+            vy: -720,
+            color: 0x00ff00,
+        },
+        bubblesRemaining: expectedOccupiedCount({
+            ...stateOf(game),
+            grid,
+        }),
+    })
+
+    expect(game.attachBubble({ kind: 'ceiling' })).toBe(true)
+    expect(JSON.stringify(stateOf(game).grid)).toBe(before)
+    expect(endSpy).toHaveBeenCalledTimes(1)
+    expect(stateOf(game).projectile).toBeNull()
+})
+```
+
+Use a local `countGrid(grid)` helper rather than constructing a synthetic state if TypeScript rejects the second `expectedOccupiedCount` call:
+
+```ts
+const countGrid = (grid: BubbleShooterState['grid']): number =>
+    grid.reduce((total, row) => total + row.filter(Boolean).length, 0)
+```
+
+- [ ] **Step 2: Run the attachment tests and verify they fail**
+
+```bash
+bun run test:run src/lib/games/bubble-shooter/BubbleShooterGame.test.ts -t "only beside|never overwrites"
+```
+
+Expected: FAIL because the current fallback searches unrelated cells and can replace row-zero center.
+
+- [ ] **Step 3: Replace global attachment search**
+
+Define the private union near the top of `BubbleShooterGame.ts`:
+
+```ts
+type ProjectileImpact =
+    | { kind: 'ceiling' }
+    | { kind: 'bubble'; anchor: GridPosition }
+```
+
+Implement candidate selection:
+
+```ts
+private findAttachPosition(
+    constants: GameConstants,
+    impact: ProjectileImpact
+): GridPosition | null {
+    const projectile = this.state.projectile
+    if (!projectile) {
+        return null
+    }
+
+    const candidates =
+        impact.kind === 'bubble'
+            ? getNeighbors(
+                  impact.anchor.row,
+                  impact.anchor.col,
+                  this.state.rowPhase,
+                  constants
+              )
+            : Array.from(
+                  {
+                      length: getRowColumnCount(
+                          0,
+                          this.state.rowPhase,
+                          constants
+                      ),
+                  },
+                  (_, col) => ({ row: 0, col })
+              )
+
+    return this.findClosestEmptyPosition(constants, candidates)
+}
+
+private findClosestEmptyPosition(
+    constants: GameConstants,
+    candidates: GridPosition[]
+): GridPosition | null {
+    const projectile = this.state.projectile
+    if (!projectile) {
+        return null
+    }
+
+    let closest: GridPosition | null = null
+    let closestDistance = Number.POSITIVE_INFINITY
+
+    for (const candidate of candidates) {
+        if (this.state.grid[candidate.row]?.[candidate.col]) {
+            continue
+        }
+        const candidatePoint = {
+            x: getBubbleX(
+                candidate.col,
+                candidate.row,
+                this.state.rowPhase,
+                constants
+            ),
+            y: getBubbleY(candidate.row, constants),
+        }
+        const candidateDistance = distance(projectile, candidatePoint)
+        if (candidateDistance < closestDistance) {
+            closest = candidate
+            closestDistance = candidateDistance
+        }
+    }
+
+    return closest
+}
+```
+
+Update `attachBubble`:
+
+```ts
+attachBubble(impact: ProjectileImpact): boolean {
+    const projectile = this.state.projectile
+    if (!projectile) {
+        return false
+    }
+
+    const constants = this.getConstantsView()
+    const attachPosition = this.findAttachPosition(constants, impact)
+    if (
+        !attachPosition ||
+        this.state.grid[attachPosition.row]?.[attachPosition.col]
+    ) {
+        this.state.projectile = null
+        this.state.needsRedraw = true
+        this.end().catch(error =>
+            console.error('BubbleShooter end failed', error)
+        )
+        return true
+    }
+
+    const row =
+        this.state.grid[attachPosition.row] ??
+        Array(
+            getRowColumnCount(
+                attachPosition.row,
+                this.state.rowPhase,
+                constants
+            )
+        ).fill(null)
+    this.state.grid[attachPosition.row] = row
+    row[attachPosition.col] = {
+        color: projectile.color,
+        x: getBubbleX(
+            attachPosition.col,
+            attachPosition.row,
+            this.state.rowPhase,
+            constants
+        ),
+        y: getBubbleY(attachPosition.row, constants),
+    }
+    this.syncBubbleCount()
+
+    // Keep the existing match, interval-row, game-over, and projectile-clear
+    // flow here. Task 5 replaces its match-resolution portion.
+}
+```
+
+Remove the old whole-board candidate construction, `isValidAttachPosition`, and fallback object.
+
+- [ ] **Step 4: Add a delayed-frame collision regression**
+
+Create an occupied anchor directly in the projectile path, call `updateProjectile(500)`, and assert that the clamped/substepped update attaches beside that anchor rather than passing through it:
+
+```ts
+it('does not tunnel through a bubble on a delayed frame', () => {
+    const game = makeGame({ projectileSpeed: 720 })
+    const anchor = { row: 8, col: 6 }
+    const grid = Array.from(
+        { length: CONSTANTS.GRID_HEIGHT },
+        () => [] as BubbleShooterState['grid'][number]
+    )
+    grid[anchor.row] = Array(
+        getRowColumnCount(anchor.row, 0, CONSTANTS)
+    ).fill(null)
+    grid[anchor.row][anchor.col] = {
+        color: 0x00ff00,
+        x: bubbleX(anchor.col, anchor.row),
+        y: bubbleY(anchor.row),
+    }
+
+    setState(game, {
+        grid,
+        rowPhase: 0,
+        projectile: {
+            x: bubbleX(anchor.col, anchor.row),
+            y: bubbleY(anchor.row) + 60,
+            vx: 0,
+            vy: -720,
+            color: 0xff0000,
+        },
+        bubblesRemaining: 1,
+    })
+
+    game.updateProjectile(500)
+
+    expect(stateOf(game).projectile).toBeNull()
+    expect(
+        neighbors(anchor.row, anchor.col).some(
+            ({ row, col }) =>
+                stateOf(game).grid[row]?.[col]?.color === 0xff0000
+        )
+    ).toBe(true)
+})
+```
+
+- [ ] **Step 5: Run Bubble Shooter game tests**
+
+```bash
+bun run test:run src/lib/games/bubble-shooter/BubbleShooterGame.test.ts
+```
+
+Expected: PASS.
+
+- [ ] **Step 6: Commit the attachment unit**
+
+```bash
+git add src/lib/games/bubble-shooter/BubbleShooterGame.ts \
+  src/lib/games/bubble-shooter/BubbleShooterGame.test.ts
+git commit -m "fix: restrict bubble shooter attachment cells"
+```
+
+---
+
+### Task 5: Resolve direct matches, dropped clusters, active colors, and true accuracy
+
+**Files:**
+- Modify: `src/lib/games/bubble-shooter/types.ts:25-75`
+- Modify: `src/lib/games/bubble-shooter/BubbleShooterGame.ts:80-620`
+- Modify: `src/lib/games/bubble-shooter/BubbleShooterGame.test.ts:80-650`
+
+**Interfaces:**
+- Produces: `ShotResolution` inside `BubbleShooterGame.ts`.
+- Produces: `successfulShots` in state, stats, and game data.
+- Produces: `collectColorCluster`, `collectCeilingConnected`, `removeUnsupportedBubbles`, `resolveMatches`, `getAvailableBubbleColors`, and `reconcileNextBubbleColor` private methods.
+- Changes: `randomAvailableColor()` chooses from active board colors with the configured palette as fallback.
+
+- [ ] **Step 1: Write failing drop, accuracy, and active-color tests**
+
+Add a direct-match-plus-drop case:
+
+```ts
+it('scores direct matches and bubbles disconnected from the ceiling', () => {
+    const game = makeGame({ rowAddInterval: 99 })
+    const grid = Array.from(
+        { length: CONSTANTS.GRID_HEIGHT },
+        (_, row) =>
+            Array(
+                getRowColumnCount(row, 0, CONSTANTS)
+            ).fill(null) as BubbleShooterState['grid'][number]
+    )
+
+    grid[0][0] = { color: 0xff0000, x: bubbleX(0, 0), y: bubbleY(0) }
+    grid[0][1] = { color: 0xff0000, x: bubbleX(1, 0), y: bubbleY(0) }
+    grid[1][0] = { color: 0x0000ff, x: bubbleX(0, 1), y: bubbleY(1) }
+
+    setState(game, {
+        grid,
+        rowPhase: 0,
+        projectile: {
+            x: bubbleX(2, 0),
+            y: bubbleY(0),
+            vx: 0,
+            vy: -720,
+            color: 0xff0000,
+        },
+        bubblesRemaining: 3,
+        shotsFired: 1,
+        successfulShots: 0,
+        score: 0,
+    })
+
+    game.attachBubble({ kind: 'ceiling' })
+
+    const state = stateOf(game)
+    expect(countGrid(state.grid)).toBe(0)
+    expect(state.bubblesPopped).toBe(4)
+    expect(state.largestCombo).toBe(4)
+    expect(state.successfulShots).toBe(1)
+    expect(state.score).toBe(1_040)
+    expect(game.getGameStats().accuracy).toBe(100)
+})
+```
+
+Add active-color coverage through the private helper:
+
+```ts
+it('uses active grid colors and configured colors after an all-clear', () => {
+    const game = makeGame()
+    const internal = game as unknown as {
+        getAvailableBubbleColors: () => number[]
+    }
+
+    setState(game, {
+        grid: [[
+            { color: 0xff0000, x: bubbleX(0, 0), y: bubbleY(0) },
+            { color: 0x00ff00, x: bubbleX(1, 0), y: bubbleY(0) },
+        ]],
+    })
+    expect(internal.getAvailableBubbleColors().sort()).toEqual(
+        [0xff0000, 0x00ff00].sort()
+    )
+
+    setState(game, { grid: [] })
+    expect(internal.getAvailableBubbleColors()).toEqual(CONSTANTS.COLORS)
+})
+```
+
+Update existing accuracy tests to set `successfulShots`, and assert that eight popped bubbles across ten shots does not define accuracy:
+
+```ts
+setState(game, {
+    shotsFired: 10,
+    successfulShots: 6,
+    bubblesPopped: 18,
+})
+expect(game.getGameStats().accuracy).toBe(60)
+```
+
+- [ ] **Step 2: Run focused tests and verify they fail**
+
+```bash
+bun run test:run src/lib/games/bubble-shooter/BubbleShooterGame.test.ts -t "disconnected|active grid colors|accuracy"
+```
+
+Expected: FAIL because unsupported bubbles remain, active colors are not scanned, and accuracy still uses popped bubbles.
+
+- [ ] **Step 3: Add state/stat contracts**
+
+In `types.ts`, add `successfulShots: number` to:
+
+- `BubbleShooterState`,
+- `BubbleShooterEndGameStats`,
+- `BubbleShooterStats`.
+
+Initialize it to zero in `createInitialState()` and include it in `getGameData()`.
+
+Replace accuracy calculation with:
+
+```ts
+const accuracy =
+    shotsFired > 0
+        ? (this.state.successfulShots / shotsFired) * 100
+        : 0
+```
+
+Return `accuracy` and `successfulShots` from `getGameStats()`.
+
+- [ ] **Step 4: Implement graph helpers and shot resolution**
+
+Add key serialization helpers inside the class methods using `${row},${col}`. Implement same-color collection:
+
+```ts
+private collectColorCluster(
+    start: GridPosition,
+    constants: GameConstants
+): GridPosition[] {
+    const startBubble = this.state.grid[start.row]?.[start.col]
+    if (!startBubble) {
+        return []
+    }
+
+    const result: GridPosition[] = []
+    const visited = new Set<string>()
+    const pending: GridPosition[] = [start]
+
+    while (pending.length > 0) {
+        const current = pending.pop()!
+        const key = `${current.row},${current.col}`
+        if (visited.has(key)) {
+            continue
+        }
+        visited.add(key)
+
+        const bubble = this.state.grid[current.row]?.[current.col]
+        if (!bubble || bubble.color !== startBubble.color) {
+            continue
+        }
+        result.push(current)
+        pending.push(
+            ...getNeighbors(
+                current.row,
+                current.col,
+                this.state.rowPhase,
+                constants
+            )
+        )
+    }
+
+    return result
+}
+```
+
+Implement ceiling reachability:
+
+```ts
+private collectCeilingConnected(
+    constants: GameConstants
+): Set<string> {
+    const connected = new Set<string>()
+    const pending: GridPosition[] = []
+    const topColumnCount = getRowColumnCount(
+        0,
+        this.state.rowPhase,
+        constants
+    )
+
+    for (let col = 0; col < topColumnCount; col++) {
+        if (this.state.grid[0]?.[col]) {
+            pending.push({ row: 0, col })
+        }
+    }
+
+    while (pending.length > 0) {
+        const current = pending.pop()!
+        const key = `${current.row},${current.col}`
+        if (connected.has(key) || !this.state.grid[current.row]?.[current.col]) {
+            continue
+        }
+        connected.add(key)
+        pending.push(
+            ...getNeighbors(
+                current.row,
+                current.col,
+                this.state.rowPhase,
+                constants
+            )
+        )
+    }
+
+    return connected
+}
+```
+
+Implement unsupported removal:
+
+```ts
+private removeUnsupportedBubbles(
+    constants: GameConstants
+): GridPosition[] {
+    const connected = this.collectCeilingConnected(constants)
+    const removed: GridPosition[] = []
+
+    for (let row = 0; row < this.state.grid.length; row++) {
+        for (let col = 0; col < this.state.grid[row].length; col++) {
+            if (
+                this.state.grid[row][col] &&
+                !connected.has(`${row},${col}`)
+            ) {
+                this.state.grid[row][col] = null
+                removed.push({ row, col })
+            }
+        }
+    }
+
+    this.syncBubbleCount()
+    return removed
+}
+```
+
+Replace `checkMatches` with:
+
+```ts
+private resolveMatches(
+    attached: GridPosition,
+    constants: GameConstants
+): ShotResolution {
+    const directMatches = this.collectColorCluster(attached, constants)
+    if (directMatches.length < MATCH_THRESHOLD) {
+        return { directMatches: [], dropped: [], removedCount: 0 }
+    }
+
+    this.removeBubbles(directMatches)
+    const dropped = this.removeUnsupportedBubbles(constants)
+    const removedCount = directMatches.length + dropped.length
+
+    this.addScore(removedCount * POINTS_PER_BUBBLE, 'bubble_pop')
+    this.state.successfulShots++
+    this.state.bubblesPopped += removedCount
+    this.state.largestCombo = Math.max(
+        this.state.largestCombo,
+        removedCount
+    )
+    this.syncBubbleCount()
+
+    if (this.state.bubblesRemaining === 0) {
+        this.addScore(ALL_CLEAR_BONUS, 'all_clear')
+    }
+    this.state.needsRedraw = true
+
+    return { directMatches, dropped, removedCount }
+}
+```
+
+Call `resolveMatches(attachPosition, constants)` immediately after attachment. Call `removeUnsupportedBubbles(constants)` without score/stat updates after `initializeGrid()` and after `addRowAtTop()` so retained state always satisfies ceiling connectivity.
+
+- [ ] **Step 5: Implement active-color queue reconciliation**
+
+Add:
+
+```ts
+private getAvailableBubbleColors(): number[] {
+    const colors = new Set<number>()
+    for (const row of this.state.grid) {
+        for (const bubble of row) {
+            if (bubble) {
+                colors.add(bubble.color)
+            }
+        }
+    }
+    return colors.size > 0 ? [...colors] : [...this.config.colors]
+}
+
+private randomAvailableColor(): number {
+    const colors = this.getAvailableBubbleColors()
+    return colors[Math.floor(Math.random() * colors.length)]
+}
+
+private reconcileNextBubbleColor(): void {
+    const colors = this.getAvailableBubbleColors()
+    if (
+        !this.state.nextBubble ||
+        !colors.includes(this.state.nextBubble.color)
+    ) {
+        this.state.nextBubble = {
+            color: colors[Math.floor(Math.random() * colors.length)],
+        }
+    }
+}
+```
+
+Use `randomAvailableColor()` in `generateBubble`, `generateNextBubble`, initial row creation, and new row creation. After match resolution and interval-row insertion, call:
+
+```ts
+this.reconcileNextBubbleColor()
+```
+
+Do not reroll `currentBubble`; it was already previewed to the player.
+
+- [ ] **Step 6: Run game tests**
+
+```bash
+bun run test:run src/lib/games/bubble-shooter/BubbleShooterGame.test.ts
+```
+
+Expected: PASS, including updated all-clear expectations and `successfulShots` fields.
+
+- [ ] **Step 7: Commit the resolution/stat unit**
+
+```bash
+git add src/lib/games/bubble-shooter/types.ts \
+  src/lib/games/bubble-shooter/BubbleShooterGame.ts \
+  src/lib/games/bubble-shooter/BubbleShooterGame.test.ts
+git commit -m "fix: resolve bubble shooter clusters and stats"
+```
+
+---
+
+### Task 6: Reset ended runs, clear previews, and align rules copy
+
+**Files:**
+- Modify: `src/lib/games/bubble-shooter/initFramework.ts:70-540`
+- Modify: `src/lib/games/bubble-shooter/initFramework.test.ts:1-650`
+- Modify: `src/pages/bubble-shooter/index.astro:1-135`
+- Modify: `src/pages/game-board-markup.test.ts:1-60`
+
+**Interfaces:**
+- Consumes: `BubbleShooterState.successfulShots` and `rowPhase` in initializer mocks.
+- Produces: null-aware preview drawing and `resetPreviewState()` local helper.
+- Changes: Start after an ended run calls `reset()` before `start()`.
+- Changes: rules copy reads `DEFAULT_BUBBLE_SHOOTER_CONFIG.rowAddInterval`.
+
+- [ ] **Step 1: Extend initializer mock state**
+
+In `initFramework.test.ts`, add to the mocked `getState()` result:
+
+```ts
+rowPhase: 0,
+successfulShots: 0,
+```
+
+Add `beginPath`, `arc`, `fill`, `stroke`, `strokeStyle`, and `lineWidth` to the canvas context mock so preview drawing can be asserted without replacing `drawBubbleOnCanvas` behavior if the existing utility mock is later narrowed.
+
+- [ ] **Step 2: Write failing ended-run start and preview-clear tests**
+
+Add:
+
+```ts
+it('resets an ended run before starting again', async () => {
+    const { BubbleShooterGame } = await import('./BubbleShooterGame')
+    result = await initBubbleShooterGameFramework()
+    const gameMock = vi.mocked(BubbleShooterGame).mock.results[0].value
+
+    vi.mocked(gameMock.getState).mockReturnValue({
+        ...gameMock.getState(),
+        isActive: false,
+        isGameOver: true,
+        gameStarted: true,
+        score: 500,
+        shotsFired: 8,
+        successfulShots: 4,
+    } as never)
+
+    document.getElementById('start-btn')!.click()
+
+    expect(gameMock.reset).toHaveBeenCalledBefore(gameMock.start)
+    expect(gameMock.start).toHaveBeenCalledTimes(1)
+})
+
+it('clears current and next previews when state resets to null', async () => {
+    const { BubbleShooterGame } = await import('./BubbleShooterGame')
+    const { drawBubbleOnCanvas } = await import('./utils')
+    result = await initBubbleShooterGameFramework()
+    const callbacks = vi.mocked(BubbleShooterGame).mock.calls[0][1] as {
+        onStateChange: (state: unknown) => void
+    }
+
+    callbacks.onStateChange({
+        bubblesRemaining: 2,
+        currentBubble: { color: 0xff0000 },
+        nextBubble: { color: 0x00ff00 },
+    })
+    callbacks.onStateChange({
+        bubblesRemaining: 0,
+        currentBubble: null,
+        nextBubble: null,
+    })
+
+    expect(vi.mocked(drawBubbleOnCanvas)).toHaveBeenCalledTimes(2)
+    const currentContext = (
+        document.getElementById('current-bubble') as HTMLCanvasElement
+    ).getContext('2d')
+    const nextContext = (
+        document.getElementById('next-bubble') as HTMLCanvasElement
+    ).getContext('2d')
+    expect(currentContext?.fillRect).toHaveBeenCalledTimes(2)
+    expect(nextContext?.fillRect).toHaveBeenCalledTimes(2)
+})
+```
+
+- [ ] **Step 3: Run initializer tests and verify they fail**
+
+```bash
+bun run test:run src/lib/games/bubble-shooter/initFramework.test.ts -t "ended run|previews"
+```
+
+Expected: FAIL because Start does not reset and undefined preview colors return before clearing.
+
+- [ ] **Step 4: Make preview drawing null-aware**
+
+Replace the duplicated preview functions with one local helper:
+
+```ts
+const drawBubblePreview = (
+    canvas: HTMLCanvasElement,
+    context: CanvasRenderingContext2D | null,
+    color: number | undefined
+): void => {
+    if (!context) {
+        return
+    }
+
+    context.fillStyle = 'rgba(0, 0, 0, 0.1)'
+    context.fillRect(0, 0, canvas.width, canvas.height)
+    if (color === undefined) {
+        return
+    }
+
+    const centerX = canvas.width / 2
+    const centerY = canvas.height / 2
+    const radius = Math.min(centerX, centerY) - 4
+    drawBubbleOnCanvas(
+        context,
+        centerX,
+        centerY,
+        radius,
+        pixiColorToHex(color)
+    )
+}
+```
+
+Use `number | undefined` caches:
+
+```ts
+let lastCurrentColor: number | undefined
+let lastNextColor: number | undefined
+
+const resetPreviewState = (): void => {
+    lastCurrentColor = undefined
+    lastNextColor = undefined
+    drawBubblePreview(currentBubbleCanvas, currentBubbleCtx, undefined)
+    drawBubblePreview(nextBubbleCanvas, nextBubbleCtx, undefined)
+}
+```
+
+In `onStateChange`, compare both defined and undefined colors and always call `drawBubblePreview` when the value changes.
+
+Call `resetPreviewState()` from reset, restart, the returned `restart()` method, and before resetting an ended run.
+
+- [ ] **Step 5: Reset before starting an ended run**
+
+Replace the Start handler:
+
+```ts
+const startHandler = (): void => {
+    const state = game.getState()
+    if (state.gameStarted && !state.isActive) {
+        game.reset()
+        resetPreviewState()
+        resetButtonVisibility()
+    }
+    game.start()
+}
+```
+
+Pass `resetPreviewState` into `setupButtonHandlers` or define the button setup closure where the helper is in scope. Prefer adding a callback parameter rather than moving unrelated initializer code:
+
+```ts
+function setupButtonHandlers(
+    game: BubbleShooterGame,
+    resetPreviews: () => void
+): () => void
+```
+
+- [ ] **Step 6: Update rules copy and pin it in the page test**
+
+In Astro frontmatter:
+
+```astro
+import { DEFAULT_BUBBLE_SHOOTER_CONFIG } from '@/lib/games/bubble-shooter/BubbleShooterGame'
+
+const rowAddInterval = DEFAULT_BUBBLE_SHOOTER_CONFIG.rowAddInterval
+```
+
+Replace the rules with:
+
+```astro
+<p>• Match 3+ bubbles of the same color</p>
+<p>• Disconnected bubbles fall after a match</p>
+<p>• New row appears every {rowAddInterval} shots</p>
+<p>• Game ends when bubbles reach the danger zone</p>
+<p>• Accuracy counts shots that clear bubbles</p>
+```
+
+In `game-board-markup.test.ts`, load the page once near the other markup constants:
+
+```ts
+const bubbleShooterMarkup = readFileSync(
+    resolve(process.cwd(), 'src/pages/bubble-shooter/index.astro'),
+    'utf-8'
+)
+```
+
+Add:
+
+```ts
+it('keeps Bubble Shooter rules aligned with configured mechanics', () => {
+    expect(bubbleShooterMarkup).toContain(
+        'DEFAULT_BUBBLE_SHOOTER_CONFIG.rowAddInterval'
+    )
+    expect(bubbleShooterMarkup).toContain(
+        'New row appears every {rowAddInterval} shots'
+    )
+    expect(bubbleShooterMarkup).toContain(
+        'Disconnected bubbles fall after a match'
+    )
+    expect(bubbleShooterMarkup).toContain(
+        'Accuracy counts shots that clear bubbles'
+    )
+    expect(bubbleShooterMarkup).not.toContain(
+        'New row appears after each shot'
+    )
+})
+```
+
+- [ ] **Step 7: Run initializer and page tests**
+
+```bash
+bun run test:run \
+  src/lib/games/bubble-shooter/initFramework.test.ts \
+  src/pages/game-board-markup.test.ts
+```
+
+Expected: PASS while the existing pointerdown-before-shooting and RAF tests remain green.
+
+- [ ] **Step 8: Commit the lifecycle/UI unit**
+
+```bash
+git add src/lib/games/bubble-shooter/initFramework.ts \
+  src/lib/games/bubble-shooter/initFramework.test.ts \
+  src/pages/bubble-shooter/index.astro \
+  src/pages/game-board-markup.test.ts
+git commit -m "fix: reset bubble shooter runs and rules"
+```
+
+---
+
+### Task 7: Verify the complete single-PR story
+
+**Files:**
+- Review: all production and test files listed in the file map.
+- Update only when a verification command reveals a concrete issue.
+
+**Interfaces:**
+- Verifies every acceptance criterion from `docs/superpowers/specs/2026-08-10-bubble-shooter-mechanics-correction-design.md`.
+- Produces no new architecture or feature scope.
+
+- [ ] **Step 1: Run all focused Bubble Shooter and page tests**
+
+```bash
+bun run test:run \
+  src/lib/games/bubble-shooter/utils.test.ts \
+  src/lib/games/bubble-shooter/BubbleShooterGame.test.ts \
+  src/lib/games/bubble-shooter/BubbleShooterRenderer.test.ts \
+  src/lib/games/bubble-shooter/initFramework.test.ts \
+  src/pages/game-board-markup.test.ts
+```
+
+Expected: PASS.
+
+- [ ] **Step 2: Search for stale state fields and old helper signatures**
+
+```bash
+rg -n "rowOffset|getBubbleY\([^,]+,[^,]+,[^,]+\)|getBubbleX\([^,]+,[^,]+,[^,]+\)|getNeighbors\([^,]+,[^,]+,[^,]+\)" \
+  src/lib/games/bubble-shooter src/pages/bubble-shooter
+```
+
+Expected:
+
+- no `rowOffset`,
+- no old three-argument `getBubbleX`,
+- no old three-argument `getNeighbors`,
+- no old row-offset `getBubbleY`.
+
+Inspect any matches manually because multiline calls can make regex results approximate; every production/test call must use the Task 1 signatures.
+
+- [ ] **Step 3: Run the full unit suite**
+
+```bash
+bun run test:run
+```
+
+Expected: PASS.
+
+- [ ] **Step 4: Run type and code-quality checks**
+
+```bash
+bun run typecheck
+bun run lint
+bun run format:check
+git diff --check
+```
+
+Expected: all commands exit successfully with no new lint errors, formatting differences, or whitespace errors.
+
+- [ ] **Step 5: Run the production build**
+
+```bash
+bun run build
+```
+
+Expected: successful Astro production build.
+
+- [ ] **Step 6: Run the existing game happy-path E2E coverage**
+
+```bash
+bun run test:e2e -- e2e/games/play-coverage.spec.ts
+```
+
+Expected: PASS for the Bubble Shooter start, play interaction, end, and restart path. If the suite cannot run because the required browser or local database service is unavailable, record the exact command and error in the PR body rather than claiming it passed.
+
+- [ ] **Step 7: Review the diff against the design acceptance criteria**
+
+Use:
+
+```bash
+git diff main...HEAD -- \
+  src/lib/games/bubble-shooter \
+  src/pages/bubble-shooter/index.astro \
+  src/pages/game-board-markup.test.ts
+```
+
+Confirm explicitly:
+
+- phase toggles on each inserted row,
+- every geometry call receives `rowPhase`,
+- movement uses elapsed seconds and bounded substeps,
+- attachment candidates are local to the impact,
+- blocked attachment cannot mutate the grid,
+- counts are scanned after board mutations,
+- direct matches drop unsupported bubbles,
+- maintenance connectivity cleanup does not score,
+- next colors use active board colors,
+- successful-shot accuracy is used,
+- ended runs reset before Start,
+- previews clear on null/reset,
+- page copy matches configuration.
+
+- [ ] **Step 8: Commit only concrete verification fixes**
+
+If formatting or verification required file changes:
+
+```bash
+git add src/lib/games/bubble-shooter \
+  src/pages/bubble-shooter/index.astro \
+  src/pages/game-board-markup.test.ts
+git commit -m "chore: finalize bubble shooter mechanics fix"
+```
+
+If no files changed, do not create an empty commit.
+
+- [ ] **Step 9: Update the draft PR body and Linear issue**
+
+Add the final command results to the PR test plan. Link the PR on `HPA-121`, retain the issue in `In Progress` during implementation, move it to `In Review` only after all required checks pass and the PR is marked ready, and move it to `Done` only after merge.

--- a/docs/superpowers/plans/2026-08-10-bubble-shooter-mechanics-correction.md
+++ b/docs/superpowers/plans/2026-08-10-bubble-shooter-mechanics-correction.md
@@ -2,62 +2,217 @@
 
 > **For agentic workers:** REQUIRED SUB-SKILL: Use superpowers:subagent-driven-development (recommended) or superpowers:executing-plans to implement this plan task-by-task. Steps use checkbox (`- [ ]`) syntax for tracking.
 
-**Goal:** Correct Bubble Shooter hex geometry, projectile simulation, legal attachment, match resolution, run lifecycle, statistics, and rules in one implementation PR.
+**Goal:** Correct Bubble Shooter hex geometry, projectile simulation, legal attachment, cluster removal, queue/stat semantics, restart behavior, previews, and rules in one implementation PR.
 
-**Architecture:** Keep the existing `BaseGame` + Pixi renderer + initializer boundaries. Extend the Bubble Shooter-specific hex helpers in `utils.ts`, keep state transitions and board algorithms in `BubbleShooterGame.ts`, and keep browser lifecycle/preview behavior in `initFramework.ts`. Do not add a production module, dependency, physics engine, shared grid package, or `BaseGame` lifecycle change.
+**Architecture:** Keep Bubble Shooter geometry and mechanics local to its existing module, reuse the shared `distance` helper, and leave the Pixi renderer coordinate-driven. Make two narrowly shared framework corrections in `BaseGame`: an ended-run `start()` resets before starting the next run, and `update(deltaTime)` is explicitly measured in seconds. No physics engine, shared hex-grid package, renderer rewrite, persistence migration, or compatibility layer is added.
 
 **Tech Stack:** Astro 5, TypeScript, PixiJS 8, Vitest/jsdom, Playwright, Bun 1.3.1.
 
 ## Global Constraints
 
-- Deliver every task on branch `agent/hpa-121-bubble-shooter-mechanics` in the same draft PR.
+- Deliver all tasks on branch `agent/hpa-121-bubble-shooter-mechanics` in draft PR #57.
 - Track the work under Linear issue `HPA-121`.
-- Do not change `BaseGame` or unrelated games.
-- Reuse `distance` from `src/lib/games/shared/geometry.ts`; do not reuse the rectangular Bejeweled helpers in `src/lib/games/shared/match3.ts`.
-- Set default `projectileSpeed` to exactly `720` pixels per second.
-- Clamp one projectile update to exactly `50ms`.
-- Limit one projectile collision substep to at most `bubbleRadius / 2` travel.
+- Reuse `distance` from `src/lib/games/shared/geometry.ts`.
+- Do not reuse `src/lib/games/shared/match3.ts`; it models rectangular run matching/gravity, not hex connectivity.
+- Do not add a physics engine, shared grid/graph package, new production module, animation, sound, asset, power-up, level, or difficulty feature.
+- `BaseGame.update(deltaTime)` uses elapsed **seconds**.
+- Set Bubble Shooter default `projectileSpeed` to exactly `720` pixels per second.
+- Clamp one Bubble Shooter projectile update to exactly `0.05` seconds.
+- Limit one Bubble Shooter projectile substep to at most `bubbleRadius / 2` travel.
 - Keep `MATCH_THRESHOLD = 3`, `POINTS_PER_BUBBLE = 10`, and `ALL_CLEAR_BONUS = 1000`.
+- Bubble collision is evaluated before ceiling collision on every projectile substep.
+- A blocked impact consumes the projectile but is not a game-over condition by itself; `checkGameOverCondition()` remains the gameplay game-over authority.
 - Count direct matches and ceiling-disconnected drops in score, `bubblesPopped`, and `largestCombo`.
-- Increment `successfulShots` once only when the newly attached bubble creates a direct same-color group of at least three.
-- Preserve the already-previewed current bubble. Reconcile only the future `nextBubble` after board resolution.
+- Increment `successfulShots` once only when the newly attached bubble creates a direct same-color cluster of at least three.
+- Preserve the already-previewed current bubble; only reconcile future `nextBubble` after all board mutation/cleanup for the shot.
 - Initial-grid generation samples one snapshot of `config.colors`.
 - Added-row generation samples one snapshot of currently active board colors before mutating the board.
-- Board mutation order is explicit: mutate grid → refresh coordinates if row geometry changed → remove unsupported bubbles when required → synchronize `bubblesRemaining` → only then generate or reconcile queue bubbles.
-- `removeUnsupportedBubbles(constants)` returns `GridPosition[]` and never synchronizes counts itself. Callers own the single `syncBubbleCount()` after the mutation sequence.
-- Every planned commit must compile with its production callers; do not commit an intermediate helper-signature change that knowingly leaves `BubbleShooterGame.ts` broken.
-- Tests must use deterministic state or a stubbed `Math.random`.
-- Remove `rowOffset`; no compatibility layer is required for internal state or helper signatures.
+- Board mutation ordering is explicit: mutate grid → refresh coordinates if row geometry changed → remove unsupported bubbles when required → synchronize `bubblesRemaining` → reconcile future queue.
+- `removeUnsupportedBubbles(constants)` returns `GridPosition[]` and does not call `syncBubbleCount()`.
+- Every planned commit must compile with all production callers; no intentionally broken signature-migration commit is allowed.
+- Tests use deterministic board state or stubbed `Math.random`.
+- Remove `rowOffset`; no compatibility layer is required for internal state/helper signatures.
+- Do not remove existing initializer-level restart guards from other games in this PR; the shared BaseGame fix makes them redundant but harmless.
 
 ---
 
 ## File Map
 
-### Production
+### Shared framework
+
+- `src/lib/games/core/BaseGame.ts`
+  - Reset a completed run inside `start()` before beginning the next run.
+  - Document `update(deltaTime)` as elapsed seconds.
+- `src/lib/games/core/core.test.ts`
+  - Regression coverage for ended-run restart and active-start no-op.
+
+### Bubble Shooter production
 
 - `src/lib/games/bubble-shooter/types.ts`
   - Add `RowPhase` and `successfulShots`; remove `rowOffset`; document speed units.
 - `src/lib/games/bubble-shooter/utils.ts`
-  - Calculate physical parity, row width, centered coordinates, and phase-aware neighbors.
+  - Physical parity, row width, centered coordinates, and phase-aware neighbors.
 - `src/lib/games/bubble-shooter/BubbleShooterGame.ts`
-  - Synchronize board state, simulate projectiles, attach legally, resolve matches/drops, choose colors, and calculate statistics.
+  - Dense board normalization, projectile substeps, wall reflection, impact-local attachment, count sync, cluster/drop resolution, active colors, scoring/statistics.
 - `src/lib/games/bubble-shooter/initFramework.ts`
-  - Reset ended runs and clear preview canvases.
+  - Convert RAF milliseconds to seconds; clear preview canvases on null/reset.
 - `src/pages/bubble-shooter/index.astro`
-  - Render rules that match configured behavior.
+  - Render configured row interval and corrected rules.
 
-### Tests
+### Bubble Shooter tests
 
 - `src/lib/games/bubble-shooter/utils.test.ts`
 - `src/lib/games/bubble-shooter/BubbleShooterGame.test.ts`
 - `src/lib/games/bubble-shooter/initFramework.test.ts`
 - `src/pages/game-board-markup.test.ts`
 
-`BubbleShooterRenderer.ts` remains unchanged; it continues drawing the coordinates supplied by game state.
+`src/lib/games/bubble-shooter/BubbleShooterRenderer.ts` remains unchanged.
 
 ---
 
-### Task 1: Make hex geometry and board state phase-aware in one atomic commit
+### Task 1: Fix shared ended-run restart semantics and define delta-time units
+
+**Files:**
+- Modify: `src/lib/games/core/BaseGame.ts`
+- Modify: `src/lib/games/core/core.test.ts`
+
+**Interfaces:**
+- Produces: `BaseGame.start()` resets when `state.gameStarted && state.isGameOver` before setting new-run flags.
+- Produces: `BaseGame.update(deltaTime)` contract = elapsed seconds.
+- Preserves: calling `start()` while already active is a no-op.
+
+- [ ] **Step 1: Add a failing ended-run restart regression**
+
+Inside the existing `BaseGame default hooks` suite, add:
+
+```ts
+it('resets state and score before starting after game over', async () => {
+    const game = new MinimalGame(
+        GameID.QUICK_MATH,
+        {
+            duration: 60,
+            achievementIntegration: false,
+            pausable: true,
+            resettable: true,
+        },
+        {}
+    )
+
+    game.start()
+    game.addScore(75, 'first-run')
+    expect(game.getState().score).toBe(75)
+
+    await game.end()
+    expect(game.getState().isGameOver).toBe(true)
+
+    game.start()
+
+    expect(game.getState()).toMatchObject({
+        score: 0,
+        isActive: true,
+        isGameOver: false,
+        gameStarted: true,
+    })
+    expect(game.getScoreManager().getScore()).toBe(0)
+})
+```
+
+- [ ] **Step 2: Add/retain active-start no-op coverage**
+
+Add a focused assertion if the existing test does not already pin `reset()`:
+
+```ts
+it('does not reset when start is called while already active', () => {
+    const game = new MinimalGame(
+        GameID.QUICK_MATH,
+        {
+            duration: 60,
+            achievementIntegration: false,
+            pausable: true,
+            resettable: true,
+        },
+        {}
+    )
+    const resetSpy = vi.spyOn(game, 'reset')
+
+    game.start()
+    game.start()
+
+    expect(resetSpy).not.toHaveBeenCalled()
+})
+```
+
+- [ ] **Step 3: Verify the ended-run test fails**
+
+```bash
+bun run test:run src/lib/games/core/core.test.ts -t "resets state and score|already active"
+```
+
+Expected: ended-run test FAILS because `start()` currently flips flags without resetting `ScoreManager`/state; active-start test passes.
+
+- [ ] **Step 4: Implement the minimal shared restart fix**
+
+In `BaseGame.start()` keep the active guard first, then reset completed runs:
+
+```ts
+start(): void {
+    if (this.state.isActive) {
+        return
+    }
+
+    if (this.state.gameStarted && this.state.isGameOver) {
+        this.reset()
+    }
+
+    this.runGuard.next()
+    this.state.isActive = true
+    this.state.gameStarted = true
+    this.state.isGameOver = false
+    this.state.isPaused = false
+
+    this.timer.start()
+    this.emit('start')
+
+    if (this.callbacks.onStart) {
+        this.callbacks.onStart()
+    }
+
+    this.onGameStart()
+}
+```
+
+Do not remove the existing reset-before-start guards from 2048/Evader/Reflex/Sudoku in this PR. Their explicit `reset()` changes `gameStarted` back to false, so the BaseGame guard is a no-op when `start()` follows.
+
+- [ ] **Step 5: Document seconds on the abstract update contract**
+
+Replace the bare abstract declaration with:
+
+```ts
+/**
+ * Advance game logic by elapsed time in seconds.
+ */
+abstract update(deltaTime: number): void
+```
+
+- [ ] **Step 6: Verify core tests and typecheck**
+
+```bash
+bun run test:run src/lib/games/core/core.test.ts
+bun run typecheck
+```
+
+Expected: PASS and typecheck exits 0.
+
+- [ ] **Step 7: Commit**
+
+```bash
+git add src/lib/games/core/BaseGame.ts src/lib/games/core/core.test.ts
+git commit -m "fix: reset completed BaseGame runs on start"
+```
+
+---
+
+### Task 2: Make hex geometry and board state phase-aware in one atomic commit
 
 **Files:**
 - Modify: `src/lib/games/bubble-shooter/types.ts`
@@ -68,31 +223,21 @@
 
 **Interfaces:**
 - Produces: `RowPhase = 0 | 1`.
-- Produces: `getRowParity(row, rowPhase)`.
-- Produces: `getRowColumnCount(row, rowPhase, constants)`.
-- Produces: `getBubbleX(col, row, rowPhase, constants)`.
-- Produces: `getBubbleY(row, constants)`.
-- Produces: `getNeighbors(row, col, rowPhase, constants)`.
+- Produces: `getRowParity(row, rowPhase): RowPhase`.
+- Produces: `getRowColumnCount(row, rowPhase, constants): number`.
+- Produces: `getBubbleX(col, row, rowPhase, constants): number`.
+- Produces: `getBubbleY(row, constants): number`.
+- Produces: `getNeighbors(row, col, rowPhase, constants): GridPosition[]`.
 - Produces: `BubbleShooterState.rowPhase`.
-- Produces: `createEmptyRow(row, constants)`, `refreshBubbleCoordinates(constants)`, and `syncBubbleCount()` private helpers.
+- Produces private `createEmptyRow`, `refreshBubbleCoordinates`, `syncBubbleCount`.
 
-- [ ] **Step 1: Rewrite the existing geometry tests for the new API**
+- [ ] **Step 1: Rewrite the existing geometry suites, not just add new tests**
 
-Do not only add a new suite. Delete or rewrite the existing `getBubbleX`, `getBubbleY`, and `getNeighbors` suites that still call the old 3-argument helpers and assert the old left-aligned coordinates.
+Replace the current `getBubbleX`, `getBubbleY`, and `getNeighbors` suites that call the old API. Keep color conversion and canvas-drawing tests.
 
-Use the phase-aware API:
+Use:
 
 ```ts
-import {
-    pixiColorToHex,
-    getRowParity,
-    getRowColumnCount,
-    getBubbleX,
-    getBubbleY,
-    getNeighbors,
-    drawBubbleOnCanvas,
-} from './utils'
-
 describe('phase-aware hex geometry', () => {
     it('derives physical parity and row width from rowPhase', () => {
         expect(getRowParity(0, 0)).toBe(0)
@@ -106,14 +251,17 @@ describe('phase-aware hex geometry', () => {
         expect(getRowColumnCount(1, 1, constants)).toBe(14)
     })
 
-    it('centers full and offset rows in the 600px canvas', () => {
+    it('centers full and offset rows inside projectile wall bounds', () => {
         expect(getBubbleX(0, 0, 0, constants)).toBe(40)
         expect(getBubbleX(13, 0, 0, constants)).toBe(560)
         expect(getBubbleX(0, 0, 1, constants)).toBe(60)
         expect(getBubbleX(12, 0, 1, constants)).toBe(540)
+
+        expect(getBubbleX(0, 0, 0, constants) - constants.BUBBLE_RADIUS).toBe(20)
+        expect(getBubbleX(13, 0, 0, constants) + constants.BUBBLE_RADIUS).toBe(580)
     })
 
-    it('uses row-only vertical geometry', () => {
+    it('uses row-only vertical spacing', () => {
         expect(getBubbleY(0, constants)).toBe(20)
         expect(getBubbleY(1, constants)).toBeCloseTo(
             20 + 20 * Math.sqrt(3)
@@ -148,11 +296,9 @@ describe('phase-aware hex geometry', () => {
 })
 ```
 
-Keep the existing color-conversion and canvas-drawing suites unchanged.
+- [ ] **Step 2: Add test wrappers and a dense-grid invariant**
 
-- [ ] **Step 2: Add a dense-grid invariant assertion before changing production code**
-
-In `BubbleShooterGame.test.ts`, import `RowPhase`, `GridPosition`, and `getRowColumnCount`, and add wrappers:
+In `BubbleShooterGame.test.ts` add:
 
 ```ts
 const bubbleX = (
@@ -199,7 +345,6 @@ function expectGridInvariant(game: BubbleShooterGame): void {
             if (!bubble) {
                 continue
             }
-
             expect(bubble.x).toBe(
                 getBubbleX(
                     col,
@@ -218,7 +363,7 @@ function expectGridInvariant(game: BubbleShooterGame): void {
 }
 ```
 
-The indexed `col in row` and `row[col] !== undefined` checks are required; `forEach`/`every` alone skip sparse holes and do not prove dense rows.
+Indexed checks are required because `Array.forEach`/`every` skip sparse holes.
 
 - [ ] **Step 3: Add a failing two-row insertion regression**
 
@@ -229,24 +374,24 @@ it('preserves dense phase-aware geometry through two inserted rows', () => {
     game.start()
 
     const internal = game as unknown as {
-        addNewRow: (constants: GameConstants) => void
+        addRowAtTop: (constants: GameConstants, colors: number[]) => void
     }
     const constants = game.getConstantsView()
 
     expect(stateOf(game).rowPhase).toBe(0)
     expectGridInvariant(game)
 
-    internal.addNewRow(constants)
+    internal.addRowAtTop(constants, CONSTANTS.COLORS)
     expect(stateOf(game).rowPhase).toBe(1)
     expectGridInvariant(game)
 
-    internal.addNewRow(constants)
+    internal.addRowAtTop(constants, CONSTANTS.COLORS)
     expect(stateOf(game).rowPhase).toBe(0)
     expectGridInvariant(game)
 })
 ```
 
-- [ ] **Step 4: Run both test files and verify the migration fails before implementation**
+- [ ] **Step 4: Verify migration tests fail before production changes**
 
 ```bash
 bun run test:run \
@@ -254,9 +399,9 @@ bun run test:run \
   src/lib/games/bubble-shooter/BubbleShooterGame.test.ts
 ```
 
-Expected: FAIL because the new helpers/signatures and `rowPhase` do not exist and row insertion still leaves stale horizontal geometry.
+Expected: FAIL because phase helpers/signatures/state do not exist and current insertion leaves stale x/parity.
 
-- [ ] **Step 5: Replace the pure geometry API**
+- [ ] **Step 5: Add RowPhase and replace geometry helpers**
 
 In `types.ts`:
 
@@ -264,11 +409,9 @@ In `types.ts`:
 export type RowPhase = 0 | 1
 ```
 
-In `utils.ts`:
+Replace geometry functions in `utils.ts` with:
 
 ```ts
-import type { GameConstants, GridPosition, RowPhase } from './types'
-
 export function getRowParity(
     row: number,
     rowPhase: RowPhase
@@ -341,25 +484,33 @@ export function getNeighbors(
     return offsets.flatMap(([rowDelta, colDelta]) => {
         const neighborRow = row + rowDelta
         const neighborCol = col + colDelta
-        const inBounds =
-            neighborRow >= 0 &&
-            neighborRow < constants.GRID_HEIGHT &&
-            neighborCol >= 0 &&
-            neighborCol <
+        if (
+            neighborRow < 0 ||
+            neighborRow >= constants.GRID_HEIGHT ||
+            neighborCol < 0 ||
+            neighborCol >=
                 getRowColumnCount(neighborRow, rowPhase, constants)
-
-        return inBounds
-            ? [{ row: neighborRow, col: neighborCol }]
-            : []
+        ) {
+            return []
+        }
+        return [{ row: neighborRow, col: neighborCol }]
     })
 }
 ```
 
-Remove the old `rowOffset` parameter and left-aligned coordinate behavior.
+- [ ] **Step 6: Replace `rowOffset` with dense phase-aware state**
 
-- [ ] **Step 6: Add dense-row and count helpers to `BubbleShooterGame`**
+In `BubbleShooterState` replace `rowOffset` with:
 
-Replace `rowOffset` with `rowPhase: RowPhase` in state and initialize it to `0`.
+```ts
+rowPhase: RowPhase
+```
+
+Initialize:
+
+```ts
+rowPhase: 0,
+```
 
 Add:
 
@@ -382,20 +533,20 @@ private createEmptyRow(
 
 private refreshBubbleCoordinates(constants: GameConstants): void {
     for (let row = 0; row < constants.GRID_HEIGHT; row++) {
-        const columnCount = getRowColumnCount(
+        const count = getRowColumnCount(
             row,
             this.state.rowPhase,
             constants
         )
         const previous = this.state.grid[row] ?? []
-        const normalized = Array.from(
-            { length: columnCount },
+        const dense = Array.from(
+            { length: count },
             (_, col) => previous[col] ?? null
         )
-        this.state.grid[row] = normalized
+        this.state.grid[row] = dense
 
-        for (let col = 0; col < normalized.length; col++) {
-            const bubble = normalized[col]
+        for (let col = 0; col < dense.length; col++) {
+            const bubble = dense[col]
             if (!bubble) {
                 continue
             }
@@ -424,32 +575,25 @@ private syncBubbleCount(): number {
 }
 ```
 
-- [ ] **Step 7: Migrate every production caller in the same task**
+- [ ] **Step 7: Migrate all production callers in the same commit**
 
-Do not commit after only editing `utils.ts`. In the same working change:
-
-- update `initializeGrid` to build every row with `createEmptyRow`, use the new coordinate signatures, then call `refreshBubbleCoordinates(constants)` and `syncBubbleCount()`;
-- update `findAttachPosition`/`findClosestPosition` candidate geometry to `getRowColumnCount` and phase-aware coordinates;
-- update `isValidAttachPosition` and the current match DFS to phase-aware `getNeighbors`;
-- update all `getBubbleY` calls to the new row-only signature;
-- update all `getBubbleX` calls to pass `this.state.rowPhase`;
-- update all tests in `BubbleShooterGame.test.ts` to use the new wrappers.
-
-Verify no old signatures remain:
-
-```bash
-rg -n "rowOffset|getBubbleX\([^\n]*CONSTANTS\)|getBubbleY\([^\n]*, 0, CONSTANTS\)|getNeighbors\([^\n]*CONSTANTS\)" \
-  src/lib/games/bubble-shooter
-```
-
-Expected: no `rowOffset`; manually inspect any geometry matches to confirm they use the new signatures.
-
-- [ ] **Step 8: Make row insertion preserve physical parity**
-
-Keep `addRowAtTop` focused on the board mutation and coordinate refresh:
+`initializeGrid()` creates every row with `createEmptyRow()`, fills the first `initialRows` from a fixed `const generationColors = [...this.config.colors]`, then calls:
 
 ```ts
-private addRowAtTop(constants: GameConstants): void {
+this.refreshBubbleCoordinates(constants)
+this.syncBubbleCount()
+this.state.needsRedraw = true
+```
+
+Change every `getBubbleX/getBubbleY/getNeighbors` call in `BubbleShooterGame.ts` to the new signatures.
+
+Change row insertion to accept a color snapshot and preserve physical parity:
+
+```ts
+private addRowAtTop(
+    constants: GameConstants,
+    generationColors: number[]
+): void {
     for (let row = constants.GRID_HEIGHT - 1; row > 0; row--) {
         this.state.grid[row] = [...(this.state.grid[row - 1] ?? [])]
     }
@@ -459,8 +603,8 @@ private addRowAtTop(constants: GameConstants): void {
     for (let col = 0; col < topRow.length; col++) {
         if (Math.random() < this.config.newRowFillChance) {
             topRow[col] = {
-                color: this.config.colors[
-                    Math.floor(Math.random() * this.config.colors.length)
+                color: generationColors[
+                    Math.floor(Math.random() * generationColors.length)
                 ],
                 x: 0,
                 y: 0,
@@ -469,23 +613,24 @@ private addRowAtTop(constants: GameConstants): void {
     }
     this.state.grid[0] = topRow
     this.refreshBubbleCoordinates(constants)
+    this.syncBubbleCount()
+    this.state.needsRedraw = true
 }
 ```
 
-For this intermediate task, `addNewRow` calls `addRowAtTop(constants)`, then `syncBubbleCount()`, then the existing game-over check. Task 4 changes row-color selection and inserts connectivity normalization before that count sync.
+For this task, `addNewRow()` may pass `[...this.config.colors]`; active-color snapshotting replaces that in Task 6.
 
-- [ ] **Step 9: Verify the atomic geometry + caller migration**
+- [ ] **Step 8: Verify no old signatures remain and commit**
 
 ```bash
+rg -n "rowOffset" src/lib/games/bubble-shooter
 bun run test:run \
   src/lib/games/bubble-shooter/utils.test.ts \
   src/lib/games/bubble-shooter/BubbleShooterGame.test.ts
 bun run typecheck
 ```
 
-Expected: both test files PASS and typecheck exits successfully. This is the first commit boundary; there is no intentionally broken helper-signature commit.
-
-- [ ] **Step 10: Commit**
+Expected: no `rowOffset`, both test files PASS, typecheck exits 0.
 
 ```bash
 git add src/lib/games/bubble-shooter/types.ts \
@@ -498,20 +643,22 @@ git commit -m "fix: make bubble shooter grid phase aware"
 
 ---
 
-### Task 2: Make projectile movement elapsed-time based
+### Task 3: Standardize Bubble Shooter on seconds and add collision-safe projectile substeps
 
 **Files:**
 - Modify: `src/lib/games/bubble-shooter/types.ts`
 - Modify: `src/lib/games/bubble-shooter/BubbleShooterGame.ts`
 - Modify: `src/lib/games/bubble-shooter/BubbleShooterGame.test.ts`
+- Modify: `src/lib/games/bubble-shooter/initFramework.ts`
+- Modify: `src/lib/games/bubble-shooter/initFramework.test.ts`
 
 **Interfaces:**
-- Produces: `updateProjectile(deltaTimeMs: number): boolean`.
-- Produces: `reflectProjectileOffWalls(constants)`.
-- Produces internally: `ProjectileImpact = { kind: 'ceiling' } | { kind: 'bubble'; anchor: GridPosition }`.
-- Changes: projectile velocity is pixels per second.
+- Produces: `updateProjectile(deltaTimeSeconds: number): boolean`.
+- Produces: `reflectProjectileOffWalls(constants): void`.
+- Produces: `ProjectileImpact` union used by Task 4.
+- Changes Bubble Shooter RAF call to pass elapsed seconds.
 
-- [ ] **Step 1: Add a failing refresh-rate regression**
+- [ ] **Step 1: Add a failing refresh-rate independence test**
 
 ```ts
 function simulateProjectile(frameCount: number): number {
@@ -542,12 +689,12 @@ function simulateProjectile(frameCount: number): number {
     })
 
     for (let frame = 0; frame < frameCount; frame++) {
-        game.updateProjectile(1_000 / frameCount)
+        game.updateProjectile(1 / frameCount)
     }
     return stateOf(game).projectile?.y ?? Number.NaN
 }
 
-it('moves equally over one second at 30Hz, 60Hz, and 120Hz', () => {
+it('moves equally for one second at 30Hz 60Hz and 120Hz', () => {
     const at30Hz = simulateProjectile(30)
     const at60Hz = simulateProjectile(60)
     const at120Hz = simulateProjectile(120)
@@ -558,10 +705,53 @@ it('moves equally over one second at 30Hz, 60Hz, and 120Hz', () => {
 })
 ```
 
-- [ ] **Step 2: Add a failing reflected-position regression**
+- [ ] **Step 2: Add a failing high-speed tunneling test that requires substeps**
+
+Use a speed where one clamped frame can cross multiple bubble diameters:
 
 ```ts
-it('keeps the projectile inside the right wall after reflection', () => {
+it('does not tunnel through a bubble at high configured speed', () => {
+    const game = makeGame({ projectileSpeed: 4_000 })
+    const grid = Array.from(
+        { length: CONSTANTS.GRID_HEIGHT },
+        (_, row) =>
+            Array.from(
+                {
+                    length: getRowColumnCount(row, 0, CONSTANTS),
+                },
+                () => null
+            )
+    )
+    grid[8][6] = {
+        color: 0x00ff00,
+        x: 300,
+        y: 300,
+    }
+
+    setState(game, {
+        grid,
+        rowPhase: 0,
+        projectile: {
+            x: 300,
+            y: 400,
+            vx: 0,
+            vy: -4_000,
+            color: 0xff0000,
+        },
+    })
+
+    game.updateProjectile(0.05)
+
+    expect(stateOf(game).projectile).toBeNull()
+})
+```
+
+The projectile travels 200px in 50ms. Without substeps it ends 100px beyond the bubble and misses the 40px collision diameter; with 10px-or-smaller substeps it resolves the collision.
+
+- [ ] **Step 3: Add a wall-reflection test**
+
+```ts
+it('reflects position back inside the right wall', () => {
     const game = makeGame({ projectileSpeed: 720 })
     setState(game, {
         projectile: {
@@ -574,7 +764,7 @@ it('keeps the projectile inside the right wall after reflection', () => {
         grid: [],
     })
 
-    game.updateProjectile(16)
+    game.updateProjectile(0.016)
 
     expect(stateOf(game).projectile?.x).toBeLessThanOrEqual(
         CONSTANTS.GAME_WIDTH - CONSTANTS.BUBBLE_RADIUS
@@ -583,28 +773,39 @@ it('keeps the projectile inside the right wall after reflection', () => {
 })
 ```
 
-- [ ] **Step 3: Verify the physics tests fail**
+- [ ] **Step 4: Add a failing initializer delta-unit test**
+
+In the RAF test, invoke the loop once to establish time and once 16ms later; assert:
+
+```ts
+expect(gameMock.update).toHaveBeenLastCalledWith(0.016)
+```
+
+Use `performance.now` stubbing consistent with the existing test setup so the assertion is deterministic.
+
+- [ ] **Step 5: Verify the new tests fail**
 
 ```bash
-bun run test:run src/lib/games/bubble-shooter/BubbleShooterGame.test.ts -t "30Hz|right wall"
+bun run test:run \
+  src/lib/games/bubble-shooter/BubbleShooterGame.test.ts \
+  src/lib/games/bubble-shooter/initFramework.test.ts \
+  -t "one second|tunnel|right wall|delta"
 ```
 
-Expected: FAIL because frame time is ignored and wall handling reverses velocity without reflecting position inside bounds.
+Expected: FAIL because Bubble Shooter ignores delta, uses per-frame velocity, and the initializer passes milliseconds.
 
-- [ ] **Step 4: Convert speed and add bounded substeps**
+- [ ] **Step 6: Convert speed and implement bounded substeps**
 
-Set:
+In config/types:
 
 ```ts
-projectileSpeed: 720,
+projectileSpeed: 720, // pixels per second
 ```
 
-and document `projectileSpeed: number // pixels per second` in the config type.
-
-Add:
+In `BubbleShooterGame.ts`:
 
 ```ts
-const MAX_PROJECTILE_FRAME_MS = 50
+const MAX_PROJECTILE_FRAME_SECONDS = 0.05
 const MAX_PROJECTILE_SUBSTEP_RATIO = 0.5
 
 type ProjectileImpact =
@@ -612,31 +813,30 @@ type ProjectileImpact =
     | { kind: 'bubble'; anchor: GridPosition }
 ```
 
-Pass the RAF milliseconds already supplied to `update(deltaTime)` into `updateProjectile(deltaTime)`.
+Change `update(deltaTime)` to call `updateProjectile(deltaTime)`.
 
 Implement:
 
 ```ts
-updateProjectile(deltaTimeMs: number): boolean {
+updateProjectile(deltaTimeSeconds: number): boolean {
     const projectile = this.state.projectile
     if (!projectile) {
         return false
     }
 
     const constants = this.getConstantsView()
-    const clampedMs = Math.min(
-        Math.max(deltaTimeMs, 0),
-        MAX_PROJECTILE_FRAME_MS
+    const elapsed = Math.min(
+        Math.max(deltaTimeSeconds, 0),
+        MAX_PROJECTILE_FRAME_SECONDS
     )
-    const elapsedSeconds = clampedMs / 1_000
     const speed = Math.hypot(projectile.vx, projectile.vy)
-    const maxDistance =
+    const maxStepDistance =
         constants.BUBBLE_RADIUS * MAX_PROJECTILE_SUBSTEP_RATIO
     const stepCount = Math.max(
         1,
-        Math.ceil((speed * elapsedSeconds) / maxDistance)
+        Math.ceil((speed * elapsed) / maxStepDistance)
     )
-    const stepSeconds = elapsedSeconds / stepCount
+    const stepSeconds = elapsed / stepCount
 
     for (let step = 0; step < stepCount; step++) {
         projectile.x += projectile.vx * stepSeconds
@@ -652,14 +852,16 @@ updateProjectile(deltaTimeMs: number): boolean {
         }
     }
 
-    if (clampedMs > 0) {
+    if (elapsed > 0) {
         this.state.needsRedraw = true
     }
     return false
 }
 ```
 
-Add:
+Bubble collision stays before ceiling collision.
+
+Implement wall reflection:
 
 ```ts
 private reflectProjectileOffWalls(constants: GameConstants): void {
@@ -683,44 +885,68 @@ private reflectProjectileOffWalls(constants: GameConstants): void {
 }
 ```
 
-Adapt `attachBubble` to accept `ProjectileImpact` while retaining its existing candidate selection until Task 3.
+Temporarily adapt `attachBubble` to accept `ProjectileImpact` while retaining its current candidate behavior; Task 4 removes the global fallback.
 
-- [ ] **Step 5: Update existing direct update tests**
+- [ ] **Step 7: Convert the RAF loop from milliseconds to seconds**
 
-Pass `16` to ordinary one-frame `updateProjectile` tests and change position expectations to velocity multiplied by `0.016`.
+In `initFramework.ts`:
 
-- [ ] **Step 6: Verify and commit**
+```ts
+const now = performance.now()
+if (lastFrame === 0) {
+    lastFrame = now
+}
+const deltaTimeSeconds = (now - lastFrame) / 1_000
+lastFrame = now
+
+game.update(deltaTimeSeconds)
+```
+
+Do not clamp here; the game owns its 0.05s clamp.
+
+- [ ] **Step 8: Update old projectile test call sites and verify**
+
+Replace old one-frame test calls with values such as `0.016`, and update expectations to `velocity * 0.016` where applicable.
 
 ```bash
-bun run test:run src/lib/games/bubble-shooter/BubbleShooterGame.test.ts
+bun run test:run \
+  src/lib/games/bubble-shooter/BubbleShooterGame.test.ts \
+  src/lib/games/bubble-shooter/initFramework.test.ts
 bun run typecheck
+```
+
+Expected: PASS and typecheck exits 0.
+
+- [ ] **Step 9: Commit**
+
+```bash
 git add src/lib/games/bubble-shooter/types.ts \
   src/lib/games/bubble-shooter/BubbleShooterGame.ts \
-  src/lib/games/bubble-shooter/BubbleShooterGame.test.ts
+  src/lib/games/bubble-shooter/BubbleShooterGame.test.ts \
+  src/lib/games/bubble-shooter/initFramework.ts \
+  src/lib/games/bubble-shooter/initFramework.test.ts
 git commit -m "fix: make bubble shooter physics time based"
 ```
 
-Expected: game tests PASS and typecheck exits successfully before the commit.
-
 ---
 
-### Task 3: Restrict attachment to impact-local empty cells
+### Task 4: Restrict attachment to impact-local cells without spurious game over
 
 **Files:**
 - Modify: `src/lib/games/bubble-shooter/BubbleShooterGame.ts`
 - Modify: `src/lib/games/bubble-shooter/BubbleShooterGame.test.ts`
 
 **Interfaces:**
-- Consumes: `ProjectileImpact` from Task 2.
-- Produces: `findAttachPosition(constants, impact)`.
-- Produces: `findClosestEmptyPosition(constants, candidates)`.
-- Removes: global candidate search, `isValidAttachPosition`, and occupied top-center fallback.
+- Consumes: `ProjectileImpact` from Task 3.
+- Produces: `findAttachPosition(constants, impact): GridPosition | null`.
+- Produces: `findClosestEmptyPosition(constants, candidates): GridPosition | null`.
+- Removes: whole-board candidate search, `isValidAttachPosition`, and forced row-zero fallback.
 
-- [ ] **Step 1: Add a failing anchor-local attachment regression**
+- [ ] **Step 1: Add an anchor-local attachment regression**
 
 ```ts
 it('attaches a bubble impact only beside the collided anchor', () => {
-    const game = makeGame()
+    const game = makeGame({ rowAddInterval: 99 })
     const anchor = { row: 4, col: 4 }
     const grid = Array.from(
         { length: CONSTANTS.GRID_HEIGHT },
@@ -762,11 +988,14 @@ it('attaches a bubble impact only beside the collided anchor', () => {
 })
 ```
 
-- [ ] **Step 2: Add a failing full-board no-overwrite regression**
+- [ ] **Step 2: Add the partial-block regression that distinguishes blocked impact from loss**
+
+Construct one reachable impact with every legal candidate filled but no bubble near the danger zone:
 
 ```ts
-it('ends without overwriting when no legal attachment exists', () => {
-    const game = makeGame()
+it('consumes a locally blocked shot without ending the run', () => {
+    const game = makeGame({ rowAddInterval: 99 })
+    const anchor = { row: 2, col: 5 }
     const grid = Array.from(
         { length: CONSTANTS.GRID_HEIGHT },
         (_, row) =>
@@ -774,13 +1003,18 @@ it('ends without overwriting when no legal attachment exists', () => {
                 {
                     length: getRowColumnCount(row, 0, CONSTANTS),
                 },
-                (_, col) => ({
-                    color: 0xff0000,
-                    x: bubbleX(col, row),
-                    y: bubbleY(row),
-                })
+                () => null
             )
     )
+
+    const occupied = [anchor, ...neighbors(anchor.row, anchor.col)]
+    for (const position of occupied) {
+        grid[position.row][position.col] = {
+            color: 0x00ff00,
+            x: bubbleX(position.col, position.row),
+            y: bubbleY(position.row),
+        }
+    }
     const before = JSON.stringify(grid)
     const endSpy = vi.spyOn(game, 'end').mockResolvedValue(undefined)
 
@@ -789,32 +1023,32 @@ it('ends without overwriting when no legal attachment exists', () => {
         grid,
         rowPhase: 0,
         projectile: {
-            x: 300,
-            y: CONSTANTS.BUBBLE_RADIUS,
+            x: bubbleX(anchor.col, anchor.row),
+            y: bubbleY(anchor.row) + 30,
             vx: 0,
             vy: -720,
-            color: 0x00ff00,
+            color: 0xff0000,
         },
         bubblesRemaining: countGrid(grid),
     })
 
-    expect(game.attachBubble({ kind: 'ceiling' })).toBe(true)
+    expect(game.attachBubble({ kind: 'bubble', anchor })).toBe(false)
     expect(JSON.stringify(stateOf(game).grid)).toBe(before)
-    expect(stateOf(game).bubblesRemaining).toBe(countGrid(grid))
     expect(stateOf(game).projectile).toBeNull()
-    expect(endSpy).toHaveBeenCalledTimes(1)
+    expect(stateOf(game).isActive).toBe(true)
+    expect(endSpy).not.toHaveBeenCalled()
 })
 ```
 
-- [ ] **Step 3: Verify the attachment tests fail**
+- [ ] **Step 3: Verify the attachment regressions fail**
 
 ```bash
-bun run test:run src/lib/games/bubble-shooter/BubbleShooterGame.test.ts -t "collided anchor|without overwriting"
+bun run test:run src/lib/games/bubble-shooter/BubbleShooterGame.test.ts -t "collided anchor|locally blocked"
 ```
 
-Expected: FAIL because the current fallback searches unrelated cells and can replace row-zero center.
+Expected: FAIL because current fallback searches the whole board and the previous plan's blocked behavior would end the run.
 
-- [ ] **Step 4: Implement impact-specific candidates using the existing shared `distance` helper**
+- [ ] **Step 4: Implement impact-specific candidates using shared `distance`**
 
 ```ts
 private findAttachPosition(
@@ -856,13 +1090,14 @@ private findClosestEmptyPosition(
         return null
     }
 
-    let result: GridPosition | null = null
-    let resultDistance = Number.POSITIVE_INFINITY
+    let best: GridPosition | null = null
+    let bestDistance = Number.POSITIVE_INFINITY
 
     for (const candidate of candidates) {
         if (this.state.grid[candidate.row]?.[candidate.col]) {
             continue
         }
+
         const candidateDistance = distance(projectile, {
             x: getBubbleX(
                 candidate.col,
@@ -872,39 +1107,96 @@ private findClosestEmptyPosition(
             ),
             y: getBubbleY(candidate.row, constants),
         })
-        if (candidateDistance < resultDistance) {
-            result = candidate
-            resultDistance = candidateDistance
+        if (candidateDistance < bestDistance) {
+            best = candidate
+            bestDistance = candidateDistance
         }
     }
 
-    return result
+    return best
 }
 ```
 
-If no legal position exists, clear the projectile, mark redraw, invoke the existing caught `end()` path, and return `true` without touching grid cells or counts.
+Delete `isValidAttachPosition` and the whole-board/fixed-cell fallback.
 
-For a successful insert, synchronize the count immediately after the cell write and again after the current legacy match function until Task 4 replaces match bookkeeping completely.
+- [ ] **Step 5: Make blocked impact a consumed normal shot**
 
-- [ ] **Step 5: Add delayed-frame tunneling coverage**
+Structure `attachBubble` so row-interval bookkeeping and danger-zone checking run for both attached and blocked resolved projectiles:
 
-Place one occupied bubble 60px above a projectile moving at `-720px/s`, call `updateProjectile(500)`, and assert the projectile attaches to an anchor neighbor rather than passing through it. The input is clamped to 50ms and split into substeps no longer than 10px for the default radius.
+```ts
+const attachPos = this.findAttachPosition(constants, impact)
 
-- [ ] **Step 6: Verify and commit**
+if (attachPos) {
+    if (this.state.grid[attachPos.row]?.[attachPos.col]) {
+        throw new Error('Bubble Shooter attach target must be empty')
+    }
+
+    this.state.grid[attachPos.row][attachPos.col] = {
+        color: this.state.projectile.color,
+        x: getBubbleX(
+            attachPos.col,
+            attachPos.row,
+            this.state.rowPhase,
+            constants
+        ),
+        y: getBubbleY(attachPos.row, constants),
+    }
+    this.syncBubbleCount()
+    this.checkMatches(attachPos.row, attachPos.col)
+    this.syncBubbleCount()
+}
+
+this.state.shotCount++
+if (
+    this.state.bubblesRemaining > 0 &&
+    this.state.shotCount % this.config.rowAddInterval === 0
+) {
+    this.addNewRow(constants)
+}
+
+this.state.projectile = null
+this.state.needsRedraw = true
+
+if (this.checkGameOverCondition(constants)) {
+    this.end().catch(error =>
+        console.error('BubbleShooter end failed', error)
+    )
+    return true
+}
+return false
+```
+
+The blocked path writes no cell and creates no successful match. It still consumes a row-interval shot, and only the danger-zone check can end the run.
+
+- [ ] **Step 6: Pin bubble-before-ceiling impact priority**
+
+Add a test with a row-zero bubble and a projectile substep that crosses both the bubble collision threshold and ceiling threshold. Spy on `attachBubble` and assert the impact is:
+
+```ts
+expect(attachSpy).toHaveBeenCalledWith({
+    kind: 'bubble',
+    anchor: { row: 0, col: targetCol },
+})
+```
+
+- [ ] **Step 7: Verify and commit**
 
 ```bash
 bun run test:run src/lib/games/bubble-shooter/BubbleShooterGame.test.ts
 bun run typecheck
+```
+
+Expected: PASS and typecheck exits 0.
+
+```bash
 git add src/lib/games/bubble-shooter/BubbleShooterGame.ts \
   src/lib/games/bubble-shooter/BubbleShooterGame.test.ts
 git commit -m "fix: restrict bubble shooter attachment cells"
 ```
 
-Expected: game tests PASS and typecheck exits successfully.
-
 ---
 
-### Task 4: Normalize connectivity before queue generation, drop clusters, use active colors, and calculate true accuracy
+### Task 5: Add ceiling-connectivity drops and one authoritative match resolution
 
 **Files:**
 - Modify: `src/lib/games/bubble-shooter/types.ts`
@@ -912,15 +1204,12 @@ Expected: game tests PASS and typecheck exits successfully.
 - Modify: `src/lib/games/bubble-shooter/BubbleShooterGame.test.ts`
 
 **Interfaces:**
-- Produces: `successfulShots` in state, end stats, and game data.
+- Produces: `successfulShots` state/stat field for Task 6 accuracy.
 - Produces: `ShotResolution`.
 - Produces: `collectColorCluster(start, constants): GridPosition[]`.
 - Produces: `collectCeilingConnected(constants): Set<string>`.
-- Produces: `removeUnsupportedBubbles(constants): GridPosition[]` with no count synchronization side effect.
+- Produces: `removeUnsupportedBubbles(constants): GridPosition[]` with no count-sync side effect.
 - Produces: `resolveMatches(attached, constants): ShotResolution`.
-- Produces: `getAvailableBubbleColors(): number[]` and `reconcileNextBubbleColor(): void`.
-- Changes startup order to `initializeGrid → removeUnsupportedBubbles → syncBubbleCount → generateBubble → generateNextBubble`.
-- Changes added-row order to `snapshot active colors → addRowAtTop → removeUnsupportedBubbles → syncBubbleCount → later reconcile nextBubble`.
 
 - [ ] **Step 1: Add a failing direct-match-plus-drop regression**
 
@@ -937,6 +1226,7 @@ it('scores a direct match and bubbles disconnected from the ceiling', () => {
                 () => null
             )
     )
+
     grid[0][0] = { color: 0xff0000, x: bubbleX(0, 0), y: bubbleY(0) }
     grid[0][1] = { color: 0xff0000, x: bubbleX(1, 0), y: bubbleY(0) }
     grid[1][0] = { color: 0x0000ff, x: bubbleX(0, 1), y: bubbleY(1) }
@@ -967,119 +1257,52 @@ it('scores a direct match and bubbles disconnected from the ceiling', () => {
 })
 ```
 
-- [ ] **Step 2: Add a failing opening-queue ordering regression**
-
-This test pins the high-cost sequencing contract: a color present only on a floating startup bubble must be removed before current/next generation samples active colors.
+- [ ] **Step 2: Add a failing contract test for maintenance cleanup**
 
 ```ts
-it('removes floating-only colors before generating the opening queue', () => {
-    const game = makeGame({ colors: [0xff0000, 0x0000ff] })
-    const grid = Array.from(
-        { length: CONSTANTS.GRID_HEIGHT },
-        (_, row) =>
-            Array.from(
-                {
-                    length: getRowColumnCount(row, 0, CONSTANTS),
-                },
-                () => null
-            )
+it('returns unsupported positions without changing score or successfulShots', () => {
+    const game = makeGame()
+    // Build one top-connected red bubble and one isolated blue bubble.
+    // Use a dense grid and sync bubblesRemaining before invoking the helper.
+    const internal = game as unknown as {
+        removeUnsupportedBubbles: (
+            constants: GameConstants
+        ) => GridPosition[]
+    }
+    const beforeScore = stateOf(game).score
+    const beforeSuccessfulShots = stateOf(game).successfulShots
+
+    const dropped = internal.removeUnsupportedBubbles(
+        game.getConstantsView()
     )
 
-    grid[0][0] = {
-        color: 0xff0000,
-        x: bubbleX(0, 0),
-        y: bubbleY(0),
-    }
-    grid[1][2] = {
-        color: 0x0000ff,
-        x: bubbleX(2, 1),
-        y: bubbleY(1),
-    }
-
-    const internal = game as unknown as {
-        initializeGrid: () => void
-        onGameStart: () => void
-    }
-    vi.spyOn(internal, 'initializeGrid').mockImplementation(() => {
-        setState(game, {
-            grid,
-            rowPhase: 0,
-            bubblesRemaining: 2,
-            currentBubble: null,
-            nextBubble: null,
-        })
-    })
-    vi.spyOn(Math, 'random').mockReturnValue(0)
-
-    internal.onGameStart()
-
-    expect(stateOf(game).grid[1][2]).toBeNull()
-    expect(stateOf(game).bubblesRemaining).toBe(1)
-    expect(stateOf(game).currentBubble?.color).toBe(0xff0000)
-    expect(stateOf(game).nextBubble?.color).toBe(0xff0000)
+    expect(dropped).toEqual([{ row: isolatedRow, col: isolatedCol }])
+    expect(stateOf(game).score).toBe(beforeScore)
+    expect(stateOf(game).successfulShots).toBe(beforeSuccessfulShots)
 })
 ```
 
-- [ ] **Step 3: Add failing active-color and successful-shot accuracy regressions**
+Use concrete `isolatedRow`/`isolatedCol` constants in the actual test setup; do not leave symbolic placeholders in committed code.
 
-```ts
-it('reports accuracy from successful shots rather than popped bubbles', () => {
-    const game = makeGame()
-    setState(game, {
-        shotsFired: 10,
-        successfulShots: 6,
-        bubblesPopped: 18,
-    })
-    expect(game.getGameStats().accuracy).toBe(60)
-})
-
-it('returns active colors and falls back after an all-clear', () => {
-    const game = makeGame()
-    const internal = game as unknown as {
-        getAvailableBubbleColors: () => number[]
-    }
-
-    setState(game, {
-        grid: [[
-            { color: 0xff0000, x: bubbleX(0, 0), y: bubbleY(0) },
-            { color: 0x00ff00, x: bubbleX(1, 0), y: bubbleY(0) },
-        ]],
-    })
-    expect(internal.getAvailableBubbleColors().sort()).toEqual(
-        [0xff0000, 0x00ff00].sort()
-    )
-
-    setState(game, { grid: [] })
-    expect(internal.getAvailableBubbleColors()).toEqual(CONSTANTS.COLORS)
-})
-```
-
-- [ ] **Step 4: Verify the new mechanics tests fail**
+- [ ] **Step 3: Verify tests fail**
 
 ```bash
-bun run test:run src/lib/games/bubble-shooter/BubbleShooterGame.test.ts -t "disconnected|opening queue|successful shots|active colors"
+bun run test:run src/lib/games/bubble-shooter/BubbleShooterGame.test.ts -t "disconnected from the ceiling|unsupported positions"
 ```
 
-Expected: FAIL because unsupported bubbles are not removed, startup queue generation happens before maintenance cleanup, and accuracy/colors still use the old behavior.
+Expected: FAIL because unsupported bubbles are not removed and the helper contracts do not exist.
 
-- [ ] **Step 5: Add successful-shot state and stats**
+- [ ] **Step 4: Add successful-shot state contracts**
 
-Add `successfulShots: number` to `BubbleShooterState`, `BubbleShooterEndGameStats`, and `BubbleShooterStats`; initialize it to zero and include it in `getGameData()`.
-
-Use:
+Add `successfulShots: number` to `BubbleShooterState`, `BubbleShooterEndGameStats`, and `BubbleShooterStats`. Initialize:
 
 ```ts
-const accuracy =
-    this.state.shotsFired > 0
-        ? (this.state.successfulShots / this.state.shotsFired) * 100
-        : 0
+successfulShots: 0,
 ```
 
-Return `successfulShots` and `accuracy` from `getGameStats()`.
+Do not switch accuracy yet; Task 6 does that with the queue/stat semantics commit.
 
-- [ ] **Step 6: Implement the traversal contracts with one owner for count synchronization**
-
-Reuse the existing hex-neighbor logic; do not use `shared/match3.ts`.
+- [ ] **Step 5: Implement local iterative hex traversals**
 
 ```ts
 interface ShotResolution {
@@ -1128,9 +1351,43 @@ private collectColorCluster(
 }
 ```
 
-Implement `collectCeilingConnected(constants): Set<string>` with the same iterative traversal, seeded by every occupied row-zero cell and without a color predicate.
+Implement ceiling traversal seeded by every occupied row-zero cell:
 
-Implement `removeUnsupportedBubbles` with this exact contract:
+```ts
+private collectCeilingConnected(
+    constants: GameConstants
+): Set<string> {
+    const connected = new Set<string>()
+    const pending: GridPosition[] = []
+
+    for (let col = 0; col < this.state.grid[0].length; col++) {
+        if (this.state.grid[0][col]) {
+            pending.push({ row: 0, col })
+        }
+    }
+
+    while (pending.length > 0) {
+        const current = pending.pop()!
+        const key = `${current.row},${current.col}`
+        if (connected.has(key) || !this.state.grid[current.row]?.[current.col]) {
+            continue
+        }
+        connected.add(key)
+        pending.push(
+            ...getNeighbors(
+                current.row,
+                current.col,
+                this.state.rowPhase,
+                constants
+            )
+        )
+    }
+
+    return connected
+}
+```
+
+Implement the exact drop contract:
 
 ```ts
 private removeUnsupportedBubbles(
@@ -1155,9 +1412,9 @@ private removeUnsupportedBubbles(
 }
 ```
 
-It does **not** call `syncBubbleCount()`. That side effect belongs to the caller after the complete mutation sequence.
+It must not call `syncBubbleCount()`.
 
-- [ ] **Step 7: Replace `checkMatches` with a single shot resolution**
+- [ ] **Step 6: Replace `checkMatches` with one resolution owner**
 
 ```ts
 private resolveMatches(
@@ -1191,11 +1448,11 @@ private resolveMatches(
 }
 ```
 
-`resolveMatches` owns exactly one `syncBubbleCount()` after direct and unsupported removals.
+`resolveMatches` owns exactly one count sync after direct + unsupported removals.
 
-- [ ] **Step 8: Make startup normalize the board before queue generation**
+- [ ] **Step 7: Normalize connectivity after startup and row insertion**
 
-Rewrite the existing start hook explicitly:
+Rewrite startup maintenance before queue generation:
 
 ```ts
 protected onGameStart(): void {
@@ -1208,9 +1465,166 @@ protected onGameStart(): void {
 }
 ```
 
-This order is required. `generateBubble()` and `generateNextBubble()` must never sample colors from bubbles that the startup connectivity pass is about to remove.
+Change `addNewRow()` to clean unsupported cells after the row mutation and then sync once:
 
-- [ ] **Step 9: Implement active-color selection and row-generation snapshotting**
+```ts
+private addNewRow(constants: GameConstants): void {
+    this.addRowAtTop(constants, [...this.config.colors])
+    this.removeUnsupportedBubbles(constants)
+    this.syncBubbleCount()
+
+    if (this.checkGameOverCondition(constants)) {
+        this.state.needsRedraw = true
+    }
+}
+```
+
+Task 6 replaces the row-generation palette with an active-color snapshot and adds queue reconciliation.
+
+- [ ] **Step 8: Verify and commit**
+
+```bash
+bun run test:run src/lib/games/bubble-shooter/BubbleShooterGame.test.ts
+bun run typecheck
+```
+
+Expected: PASS and typecheck exits 0.
+
+```bash
+git add src/lib/games/bubble-shooter/types.ts \
+  src/lib/games/bubble-shooter/BubbleShooterGame.ts \
+  src/lib/games/bubble-shooter/BubbleShooterGame.test.ts
+git commit -m "fix: drop unsupported bubble clusters"
+```
+
+---
+
+### Task 6: Generate playable future colors and switch to successful-shot accuracy
+
+**Files:**
+- Modify: `src/lib/games/bubble-shooter/BubbleShooterGame.ts`
+- Modify: `src/lib/games/bubble-shooter/BubbleShooterGame.test.ts`
+
+**Interfaces:**
+- Consumes: `successfulShots` and connectivity cleanup from Task 5.
+- Produces: `getAvailableBubbleColors(): number[]`.
+- Produces: `reconcileNextBubbleColor(): void`.
+- Changes: opening/current/next generation samples active board colors after maintenance cleanup.
+- Changes: accuracy = `successfulShots / shotsFired`.
+
+- [ ] **Step 1: Add the floating-only opening-color regression**
+
+```ts
+it('removes floating-only colors before generating the opening queue', () => {
+    const game = makeGame({ colors: [0xff0000, 0x0000ff] })
+    const grid = Array.from(
+        { length: CONSTANTS.GRID_HEIGHT },
+        (_, row) =>
+            Array.from(
+                {
+                    length: getRowColumnCount(row, 0, CONSTANTS),
+                },
+                () => null
+            )
+    )
+
+    grid[0][0] = {
+        color: 0xff0000,
+        x: bubbleX(0, 0),
+        y: bubbleY(0),
+    }
+    grid[2][5] = {
+        color: 0x0000ff,
+        x: bubbleX(5, 2),
+        y: bubbleY(2),
+    }
+
+    const internal = game as unknown as {
+        initializeGrid: () => void
+        onGameStart: () => void
+    }
+    vi.spyOn(internal, 'initializeGrid').mockImplementation(() => {
+        setState(game, {
+            grid,
+            rowPhase: 0,
+            bubblesRemaining: 2,
+            currentBubble: null,
+            nextBubble: null,
+        })
+    })
+    vi.spyOn(Math, 'random').mockReturnValue(0)
+
+    internal.onGameStart()
+
+    expect(stateOf(game).grid[2][5]).toBeNull()
+    expect(stateOf(game).bubblesRemaining).toBe(1)
+    expect(stateOf(game).currentBubble?.color).toBe(0xff0000)
+    expect(stateOf(game).nextBubble?.color).toBe(0xff0000)
+})
+```
+
+- [ ] **Step 2: Add active-color and accuracy regressions**
+
+```ts
+it('returns active colors and falls back to config on an empty board', () => {
+    const game = makeGame()
+    const internal = game as unknown as {
+        getAvailableBubbleColors: () => number[]
+    }
+
+    setState(game, {
+        grid: [[
+            { color: 0xff0000, x: bubbleX(0, 0), y: bubbleY(0) },
+            { color: 0x00ff00, x: bubbleX(1, 0), y: bubbleY(0) },
+        ]],
+    })
+    expect(internal.getAvailableBubbleColors().sort()).toEqual(
+        [0xff0000, 0x00ff00].sort()
+    )
+
+    setState(game, { grid: [] })
+    expect(internal.getAvailableBubbleColors()).toEqual(CONSTANTS.COLORS)
+})
+
+it('reports accuracy from successful shots', () => {
+    const game = makeGame()
+    setState(game, {
+        shotsFired: 10,
+        successfulShots: 6,
+        bubblesPopped: 18,
+    })
+
+    expect(game.getGameStats().accuracy).toBe(60)
+})
+```
+
+- [ ] **Step 3: Add the post-row cleanup/reconcile ordering regression**
+
+Create a deterministic interval-shot board where a color becomes unsupported after row mutation/cleanup. Assert after resolution:
+
+```ts
+expect(
+    stateOf(game).grid.flat().some(
+        bubble => bubble?.color === isolatedColor
+    )
+).toBe(false)
+expect(stateOf(game).bubblesRemaining).toBe(
+    countGrid(stateOf(game).grid)
+)
+expect(stateOf(game).nextBubble?.color).not.toBe(isolatedColor)
+```
+
+Use a concrete `const isolatedColor = 0x0000ff` in the committed test.
+
+- [ ] **Step 4: Verify tests fail**
+
+```bash
+bun run test:run src/lib/games/bubble-shooter/BubbleShooterGame.test.ts -t "opening queue|active colors|accuracy|reconcile"
+```
+
+Expected: FAIL because generation still uses the full configured palette and accuracy still uses popped bubbles.
+
+- [ ] **Step 5: Implement active-board color selection**
 
 ```ts
 private getAvailableBubbleColors(): number[] {
@@ -1226,6 +1640,10 @@ private getAvailableBubbleColors(): number[] {
     return colors.size > 0 ? [...colors] : [...this.config.colors]
 }
 
+private randomColor(colors: number[]): number {
+    return colors[Math.floor(Math.random() * colors.length)]
+}
+
 private reconcileNextBubbleColor(): void {
     const colors = this.getAvailableBubbleColors()
     if (
@@ -1233,35 +1651,19 @@ private reconcileNextBubbleColor(): void {
         !colors.includes(this.state.nextBubble.color)
     ) {
         this.state.nextBubble = {
-            color: colors[Math.floor(Math.random() * colors.length)],
+            color: this.randomColor(colors),
         }
     }
 }
 ```
 
-Use active colors in `generateBubble()` and `generateNextBubble()`.
+Use `randomColor(this.getAvailableBubbleColors())` in `generateBubble()` and `generateNextBubble()`.
 
-Keep initial-grid generation independent of its own partially generated board:
+`initializeGrid()` continues using `const generationColors = [...this.config.colors]` so partially generated cells do not feed back into initial generation.
 
-```ts
-const generationColors = [...this.config.colors]
-```
+- [ ] **Step 6: Snapshot active colors before added-row mutation**
 
-before filling the initial grid.
-
-For an added row, snapshot active colors **before** row mutation. Change the row insertion API to accept that snapshot:
-
-```ts
-private addRowAtTop(
-    constants: GameConstants,
-    generationColors: number[]
-): void {
-    // shift rows, toggle rowPhase, fill row zero from generationColors,
-    // then refreshBubbleCoordinates(constants)
-}
-```
-
-Use this final ordering in `addNewRow`:
+Change `addNewRow()` to:
 
 ```ts
 private addNewRow(constants: GameConstants): void {
@@ -1276,38 +1678,47 @@ private addNewRow(constants: GameConstants): void {
 }
 ```
 
-Do not touch `currentBubble` or `nextBubble` inside `addRowAtTop`/`addNewRow`. In `attachBubble`, after match resolution and any interval row insertion have completed, call `reconcileNextBubbleColor()` exactly once. That guarantees row mutation and maintenance normalization finish before queue reconciliation.
+Do not reconcile queue state inside `addRowAtTop()` or `addNewRow()`.
 
-- [ ] **Step 10: Verify board-mutation ordering explicitly**
-
-Add one row-insertion test where a color exists only on a cluster that becomes unsupported after the new row. Stub the generated top row so that cluster is disconnected, fire the interval attachment path, and assert:
+At the end of `attachBubble`, after direct/drop resolution and any interval row insertion, call:
 
 ```ts
-expect(stateOf(game).grid.flat().some(
-    bubble => bubble?.color === isolatedColor
-)).toBe(false)
-expect(stateOf(game).bubblesRemaining).toBe(countGrid(stateOf(game).grid))
-expect(stateOf(game).nextBubble?.color).not.toBe(isolatedColor)
+this.reconcileNextBubbleColor()
 ```
 
-This pins `addRowAtTop → connectivity cleanup → count sync → nextBubble reconciliation`.
+exactly once before final redraw/game-over completion. Never reroll `currentBubble`.
 
-- [ ] **Step 11: Verify and commit**
+- [ ] **Step 7: Switch statistics to successful-shot accuracy**
+
+In `getGameStats()`:
+
+```ts
+const accuracy =
+    this.state.shotsFired > 0
+        ? (this.state.successfulShots / this.state.shotsFired) * 100
+        : 0
+```
+
+Return `successfulShots` and include it in `getGameData()`.
+
+- [ ] **Step 8: Verify and commit**
 
 ```bash
 bun run test:run src/lib/games/bubble-shooter/BubbleShooterGame.test.ts
 bun run typecheck
-git add src/lib/games/bubble-shooter/types.ts \
-  src/lib/games/bubble-shooter/BubbleShooterGame.ts \
-  src/lib/games/bubble-shooter/BubbleShooterGame.test.ts
-git commit -m "fix: resolve bubble shooter clusters and stats"
 ```
 
-Expected: game tests PASS and typecheck exits successfully.
+Expected: PASS and typecheck exits 0.
+
+```bash
+git add src/lib/games/bubble-shooter/BubbleShooterGame.ts \
+  src/lib/games/bubble-shooter/BubbleShooterGame.test.ts
+git commit -m "fix: keep bubble shooter colors and stats playable"
+```
 
 ---
 
-### Task 5: Reset ended runs, clear previews, and align rules
+### Task 7: Clear previews and align Bubble Shooter rules
 
 **Files:**
 - Modify: `src/lib/games/bubble-shooter/initFramework.ts`
@@ -1316,11 +1727,11 @@ Expected: game tests PASS and typecheck exits successfully.
 - Modify: `src/pages/game-board-markup.test.ts`
 
 **Interfaces:**
-- Consumes: `rowPhase` and `successfulShots` in initializer state.
-- Produces: `drawBubblePreview(...)` and `resetPreviewState()` local helpers.
-- Changes: ended-run Start calls `reset()` before `start()`.
+- Consumes: BaseGame restart behavior from Task 1; no Bubble Shooter start-handler reset workaround is added.
+- Produces: null-aware preview drawing and `resetPreviewState()`.
+- Changes: page rules use configured `rowAddInterval`.
 
-- [ ] **Step 1: Extend the initializer mock state**
+- [ ] **Step 1: Extend initializer mock state**
 
 Add:
 
@@ -1329,46 +1740,41 @@ rowPhase: 0,
 successfulShots: 0,
 ```
 
-Keep all existing pointer and RAF mock behavior.
+Keep existing pointer/RAF mock behavior.
 
-- [ ] **Step 2: Add a failing ended-run Start regression**
+- [ ] **Step 2: Add a failing null-preview regression**
+
+Capture `onStateChange`, invoke it once with colors and once with both colors null. Assert each preview canvas is cleared for both states while bubble drawing only occurs for the colored state.
+
+A concrete assertion pattern:
 
 ```ts
-it('resets an ended run before starting again', async () => {
-    const { BubbleShooterGame } = await import('./BubbleShooterGame')
-    result = await initBubbleShooterGameFramework()
-    const gameMock = vi.mocked(BubbleShooterGame).mock.results[0].value
-
-    vi.mocked(gameMock.getState).mockReturnValue({
-        ...gameMock.getState(),
-        isActive: false,
-        isGameOver: true,
-        gameStarted: true,
-        score: 500,
-        shotsFired: 8,
-        successfulShots: 4,
-    } as never)
-
-    document.getElementById('start-btn')!.click()
-
-    expect(gameMock.reset).toHaveBeenCalledBefore(gameMock.start)
-    expect(gameMock.start).toHaveBeenCalledTimes(1)
+callbacksArg.onStateChange({
+    ...baseState,
+    currentBubble: { x: 300, y: 700, color: 0xff0000 },
+    nextBubble: { color: 0x00ff00 },
 })
+callbacksArg.onStateChange({
+    ...baseState,
+    currentBubble: null,
+    nextBubble: null,
+})
+
+expect(currentContext.fillRect).toHaveBeenCalledTimes(2)
+expect(nextContext.fillRect).toHaveBeenCalledTimes(2)
 ```
 
-- [ ] **Step 3: Add a failing null-preview regression**
+Use separate mocked contexts for current/next canvases so the assertions are not ambiguous.
 
-Invoke the captured `onStateChange` once with current/next colors and then once with both values null. Assert each preview context's `fillRect` runs for both states while `drawBubbleOnCanvas` runs only for the colored state.
-
-- [ ] **Step 4: Verify the initializer tests fail**
+- [ ] **Step 3: Verify preview test fails**
 
 ```bash
-bun run test:run src/lib/games/bubble-shooter/initFramework.test.ts -t "ended run|preview"
+bun run test:run src/lib/games/bubble-shooter/initFramework.test.ts -t "preview"
 ```
 
-Expected: FAIL because Start does not reset and undefined colors return before clearing the preview canvas.
+Expected: FAIL because undefined colors currently return before clearing the canvas.
 
-- [ ] **Step 5: Consolidate preview drawing and reset cached colors**
+- [ ] **Step 4: Consolidate preview drawing**
 
 ```ts
 const drawBubblePreview = (
@@ -1399,7 +1805,7 @@ const drawBubblePreview = (
 }
 ```
 
-Track cached colors as `number | undefined` and add:
+Track cached colors as `number | undefined`. Add:
 
 ```ts
 const resetPreviewState = (): void => {
@@ -1410,27 +1816,9 @@ const resetPreviewState = (): void => {
 }
 ```
 
-Call `drawBubblePreview` whenever a defined or undefined color differs from its cached value. Call `resetPreviewState()` from reset, restart, returned `restart()`, and ended-run Start.
+Call it from explicit reset/restart handlers and the returned `restart()` function. Do not add reset logic to `startHandler`; Task 1 makes `BaseGame.start()` own ended-run reset.
 
-- [ ] **Step 6: Reset locally before restarting an ended run**
-
-Pass `resetPreviewState` into `setupButtonHandlers` and use:
-
-```ts
-const startHandler = (): void => {
-    const state = game.getState()
-    if (state.gameStarted && !state.isActive) {
-        game.reset()
-        resetPreviews()
-        resetButtonVisibility()
-    }
-    game.start()
-}
-```
-
-Reset and restart handlers call `game.reset()`, `resetPreviews()`, and `resetButtonVisibility()` in that order. Do not change `BaseGame.start()`.
-
-- [ ] **Step 7: Update rules from the configured interval**
+- [ ] **Step 5: Update rules from the configured interval**
 
 In Astro frontmatter:
 
@@ -1450,40 +1838,58 @@ Render:
 <p>• Accuracy counts shots that clear bubbles</p>
 ```
 
-In `game-board-markup.test.ts`, load the Bubble Shooter source and assert the configured interpolation plus absence of the stale text `New row appears after each shot`.
+- [ ] **Step 6: Pin rule-source markup**
 
-- [ ] **Step 8: Verify and commit**
+In `game-board-markup.test.ts`, load `src/pages/bubble-shooter/index.astro` and assert:
+
+```ts
+expect(bubbleShooterMarkup).toContain(
+    'DEFAULT_BUBBLE_SHOOTER_CONFIG.rowAddInterval'
+)
+expect(bubbleShooterMarkup).toContain(
+    'Disconnected bubbles fall after a match'
+)
+expect(bubbleShooterMarkup).not.toContain(
+    'New row appears after each shot'
+)
+```
+
+- [ ] **Step 7: Verify and commit**
 
 ```bash
 bun run test:run \
   src/lib/games/bubble-shooter/initFramework.test.ts \
   src/pages/game-board-markup.test.ts
 bun run typecheck
+```
+
+Expected: PASS and typecheck exits 0.
+
+```bash
 git add src/lib/games/bubble-shooter/initFramework.ts \
   src/lib/games/bubble-shooter/initFramework.test.ts \
   src/pages/bubble-shooter/index.astro \
   src/pages/game-board-markup.test.ts
-git commit -m "fix: reset bubble shooter runs and rules"
+git commit -m "fix: align bubble shooter previews and rules"
 ```
-
-Expected: initializer/page tests PASS and typecheck exits successfully.
 
 ---
 
-### Task 6: Verify the complete single-PR implementation
+### Task 8: Verify the complete single-PR implementation
 
 **Files:**
-- Review every production and test file in the file map.
+- Review every file in the File Map.
 - Modify only when a verification command exposes a concrete defect.
 
 **Interfaces:**
 - Verifies: `docs/superpowers/specs/2026-08-10-bubble-shooter-mechanics-correction-design.md`.
 - Produces: no new feature scope.
 
-- [ ] **Step 1: Run focused Bubble Shooter tests**
+- [ ] **Step 1: Run focused Bubble Shooter and core tests**
 
 ```bash
 bun run test:run \
+  src/lib/games/core/core.test.ts \
   src/lib/games/bubble-shooter/utils.test.ts \
   src/lib/games/bubble-shooter/BubbleShooterGame.test.ts \
   src/lib/games/bubble-shooter/BubbleShooterRenderer.test.ts \
@@ -1493,7 +1899,7 @@ bun run test:run \
 
 Expected: PASS.
 
-- [ ] **Step 2: Search for stale state, signatures, and obsolete fallbacks**
+- [ ] **Step 2: Search for stale state/signatures/fallbacks**
 
 ```bash
 rg -n "rowOffset|isValidAttachPosition" src/lib/games/bubble-shooter
@@ -1502,32 +1908,18 @@ rg -n "getBubbleX|getBubbleY|getNeighbors" src/lib/games/bubble-shooter
 
 Expected: no `rowOffset` or `isValidAttachPosition`; manually confirm every geometry call uses the phase-aware signatures.
 
-- [ ] **Step 3: Re-check the critical ordering contracts in code**
+- [ ] **Step 3: Verify the critical lifecycle and unit contracts**
 
-Confirm `onGameStart` is exactly:
-
-```text
-initialize grid
-→ remove unsupported bubbles
-→ sync bubble count
-→ generate current bubble
-→ generate next bubble
+```bash
+rg -n "gameStarted && this.state.isGameOver|elapsed time in seconds" \
+  src/lib/games/core/BaseGame.ts
+rg -n "deltaTimeSeconds|/ 1_000" \
+  src/lib/games/bubble-shooter/initFramework.ts
 ```
 
-Confirm the interval-row path is exactly:
+Expected: BaseGame contains the ended-run reset guard and seconds documentation; Bubble Shooter RAF converts milliseconds to seconds.
 
-```text
-snapshot active colors
-→ shift/toggle/fill row
-→ refresh coordinates
-→ remove unsupported bubbles
-→ sync bubble count
-→ reconcile next bubble after row handling returns
-```
-
-Confirm `removeUnsupportedBubbles` returns dropped positions and does not call `syncBubbleCount`.
-
-- [ ] **Step 4: Run the full unit suite**
+- [ ] **Step 4: Run full unit suite**
 
 ```bash
 bun run test:run
@@ -1541,7 +1933,7 @@ Expected: PASS with zero failed tests.
 bun run typecheck
 ```
 
-Expected: exit code 0.
+Expected: exit 0.
 
 - [ ] **Step 6: Run lint**
 
@@ -1551,64 +1943,89 @@ bun run lint
 
 Expected: zero lint errors.
 
-- [ ] **Step 7: Run formatting check**
+- [ ] **Step 7: Run format check**
 
 ```bash
 bun run format:check
 ```
 
-Expected: exit code 0.
+Expected: exit 0.
 
-- [ ] **Step 8: Run the production build**
+- [ ] **Step 8: Run production build**
 
 ```bash
 bun run build
 ```
 
-Expected: exit code 0.
+Expected: exit 0.
 
-- [ ] **Step 9: Run existing game happy-path E2E coverage**
-
-```bash
-bun run test:e2e e2e/games/play-coverage.spec.ts
-```
-
-Expected: the play-coverage spec passes, including Bubble Shooter start/play/end/restart behavior.
-
-- [ ] **Step 10: Review the final diff against HPA-121 acceptance criteria**
-
-Check that the PR contains only the planned Bubble Shooter production/test changes plus the two planning documents. Confirm there is no `BaseGame`, shared `match3`, renderer-architecture, dependency, or unrelated-game change.
-
-- [ ] **Step 11: Commit only verification-driven fixes, if any**
-
-If Steps 1-10 required a concrete correction, stage only those files and use:
+- [ ] **Step 9: Run existing Bubble Shooter happy-path E2E coverage**
 
 ```bash
-git commit -m "test: finish bubble shooter mechanics correction"
+bunx playwright test e2e/games/play-coverage.spec.ts --grep "bubble-shooter|Bubble Shooter"
 ```
 
-If no verification-driven code change exists, do not create an empty commit.
+If the shared play-coverage suite does not expose a title matching that grep, run the complete file instead:
+
+```bash
+bunx playwright test e2e/games/play-coverage.spec.ts
+```
+
+Expected: Bubble Shooter start → play → end/restart path passes.
+
+- [ ] **Step 10: Review score-era impact without adding migration scope**
+
+Confirm the PR description notes:
+
+```text
+Bubble Shooter now awards points for dropped unsupported bubbles and reports
+successful-shot accuracy, so historical and new leaderboard rows may represent
+different scoring/stat semantics. No score migration/versioning is included.
+```
+
+- [ ] **Step 11: Inspect final diff against scope**
+
+```bash
+git diff --stat main...HEAD
+git diff --name-only main...HEAD
+```
+
+Expected production changes are limited to:
+
+```text
+src/lib/games/core/BaseGame.ts
+src/lib/games/core/core.test.ts
+src/lib/games/bubble-shooter/types.ts
+src/lib/games/bubble-shooter/utils.ts
+src/lib/games/bubble-shooter/utils.test.ts
+src/lib/games/bubble-shooter/BubbleShooterGame.ts
+src/lib/games/bubble-shooter/BubbleShooterGame.test.ts
+src/lib/games/bubble-shooter/initFramework.ts
+src/lib/games/bubble-shooter/initFramework.test.ts
+src/pages/bubble-shooter/index.astro
+src/pages/game-board-markup.test.ts
+```
+
+plus the existing design/plan documents.
+
+- [ ] **Step 12: Update the draft PR validation checklist**
+
+Mark checks complete only from the fresh outputs above. Keep the PR draft until every required check passes.
 
 ---
 
-## Review Checklist
+## Plan Self-Review
 
-Before marking PR #57 ready for review:
-
-- [ ] Existing `utils.test.ts` geometry suites use only the phase-aware centered API.
-- [ ] No commit leaves changed helper signatures with broken production callers.
-- [ ] Grid rows are dense arrays with explicit `null` empty cells; indexed tests prove no sparse holes.
-- [ ] `rowPhase` preserves physical parity through repeated row insertion.
-- [ ] Projectile motion is elapsed-time based, 50ms-clamped, and substepped at `radius / 2` maximum travel.
-- [ ] Attachment is impact-local and never overwrites an occupied cell.
-- [ ] `removeUnsupportedBubbles(constants): GridPosition[]` has no hidden count-sync side effect.
-- [ ] `resolveMatches` synchronizes count once after direct and unsupported removal.
-- [ ] Startup removes unsupported bubbles before current/next colors are generated.
-- [ ] Added-row mutation and maintenance cleanup complete before `nextBubble` reconciliation.
-- [ ] `bubblesRemaining` equals occupied grid cells after every completed board mutation.
-- [ ] Opening and future queue colors cannot depend on colors that maintenance cleanup removes.
-- [ ] Accuracy is `successfulShots / shotsFired`.
-- [ ] Ended-run Start uses local `reset()` before `start()` without modifying `BaseGame`.
-- [ ] Preview canvases clear when colors become null/undefined.
-- [ ] Rules copy reflects the configured row interval and implemented drop/accuracy behavior.
-- [ ] Focused tests, full unit suite, typecheck, lint, format check, build, and play-coverage E2E have fresh passing evidence.
+- Every design requirement maps to a task: core restart/time units (Task 1), geometry/counts (Task 2), physics (Task 3), attachment (Task 4), connectivity/drops (Task 5), colors/accuracy (Task 6), previews/rules (Task 7), full verification (Task 8).
+- Existing geometry tests are explicitly rewritten in Task 2; no obsolete helper signatures survive that commit.
+- The phase-aware helper migration and all production callers are one atomic commit, so per-commit CI is compile-safe.
+- `removeUnsupportedBubbles(constants): GridPosition[]` has one unambiguous contract and no count-sync side effect.
+- Dense-array invariants use indexed checks rather than callbacks that skip holes.
+- Opening queue generation occurs only after startup connectivity cleanup.
+- Added-row queue reconciliation occurs only after row mutation, connectivity cleanup, and count sync.
+- Blocked attachment consumes a shot but cannot trigger game over except through the existing danger-zone condition.
+- The substep regression uses 4000px/s so it fails without substeps; it does not merely test the 50ms clamp.
+- Bubble Shooter uses seconds, matching the shared `BaseGame.update` contract and Evader precedent.
+- Connectivity/drop work is separate from active-color/accuracy work for cleaner review boundaries.
+- Scoring-era comparability is documented as a risk; no migration scope is added.
+- No `TBD`, `TODO`, compatibility shim, shared hex abstraction, or unrelated refactor is planned.

--- a/docs/superpowers/plans/2026-08-10-bubble-shooter-mechanics-correction.md
+++ b/docs/superpowers/plans/2026-08-10-bubble-shooter-mechanics-correction.md
@@ -4,7 +4,7 @@
 
 **Goal:** Correct Bubble Shooter hex geometry, projectile simulation, legal attachment, match resolution, run lifecycle, statistics, and rules in one implementation PR.
 
-**Architecture:** Keep the current `BaseGame` + Pixi renderer + initializer boundaries. Add phase-aware pure geometry helpers in `utils.ts`; keep state transitions and board algorithms in `BubbleShooterGame.ts`; keep DOM lifecycle and preview behavior in `initFramework.ts`. No new production module or dependency is required.
+**Architecture:** Keep the current `BaseGame` + Pixi renderer + initializer boundaries. Put phase-aware pure geometry in `utils.ts`, board and projectile mechanics in `BubbleShooterGame.ts`, and browser lifecycle/preview behavior in `initFramework.ts`. Do not add a production file, dependency, physics engine, or cross-game abstraction.
 
 **Tech Stack:** Astro 5, TypeScript, PixiJS 8, Vitest/jsdom, Playwright, Bun 1.3.1.
 
@@ -12,104 +12,85 @@
 
 - Deliver every task on branch `agent/hpa-121-bubble-shooter-mechanics` in the same draft PR.
 - Track the work under Linear issue `HPA-121`.
-- Do not modify `BaseGame` behavior or unrelated games.
-- Do not add a physics engine, grid dependency, source abstraction, animation, asset, sound, power-up, level, or difficulty feature.
-- Treat `projectileSpeed` as pixels per second and set the default to exactly `720`.
-- Clamp one projectile update to exactly `50ms` and limit one collision substep to at most `bubbleRadius / 2` travel.
+- Do not change `BaseGame` or unrelated games.
+- Set default `projectileSpeed` to exactly `720` pixels per second.
+- Clamp a projectile update to exactly `50ms`.
+- Limit a projectile substep to at most `bubbleRadius / 2` travel.
 - Keep `MATCH_THRESHOLD = 3`, `POINTS_PER_BUBBLE = 10`, and `ALL_CLEAR_BONUS = 1000`.
-- Count both direct matches and ceiling-disconnected drops in shot score, `bubblesPopped`, and `largestCombo`.
-- Count one `successfulShot` only when the newly attached bubble creates a direct same-color match of at least three.
-- Preserve the already-previewed current bubble; only reconcile future `nextBubble` colors after board resolution.
-- Use deterministic grids or stubbed `Math.random` in tests.
-- Do not preserve backward compatibility for the internal `rowOffset` state field or old utility signatures.
+- Count direct matches and ceiling-disconnected drops in score, `bubblesPopped`, and `largestCombo`.
+- Increment `successfulShots` once only when the attached bubble creates a direct same-color group of at least three.
+- Preserve the already-previewed current bubble. Reconcile only the future `nextBubble` after board resolution.
+- Initial-grid generation samples a snapshot of `config.colors`.
+- Added-row generation samples one snapshot of currently active board colors before mutating the row.
+- Tests must use deterministic state or a stubbed `Math.random`.
+- Remove `rowOffset`; no compatibility layer is required for internal state or helper signatures.
 
 ---
 
 ## File map
 
-### Production files
+### Production
 
 - `src/lib/games/bubble-shooter/types.ts`
-  - Add `RowPhase` and `successfulShots`.
-  - Remove `rowOffset`.
-  - Clarify that `projectileSpeed` is pixels per second.
+  - Add `RowPhase` and `successfulShots`; remove `rowOffset`; document speed units.
 - `src/lib/games/bubble-shooter/utils.ts`
-  - Own physical row parity, row width, centered coordinates, and phase-aware neighbors.
+  - Calculate physical parity, row width, centered coordinates, and neighbors.
 - `src/lib/games/bubble-shooter/BubbleShooterGame.ts`
-  - Own coordinate synchronization, projectile substeps, legal attachment, board counts, ceiling connectivity, match resolution, active colors, score, and statistics.
+  - Synchronize board state, simulate projectiles, attach legally, resolve matches/drops, choose colors, and calculate stats.
 - `src/lib/games/bubble-shooter/initFramework.ts`
-  - Own clean ended-run start behavior and null-aware preview clearing.
+  - Reset ended runs and clear preview canvases.
 - `src/pages/bubble-shooter/index.astro`
-  - Render the configured row interval and corrected rules.
+  - Render rules that match configured behavior.
 
-### Test files
+### Tests
 
 - `src/lib/games/bubble-shooter/utils.test.ts`
-  - Cover phase-aware geometry and neighbor invariants.
 - `src/lib/games/bubble-shooter/BubbleShooterGame.test.ts`
-  - Cover row insertion, physics, legal attachment, match/drop behavior, colors, counts, and statistics.
 - `src/lib/games/bubble-shooter/initFramework.test.ts`
-  - Cover ended-run reset and preview clearing while retaining pointer/RAF tests.
 - `src/pages/game-board-markup.test.ts`
-  - Pin Bubble Shooter rule-copy wiring.
 
-No change is planned for `BubbleShooterRenderer.ts`; it should continue rendering state coordinates without calculating grid geometry.
+`BubbleShooterRenderer.ts` remains unchanged; it continues drawing coordinates supplied by game state.
 
 ---
 
-### Task 1: Introduce phase-aware centered hex geometry
+### Task 1: Add phase-aware centered hex geometry
 
 **Files:**
 - Modify: `src/lib/games/bubble-shooter/types.ts:1-75`
 - Modify: `src/lib/games/bubble-shooter/utils.ts:1-75`
-- Modify: `src/lib/games/bubble-shooter/utils.test.ts:1-150`
+- Modify: `src/lib/games/bubble-shooter/utils.test.ts:1-160`
 
 **Interfaces:**
 - Produces: `RowPhase = 0 | 1`
-- Produces: `getRowParity(row: number, rowPhase: RowPhase): RowPhase`
-- Produces: `getRowColumnCount(row: number, rowPhase: RowPhase, constants: GameConstants): number`
-- Produces: `getBubbleX(col: number, row: number, rowPhase: RowPhase, constants: GameConstants): number`
-- Produces: `getBubbleY(row: number, constants: GameConstants): number`
-- Produces: `getNeighbors(row: number, col: number, rowPhase: RowPhase, constants: GameConstants): GridPosition[]`
+- Produces: `getRowParity(row, rowPhase)`
+- Produces: `getRowColumnCount(row, rowPhase, constants)`
+- Produces: `getBubbleX(col, row, rowPhase, constants)`
+- Produces: `getBubbleY(row, constants)`
+- Produces: `getNeighbors(row, col, rowPhase, constants)`
 
 - [ ] **Step 1: Write failing geometry tests**
 
-Update imports in `utils.test.ts` to include `getRowParity` and `getRowColumnCount`, then replace the old coordinate/neighbor cases with phase-aware assertions. Keep the existing color and canvas-drawing tests.
+Add imports for `getRowParity` and `getRowColumnCount`, then add:
 
 ```ts
-import {
-    pixiColorToHex,
-    getRowParity,
-    getRowColumnCount,
-    getBubbleX,
-    getBubbleY,
-    getNeighbors,
-    drawBubbleOnCanvas,
-} from './utils'
-
 describe('phase-aware hex geometry', () => {
-    it('alternates physical parity from the top-row phase', () => {
+    it('derives row parity and width from rowPhase', () => {
         expect(getRowParity(0, 0)).toBe(0)
         expect(getRowParity(1, 0)).toBe(1)
         expect(getRowParity(0, 1)).toBe(1)
         expect(getRowParity(1, 1)).toBe(0)
-    })
-
-    it('uses fourteen cells for full rows and thirteen for offset rows', () => {
         expect(getRowColumnCount(0, 0, constants)).toBe(14)
-        expect(getRowColumnCount(1, 0, constants)).toBe(13)
         expect(getRowColumnCount(0, 1, constants)).toBe(13)
-        expect(getRowColumnCount(1, 1, constants)).toBe(14)
     })
 
-    it('centers both row shapes in the 600px board', () => {
+    it('centers both row shapes in the 600px canvas', () => {
         expect(getBubbleX(0, 0, 0, constants)).toBe(40)
         expect(getBubbleX(13, 0, 0, constants)).toBe(560)
         expect(getBubbleX(0, 0, 1, constants)).toBe(60)
         expect(getBubbleX(12, 0, 1, constants)).toBe(540)
     })
 
-    it('keeps every neighbor exactly one diameter away', () => {
+    it('keeps each interior neighbor one diameter away', () => {
         const origin = { row: 5, col: 5 }
         const originPoint = {
             x: getBubbleX(origin.col, origin.row, 1, constants),
@@ -122,14 +103,14 @@ describe('phase-aware hex geometry', () => {
             1,
             constants
         )) {
-            const neighborPoint = {
+            const point = {
                 x: getBubbleX(neighbor.col, neighbor.row, 1, constants),
                 y: getBubbleY(neighbor.row, constants),
             }
             expect(
                 Math.hypot(
-                    neighborPoint.x - originPoint.x,
-                    neighborPoint.y - originPoint.y
+                    point.x - originPoint.x,
+                    point.y - originPoint.y
                 )
             ).toBeCloseTo(constants.BUBBLE_RADIUS * 2)
         }
@@ -137,25 +118,25 @@ describe('phase-aware hex geometry', () => {
 })
 ```
 
-- [ ] **Step 2: Run the geometry test and verify it fails**
+Keep the existing color-conversion and canvas-drawing tests.
 
-Run:
+- [ ] **Step 2: Verify the test fails**
 
 ```bash
 bun run test:run src/lib/games/bubble-shooter/utils.test.ts
 ```
 
-Expected: FAIL because `getRowParity` and `getRowColumnCount` do not exist and the old helper signatures do not accept `rowPhase`.
+Expected: FAIL because phase helpers and signatures do not exist.
 
-- [ ] **Step 3: Add `RowPhase` and replace geometry helpers**
+- [ ] **Step 3: Implement the geometry API**
 
-In `types.ts`, add:
+In `types.ts`:
 
 ```ts
 export type RowPhase = 0 | 1
 ```
 
-In `utils.ts`, import `RowPhase` and implement:
+In `utils.ts`:
 
 ```ts
 import type { GameConstants, GridPosition, RowPhase } from './types'
@@ -210,9 +191,8 @@ export function getNeighbors(
     rowPhase: RowPhase,
     constants: GameConstants
 ): GridPosition[] {
-    const parity = getRowParity(row, rowPhase)
     const offsets =
-        parity === 0
+        getRowParity(row, rowPhase) === 0
             ? [
                   [-1, -1],
                   [-1, 0],
@@ -233,25 +213,21 @@ export function getNeighbors(
     return offsets.flatMap(([rowDelta, colDelta]) => {
         const neighborRow = row + rowDelta
         const neighborCol = col + colDelta
-        if (
-            neighborRow < 0 ||
-            neighborRow >= constants.GRID_HEIGHT ||
-            neighborCol < 0 ||
-            neighborCol >=
+        const inBounds =
+            neighborRow >= 0 &&
+            neighborRow < constants.GRID_HEIGHT &&
+            neighborCol >= 0 &&
+            neighborCol <
                 getRowColumnCount(neighborRow, rowPhase, constants)
-        ) {
-            return []
-        }
-        return [{ row: neighborRow, col: neighborCol }]
+
+        return inBounds
+            ? [{ row: neighborRow, col: neighborCol }]
+            : []
     })
 }
 ```
 
-Keep `pixiColorToHex` and `drawBubbleOnCanvas` unchanged.
-
-- [ ] **Step 4: Run the geometry test and verify it passes**
-
-Run:
+- [ ] **Step 4: Verify geometry tests pass**
 
 ```bash
 bun run test:run src/lib/games/bubble-shooter/utils.test.ts
@@ -259,7 +235,7 @@ bun run test:run src/lib/games/bubble-shooter/utils.test.ts
 
 Expected: PASS.
 
-- [ ] **Step 5: Commit the geometry unit**
+- [ ] **Step 5: Commit**
 
 ```bash
 git add src/lib/games/bubble-shooter/types.ts \
@@ -270,35 +246,43 @@ git commit -m "fix: make bubble shooter grid phase aware"
 
 ---
 
-### Task 2: Make grid state and row insertion obey geometry invariants
+### Task 2: Enforce dense grid rows, coordinates, counts, and row phase
 
 **Files:**
-- Modify: `src/lib/games/bubble-shooter/types.ts:35-70`
-- Modify: `src/lib/games/bubble-shooter/BubbleShooterGame.ts:1-610`
-- Modify: `src/lib/games/bubble-shooter/BubbleShooterGame.test.ts:1-650`
+- Modify: `src/lib/games/bubble-shooter/types.ts:30-75`
+- Modify: `src/lib/games/bubble-shooter/BubbleShooterGame.ts:1-620`
+- Modify: `src/lib/games/bubble-shooter/BubbleShooterGame.test.ts:1-700`
 
 **Interfaces:**
-- Consumes: all Task 1 geometry helpers.
-- Produces: `BubbleShooterState.rowPhase: RowPhase`.
-- Produces: `refreshBubbleCoordinates(constants: GameConstants): void`.
-- Produces: `syncBubbleCount(): number`.
-- Preserves: `grid` as the authoritative board representation.
+- Consumes: Task 1 geometry helpers.
+- Produces: `BubbleShooterState.rowPhase`.
+- Produces: `refreshBubbleCoordinates(constants)`.
+- Produces: `syncBubbleCount()`.
+- Produces: `randomColor(colors)`.
 
-- [ ] **Step 1: Add failing row-insertion and count-invariant tests**
+- [ ] **Step 1: Add test wrappers and a grid invariant assertion**
 
-Add test helpers near `stateOf` in `BubbleShooterGame.test.ts`:
+Import `RowPhase`, `GridPosition`, and `getRowColumnCount`. Add:
 
 ```ts
-function expectedOccupiedCount(state: BubbleShooterState): number {
-    return state.grid.reduce(
-        (total, row) => total + row.filter(Boolean).length,
-        0
-    )
-}
+const bubbleX = (
+    col: number,
+    row: number,
+    rowPhase: RowPhase = 0
+): number => getBubbleX(col, row, rowPhase, CONSTANTS)
 
-function expectGridCoordinatesToMatchState(
-    game: BubbleShooterGame
-): void {
+const bubbleY = (row: number): number => getBubbleY(row, CONSTANTS)
+
+const neighbors = (
+    row: number,
+    col: number,
+    rowPhase: RowPhase = 0
+): GridPosition[] => getNeighbors(row, col, rowPhase, CONSTANTS)
+
+const countGrid = (grid: BubbleShooterState['grid']): number =>
+    grid.reduce((total, row) => total + row.filter(Boolean).length, 0)
+
+function expectGridInvariant(game: BubbleShooterGame): void {
     const state = stateOf(game)
     const constants = game.getConstantsView()
 
@@ -306,6 +290,8 @@ function expectGridCoordinatesToMatchState(
         expect(row).toHaveLength(
             getRowColumnCount(rowIndex, state.rowPhase, constants)
         )
+        expect(row.every(cell => cell === null || cell !== undefined)).toBe(true)
+
         row.forEach((bubble, colIndex) => {
             if (!bubble) {
                 return
@@ -323,14 +309,17 @@ function expectGridCoordinatesToMatchState(
             )
         })
     })
-    expect(state.bubblesRemaining).toBe(expectedOccupiedCount(state))
+
+    expect(state.bubblesRemaining).toBe(countGrid(state.grid))
 }
 ```
 
-Add deterministic insertion coverage:
+Replace old utility call sites in this test file with the wrappers.
+
+- [ ] **Step 2: Add a failing two-row insertion test**
 
 ```ts
-it('preserves physical layout through two inserted rows', () => {
+it('preserves the physical grid through two inserted rows', () => {
     vi.spyOn(Math, 'random').mockReturnValue(0)
     const game = makeGame({ newRowFillChance: 1 })
     game.start()
@@ -341,71 +330,49 @@ it('preserves physical layout through two inserted rows', () => {
     const constants = game.getConstantsView()
 
     expect(stateOf(game).rowPhase).toBe(0)
-    expectGridCoordinatesToMatchState(game)
+    expectGridInvariant(game)
 
     internal.addRowAtTop(constants)
     expect(stateOf(game).rowPhase).toBe(1)
-    expectGridCoordinatesToMatchState(game)
+    expectGridInvariant(game)
 
     internal.addRowAtTop(constants)
     expect(stateOf(game).rowPhase).toBe(0)
-    expectGridCoordinatesToMatchState(game)
+    expectGridInvariant(game)
 })
 ```
 
-- [ ] **Step 2: Update test call sites to the Task 1 signatures**
-
-Add local wrappers to reduce repeated phase arguments:
-
-```ts
-const bubbleX = (
-    col: number,
-    row: number,
-    rowPhase: RowPhase = 0
-): number => getBubbleX(col, row, rowPhase, CONSTANTS)
-
-const bubbleY = (row: number): number => getBubbleY(row, CONSTANTS)
-
-const neighbors = (
-    row: number,
-    col: number,
-    rowPhase: RowPhase = 0
-): GridPosition[] => getNeighbors(row, col, rowPhase, CONSTANTS)
-```
-
-Replace all old direct calls in `BubbleShooterGame.test.ts` with these wrappers. Verify no stale signatures remain:
-
-```bash
-rg -n "getBubbleX\([^,]+,[^,]+, CONSTANTS|getBubbleY\([^,]+, 0, CONSTANTS|getNeighbors\([^,]+,[^,]+, CONSTANTS" src/lib/games/bubble-shooter
-```
-
-Expected: no matches.
-
-- [ ] **Step 3: Run the game tests and verify the new invariant test fails**
+- [ ] **Step 3: Verify the game test fails**
 
 ```bash
 bun run test:run src/lib/games/bubble-shooter/BubbleShooterGame.test.ts
 ```
 
-Expected: FAIL because state lacks `rowPhase`, coordinates still use logical `row % 2`, and row lengths are not normalized after insertion.
+Expected: FAIL because state lacks `rowPhase`, rows can be sparse, and insertion does not recompute `x`.
 
-- [ ] **Step 4: Add row phase and authoritative synchronization**
+- [ ] **Step 4: Add dense-row and count helpers**
 
-In `types.ts`, replace `rowOffset` with:
+Replace `rowOffset` with `rowPhase: RowPhase` in state and initialize `rowPhase: 0`.
 
-```ts
-rowPhase: RowPhase
-```
-
-In `createInitialState()` initialize:
+Add:
 
 ```ts
-rowPhase: 0,
-```
+private createEmptyRow(
+    row: number,
+    constants: GameConstants
+): (Bubble | null)[] {
+    return Array.from(
+        {
+            length: getRowColumnCount(
+                row,
+                this.state.rowPhase,
+                constants
+            ),
+        },
+        () => null
+    )
+}
 
-Add these private methods in `BubbleShooterGame.ts`:
-
-```ts
 private refreshBubbleCoordinates(constants: GameConstants): void {
     for (let row = 0; row < constants.GRID_HEIGHT; row++) {
         const columnCount = getRowColumnCount(
@@ -413,14 +380,16 @@ private refreshBubbleCoordinates(constants: GameConstants): void {
             this.state.rowPhase,
             constants
         )
-        const gridRow = this.state.grid[row] ?? []
-        gridRow.length = columnCount
-        this.state.grid[row] = gridRow
+        const previousRow = this.state.grid[row] ?? []
+        const normalizedRow = Array.from(
+            { length: columnCount },
+            (_, col) => previousRow[col] ?? null
+        )
+        this.state.grid[row] = normalizedRow
 
-        for (let col = 0; col < columnCount; col++) {
-            const bubble = gridRow[col]
+        normalizedRow.forEach((bubble, col) => {
             if (!bubble) {
-                continue
+                return
             }
             bubble.x = getBubbleX(
                 col,
@@ -429,7 +398,7 @@ private refreshBubbleCoordinates(constants: GameConstants): void {
                 constants
             )
             bubble.y = getBubbleY(row, constants)
-        }
+        })
     }
 }
 
@@ -441,9 +410,22 @@ private syncBubbleCount(): number {
     this.state.bubblesRemaining = count
     return count
 }
+
+private randomColor(colors: number[]): number {
+    return colors[Math.floor(Math.random() * colors.length)]
+}
 ```
 
-Update `initializeGrid()` to use `getRowColumnCount`, the new coordinate signatures, and finish with:
+- [ ] **Step 5: Make initialization use a configured-color snapshot**
+
+At the beginning of `initializeGrid()`:
+
+```ts
+const generationColors = [...constants.COLORS]
+this.state.grid = []
+```
+
+Create every row with `createEmptyRow`, fill initial rows with `randomColor(generationColors)`, then finish with:
 
 ```ts
 this.refreshBubbleCoordinates(constants)
@@ -451,34 +433,32 @@ this.syncBubbleCount()
 this.state.needsRedraw = true
 ```
 
-Update every production call to `getBubbleX`, `getBubbleY`, and `getNeighbors` to pass `this.state.rowPhase`.
+Update every production geometry call to pass `this.state.rowPhase`.
 
-Replace `addRowAtTop()` with phase-aware shifting:
+- [ ] **Step 6: Make row insertion toggle phase and use an active-color snapshot**
+
+Use this structure:
 
 ```ts
 private addRowAtTop(constants: GameConstants): void {
+    const generationColors = this.getAvailableBubbleColors()
+
     for (let row = constants.GRID_HEIGHT - 1; row > 0; row--) {
-        this.state.grid[row] = this.state.grid[row - 1]
-            ? [...this.state.grid[row - 1]]
-            : []
+        this.state.grid[row] = [...(this.state.grid[row - 1] ?? [])]
     }
 
     this.state.rowPhase = this.state.rowPhase === 0 ? 1 : 0
-    const columnCount = getRowColumnCount(
-        0,
-        this.state.rowPhase,
-        constants
-    )
-    this.state.grid[0] = Array.from({ length: columnCount }, () => {
-        if (Math.random() >= this.config.newRowFillChance) {
-            return null
+    const topRow = this.createEmptyRow(0, constants)
+    for (let col = 0; col < topRow.length; col++) {
+        if (Math.random() < this.config.newRowFillChance) {
+            topRow[col] = {
+                color: this.randomColor(generationColors),
+                x: 0,
+                y: 0,
+            }
         }
-        return {
-            color: this.randomAvailableColor(),
-            x: 0,
-            y: 0,
-        }
-    })
+    }
+    this.state.grid[0] = topRow
 
     this.refreshBubbleCoordinates(constants)
     this.syncBubbleCount()
@@ -486,16 +466,9 @@ private addRowAtTop(constants: GameConstants): void {
 }
 ```
 
-At this task, implement `randomAvailableColor()` as a private helper that chooses from `config.colors`; Task 5 will change its source to active board colors:
+For this task, define `getAvailableBubbleColors()` to return `[...config.colors]`; Task 5 replaces it with the active-board scan.
 
-```ts
-private randomAvailableColor(): number {
-    const colors = this.config.colors
-    return colors[Math.floor(Math.random() * colors.length)]
-}
-```
-
-- [ ] **Step 5: Run geometry and game tests**
+- [ ] **Step 7: Verify geometry and game tests**
 
 ```bash
 bun run test:run \
@@ -503,9 +476,9 @@ bun run test:run \
   src/lib/games/bubble-shooter/BubbleShooterGame.test.ts
 ```
 
-Expected: PASS after updating existing expectations for centered coordinates and `rowPhase`.
+Expected: PASS after updating old coordinate expectations to the centered layout.
 
-- [ ] **Step 6: Commit the board invariant unit**
+- [ ] **Step 8: Commit**
 
 ```bash
 git add src/lib/games/bubble-shooter/types.ts \
@@ -516,25 +489,22 @@ git commit -m "fix: preserve bubble shooter row geometry"
 
 ---
 
-### Task 3: Make projectile movement elapsed-time based and collision safe
+### Task 3: Make projectile movement elapsed-time based
 
 **Files:**
-- Modify: `src/lib/games/bubble-shooter/types.ts:55-70`
-- Modify: `src/lib/games/bubble-shooter/BubbleShooterGame.ts:20-380`
-- Modify: `src/lib/games/bubble-shooter/BubbleShooterGame.test.ts:220-360`
+- Modify: `src/lib/games/bubble-shooter/types.ts:55-75`
+- Modify: `src/lib/games/bubble-shooter/BubbleShooterGame.ts:20-400`
+- Modify: `src/lib/games/bubble-shooter/BubbleShooterGame.test.ts:220-400`
 
 **Interfaces:**
-- Produces: `updateProjectile(deltaTimeMs: number): boolean`.
-- Produces: `reflectProjectileOffWalls(constants: GameConstants): void`.
-- Changes: `BubbleShooterConfig.projectileSpeed` is pixels per second.
-- Keeps: projectile `vx` and `vy` in pixels per second.
+- Produces: `updateProjectile(deltaTimeMs: number)`.
+- Produces: `reflectProjectileOffWalls(constants)`.
+- Changes: `projectileSpeed` and projectile velocity are pixels per second.
 
-- [ ] **Step 1: Write failing refresh-rate and wall-bound tests**
-
-Add a deterministic simulation helper:
+- [ ] **Step 1: Write a failing refresh-rate test**
 
 ```ts
-function simulateProjectileForOneSecond(frameCount: number): number {
+function simulateProjectile(frameCount: number): number {
     const game = makeGame({
         gameHeight: 12_000,
         shooterY: 10_000,
@@ -548,7 +518,17 @@ function simulateProjectileForOneSecond(frameCount: number): number {
             vy: -720,
             color: 0xff0000,
         },
-        grid: Array.from({ length: CONSTANTS.GRID_HEIGHT }, () => []),
+        grid: Array.from(
+            { length: CONSTANTS.GRID_HEIGHT },
+            (_, row) =>
+                Array.from(
+                    {
+                        length: getRowColumnCount(row, 0, CONSTANTS),
+                    },
+                    () => null
+                )
+        ),
+        rowPhase: 0,
     })
 
     for (let frame = 0; frame < frameCount; frame++) {
@@ -557,17 +537,21 @@ function simulateProjectileForOneSecond(frameCount: number): number {
     return stateOf(game).projectile?.y ?? Number.NaN
 }
 
-it('moves the same distance at 30Hz, 60Hz, and 120Hz', () => {
-    const at30Hz = simulateProjectileForOneSecond(30)
-    const at60Hz = simulateProjectileForOneSecond(60)
-    const at120Hz = simulateProjectileForOneSecond(120)
+it('moves equally at 30Hz, 60Hz, and 120Hz', () => {
+    const at30Hz = simulateProjectile(30)
+    const at60Hz = simulateProjectile(60)
+    const at120Hz = simulateProjectile(120)
 
     expect(at30Hz).toBeCloseTo(4_280, 5)
     expect(at60Hz).toBeCloseTo(at30Hz, 5)
     expect(at120Hz).toBeCloseTo(at30Hz, 5)
 })
+```
 
-it('reflects position and velocity inside the right wall', () => {
+- [ ] **Step 2: Write a failing reflected-position test**
+
+```ts
+it('keeps the projectile inside the right wall after reflection', () => {
     const game = makeGame({ projectileSpeed: 720 })
     setState(game, {
         projectile: {
@@ -577,69 +561,44 @@ it('reflects position and velocity inside the right wall', () => {
             vy: 0,
             color: 0xff0000,
         },
-        grid: Array.from({ length: CONSTANTS.GRID_HEIGHT }, () => []),
+        grid: [],
     })
 
     game.updateProjectile(16)
 
-    const projectile = stateOf(game).projectile
-    expect(projectile?.x).toBeLessThanOrEqual(
+    expect(stateOf(game).projectile?.x).toBeLessThanOrEqual(
         CONSTANTS.GAME_WIDTH - CONSTANTS.BUBBLE_RADIUS
     )
-    expect(projectile?.vx).toBeLessThan(0)
+    expect(stateOf(game).projectile?.vx).toBeLessThan(0)
 })
 ```
 
-- [ ] **Step 2: Run the focused tests and verify they fail**
+- [ ] **Step 3: Verify the tests fail**
 
 ```bash
 bun run test:run src/lib/games/bubble-shooter/BubbleShooterGame.test.ts -t "30Hz|right wall"
 ```
 
-Expected: FAIL because `updateProjectile` ignores elapsed time and can leave `x` outside the legal range.
+Expected: FAIL because frame time is ignored and position is not reflected inside bounds.
 
-- [ ] **Step 3: Convert speed and implement bounded substeps**
+- [ ] **Step 4: Convert speed and add bounded substeps**
 
-Update the default:
+Set the default to `720` and document `projectileSpeed: number // pixels per second`.
 
-```ts
-projectileSpeed: 720,
-```
-
-Update the config comment in `types.ts`:
-
-```ts
-projectileSpeed: number // pixels per second
-```
-
-Add constants near the scoring constants:
+Add:
 
 ```ts
 const MAX_PROJECTILE_FRAME_MS = 50
 const MAX_PROJECTILE_SUBSTEP_RATIO = 0.5
+
+type ProjectileImpact =
+    | { kind: 'ceiling' }
+    | { kind: 'bubble'; anchor: GridPosition }
 ```
 
-Pass RAF time through `update`:
+Pass `deltaTime` from `update` to `updateProjectile`.
 
-```ts
-update(deltaTime: number): void {
-    if (
-        !this.state.isActive ||
-        this.state.isPaused ||
-        this.state.isGameOver
-    ) {
-        return
-    }
-
-    this.updateProjectile(deltaTime)
-
-    if (this.state.needsRedraw) {
-        this.emitStateChange()
-    }
-}
-```
-
-Implement substeps:
+Implement:
 
 ```ts
 updateProjectile(deltaTimeMs: number): boolean {
@@ -655,17 +614,17 @@ updateProjectile(deltaTimeMs: number): boolean {
     )
     const elapsedSeconds = clampedMs / 1_000
     const speed = Math.hypot(projectile.vx, projectile.vy)
-    const maxSubstepDistance =
+    const maxDistance =
         constants.BUBBLE_RADIUS * MAX_PROJECTILE_SUBSTEP_RATIO
-    const substepCount = Math.max(
+    const stepCount = Math.max(
         1,
-        Math.ceil((speed * elapsedSeconds) / maxSubstepDistance)
+        Math.ceil((speed * elapsedSeconds) / maxDistance)
     )
-    const substepSeconds = elapsedSeconds / substepCount
+    const stepSeconds = elapsedSeconds / stepCount
 
-    for (let step = 0; step < substepCount; step++) {
-        projectile.x += projectile.vx * substepSeconds
-        projectile.y += projectile.vy * substepSeconds
+    for (let step = 0; step < stepCount; step++) {
+        projectile.x += projectile.vx * stepSeconds
+        projectile.y += projectile.vy * stepSeconds
         this.reflectProjectileOffWalls(constants)
 
         const anchor = this.checkBubbleCollision()
@@ -684,9 +643,7 @@ updateProjectile(deltaTimeMs: number): boolean {
 }
 ```
 
-Task 4 defines the final `ProjectileImpact` type and `attachBubble` signature. During this task, add the union type and adapt the existing attachment function without changing candidate behavior yet so the physics commit compiles.
-
-Add wall reflection:
+Add:
 
 ```ts
 private reflectProjectileOffWalls(constants: GameConstants): void {
@@ -710,17 +667,13 @@ private reflectProjectileOffWalls(constants: GameConstants): void {
 }
 ```
 
-- [ ] **Step 4: Update existing projectile tests to pass milliseconds**
+Temporarily adapt `attachBubble` to the `ProjectileImpact` signature while retaining its current candidate logic; Task 4 replaces that logic.
 
-Every direct call must pass an elapsed time. Use `16` for one nominal frame unless a test explicitly exercises another rate:
+- [ ] **Step 5: Update existing direct calls**
 
-```ts
-game.updateProjectile(16)
-```
+Pass `16` to ordinary one-frame `updateProjectile` tests and update movement expectations to velocity multiplied by `0.016`.
 
-Update expected one-frame travel from raw velocity to velocity multiplied by `0.016`.
-
-- [ ] **Step 5: Run Bubble Shooter game tests**
+- [ ] **Step 6: Verify game tests**
 
 ```bash
 bun run test:run src/lib/games/bubble-shooter/BubbleShooterGame.test.ts
@@ -728,7 +681,7 @@ bun run test:run src/lib/games/bubble-shooter/BubbleShooterGame.test.ts
 
 Expected: PASS.
 
-- [ ] **Step 6: Commit the physics unit**
+- [ ] **Step 7: Commit**
 
 ```bash
 git add src/lib/games/bubble-shooter/types.ts \
@@ -739,34 +692,34 @@ git commit -m "fix: make bubble shooter physics time based"
 
 ---
 
-### Task 4: Restrict attachment to legal impact-local cells
+### Task 4: Restrict attachment to impact-local empty cells
 
 **Files:**
-- Modify: `src/lib/games/bubble-shooter/BubbleShooterGame.ts:300-500`
-- Modify: `src/lib/games/bubble-shooter/BubbleShooterGame.test.ts:360-520`
+- Modify: `src/lib/games/bubble-shooter/BubbleShooterGame.ts:300-510`
+- Modify: `src/lib/games/bubble-shooter/BubbleShooterGame.test.ts:350-560`
 
 **Interfaces:**
-- Consumes: `ProjectileImpact` introduced in Task 3.
-- Produces: `attachBubble(impact: ProjectileImpact): boolean`.
-- Produces: `findAttachPosition(constants: GameConstants, impact: ProjectileImpact): GridPosition | null`.
-- Produces: `findClosestEmptyPosition(constants: GameConstants, candidates: GridPosition[]): GridPosition | null`.
-- Removes: whole-board candidate search, `isValidAttachPosition`, and occupied top-center fallback.
+- Consumes: `ProjectileImpact` from Task 3.
+- Produces: `findAttachPosition(constants, impact)`.
+- Produces: `findClosestEmptyPosition(constants, candidates)`.
+- Removes: global candidate search, `isValidAttachPosition`, and occupied top-center fallback.
 
-- [ ] **Step 1: Write failing legal-attachment tests**
-
-Add these cases:
+- [ ] **Step 1: Write a failing anchor-local attachment test**
 
 ```ts
-it('attaches a bubble impact only beside its anchor', () => {
+it('attaches a bubble impact only beside the collided anchor', () => {
     const game = makeGame()
     const anchor = { row: 4, col: 4 }
     const grid = Array.from(
         { length: CONSTANTS.GRID_HEIGHT },
-        () => [] as BubbleShooterState['grid'][number]
+        (_, row) =>
+            Array.from(
+                {
+                    length: getRowColumnCount(row, 0, CONSTANTS),
+                },
+                () => null
+            )
     )
-    grid[anchor.row] = Array(
-        getRowColumnCount(anchor.row, 0, CONSTANTS)
-    ).fill(null)
     grid[anchor.row][anchor.col] = {
         color: 0x00ff00,
         x: bubbleX(anchor.col, anchor.row),
@@ -788,13 +741,19 @@ it('attaches a bubble impact only beside its anchor', () => {
 
     game.attachBubble({ kind: 'bubble', anchor })
 
-    const redCells = neighbors(anchor.row, anchor.col).filter(
-        ({ row, col }) => stateOf(game).grid[row]?.[col]?.color === 0xff0000
-    )
-    expect(redCells).toHaveLength(1)
+    expect(
+        neighbors(anchor.row, anchor.col).filter(
+            ({ row, col }) =>
+                stateOf(game).grid[row][col]?.color === 0xff0000
+        )
+    ).toHaveLength(1)
 })
+```
 
-it('never overwrites a full board when no legal cell exists', () => {
+- [ ] **Step 2: Write a failing full-board no-overwrite test**
+
+```ts
+it('ends without overwriting when no legal attachment exists', () => {
     const game = makeGame()
     const grid = Array.from(
         { length: CONSTANTS.GRID_HEIGHT },
@@ -824,53 +783,33 @@ it('never overwrites a full board when no legal cell exists', () => {
             vy: -720,
             color: 0x00ff00,
         },
-        bubblesRemaining: expectedOccupiedCount({
-            ...stateOf(game),
-            grid,
-        }),
+        bubblesRemaining: countGrid(grid),
     })
 
     expect(game.attachBubble({ kind: 'ceiling' })).toBe(true)
     expect(JSON.stringify(stateOf(game).grid)).toBe(before)
-    expect(endSpy).toHaveBeenCalledTimes(1)
+    expect(stateOf(game).bubblesRemaining).toBe(countGrid(grid))
     expect(stateOf(game).projectile).toBeNull()
+    expect(endSpy).toHaveBeenCalledTimes(1)
 })
 ```
 
-Use a local `countGrid(grid)` helper rather than constructing a synthetic state if TypeScript rejects the second `expectedOccupiedCount` call:
-
-```ts
-const countGrid = (grid: BubbleShooterState['grid']): number =>
-    grid.reduce((total, row) => total + row.filter(Boolean).length, 0)
-```
-
-- [ ] **Step 2: Run the attachment tests and verify they fail**
+- [ ] **Step 3: Verify the tests fail**
 
 ```bash
-bun run test:run src/lib/games/bubble-shooter/BubbleShooterGame.test.ts -t "only beside|never overwrites"
+bun run test:run src/lib/games/bubble-shooter/BubbleShooterGame.test.ts -t "collided anchor|without overwriting"
 ```
 
-Expected: FAIL because the current fallback searches unrelated cells and can replace row-zero center.
+Expected: FAIL because the current fallback can search elsewhere or replace row-zero center.
 
-- [ ] **Step 3: Replace global attachment search**
-
-Define the private union near the top of `BubbleShooterGame.ts`:
-
-```ts
-type ProjectileImpact =
-    | { kind: 'ceiling' }
-    | { kind: 'bubble'; anchor: GridPosition }
-```
-
-Implement candidate selection:
+- [ ] **Step 4: Implement impact-specific candidates**
 
 ```ts
 private findAttachPosition(
     constants: GameConstants,
     impact: ProjectileImpact
 ): GridPosition | null {
-    const projectile = this.state.projectile
-    if (!projectile) {
+    if (!this.state.projectile) {
         return null
     }
 
@@ -905,14 +844,14 @@ private findClosestEmptyPosition(
         return null
     }
 
-    let closest: GridPosition | null = null
-    let closestDistance = Number.POSITIVE_INFINITY
+    let result: GridPosition | null = null
+    let resultDistance = Number.POSITIVE_INFINITY
 
     for (const candidate of candidates) {
         if (this.state.grid[candidate.row]?.[candidate.col]) {
             continue
         }
-        const candidatePoint = {
+        const candidateDistance = distance(projectile, {
             x: getBubbleX(
                 candidate.col,
                 candidate.row,
@@ -920,117 +859,35 @@ private findClosestEmptyPosition(
                 constants
             ),
             y: getBubbleY(candidate.row, constants),
-        }
-        const candidateDistance = distance(projectile, candidatePoint)
-        if (candidateDistance < closestDistance) {
-            closest = candidate
-            closestDistance = candidateDistance
+        })
+        if (candidateDistance < resultDistance) {
+            result = candidate
+            resultDistance = candidateDistance
         }
     }
 
-    return closest
+    return result
 }
 ```
 
-Update `attachBubble`:
+In `attachBubble(impact)`, if no empty position exists:
 
 ```ts
-attachBubble(impact: ProjectileImpact): boolean {
-    const projectile = this.state.projectile
-    if (!projectile) {
-        return false
-    }
-
-    const constants = this.getConstantsView()
-    const attachPosition = this.findAttachPosition(constants, impact)
-    if (
-        !attachPosition ||
-        this.state.grid[attachPosition.row]?.[attachPosition.col]
-    ) {
-        this.state.projectile = null
-        this.state.needsRedraw = true
-        this.end().catch(error =>
-            console.error('BubbleShooter end failed', error)
-        )
-        return true
-    }
-
-    const row =
-        this.state.grid[attachPosition.row] ??
-        Array(
-            getRowColumnCount(
-                attachPosition.row,
-                this.state.rowPhase,
-                constants
-            )
-        ).fill(null)
-    this.state.grid[attachPosition.row] = row
-    row[attachPosition.col] = {
-        color: projectile.color,
-        x: getBubbleX(
-            attachPosition.col,
-            attachPosition.row,
-            this.state.rowPhase,
-            constants
-        ),
-        y: getBubbleY(attachPosition.row, constants),
-    }
-    this.syncBubbleCount()
-
-    // Keep the existing match, interval-row, game-over, and projectile-clear
-    // flow here. Task 5 replaces its match-resolution portion.
-}
+this.state.projectile = null
+this.state.needsRedraw = true
+this.end().catch(error =>
+    console.error('BubbleShooter end failed', error)
+)
+return true
 ```
 
-Remove the old whole-board candidate construction, `isValidAttachPosition`, and fallback object.
+Otherwise, verify the cell is still empty, insert the bubble using phase-aware coordinates, and call `syncBubbleCount()` before match resolution. Remove `isValidAttachPosition` and all whole-board fallback code.
 
-- [ ] **Step 4: Add a delayed-frame collision regression**
+- [ ] **Step 5: Add delayed-frame tunneling coverage**
 
-Create an occupied anchor directly in the projectile path, call `updateProjectile(500)`, and assert that the clamped/substepped update attaches beside that anchor rather than passing through it:
+Place one occupied bubble 60px above a projectile moving at `-720px/s`, call `updateProjectile(500)`, and assert the projectile attaches to an anchor neighbor. The 500ms input is clamped to 50ms and split into at least four substeps.
 
-```ts
-it('does not tunnel through a bubble on a delayed frame', () => {
-    const game = makeGame({ projectileSpeed: 720 })
-    const anchor = { row: 8, col: 6 }
-    const grid = Array.from(
-        { length: CONSTANTS.GRID_HEIGHT },
-        () => [] as BubbleShooterState['grid'][number]
-    )
-    grid[anchor.row] = Array(
-        getRowColumnCount(anchor.row, 0, CONSTANTS)
-    ).fill(null)
-    grid[anchor.row][anchor.col] = {
-        color: 0x00ff00,
-        x: bubbleX(anchor.col, anchor.row),
-        y: bubbleY(anchor.row),
-    }
-
-    setState(game, {
-        grid,
-        rowPhase: 0,
-        projectile: {
-            x: bubbleX(anchor.col, anchor.row),
-            y: bubbleY(anchor.row) + 60,
-            vx: 0,
-            vy: -720,
-            color: 0xff0000,
-        },
-        bubblesRemaining: 1,
-    })
-
-    game.updateProjectile(500)
-
-    expect(stateOf(game).projectile).toBeNull()
-    expect(
-        neighbors(anchor.row, anchor.col).some(
-            ({ row, col }) =>
-                stateOf(game).grid[row]?.[col]?.color === 0xff0000
-        )
-    ).toBe(true)
-})
-```
-
-- [ ] **Step 5: Run Bubble Shooter game tests**
+- [ ] **Step 6: Verify game tests**
 
 ```bash
 bun run test:run src/lib/games/bubble-shooter/BubbleShooterGame.test.ts
@@ -1038,7 +895,7 @@ bun run test:run src/lib/games/bubble-shooter/BubbleShooterGame.test.ts
 
 Expected: PASS.
 
-- [ ] **Step 6: Commit the attachment unit**
+- [ ] **Step 7: Commit**
 
 ```bash
 git add src/lib/games/bubble-shooter/BubbleShooterGame.ts \
@@ -1048,34 +905,33 @@ git commit -m "fix: restrict bubble shooter attachment cells"
 
 ---
 
-### Task 5: Resolve direct matches, dropped clusters, active colors, and true accuracy
+### Task 5: Drop unsupported clusters, use active colors, and calculate true accuracy
 
 **Files:**
-- Modify: `src/lib/games/bubble-shooter/types.ts:25-75`
-- Modify: `src/lib/games/bubble-shooter/BubbleShooterGame.ts:80-620`
-- Modify: `src/lib/games/bubble-shooter/BubbleShooterGame.test.ts:80-650`
+- Modify: `src/lib/games/bubble-shooter/types.ts:20-80`
+- Modify: `src/lib/games/bubble-shooter/BubbleShooterGame.ts:80-650`
+- Modify: `src/lib/games/bubble-shooter/BubbleShooterGame.test.ts:70-750`
 
 **Interfaces:**
-- Produces: `ShotResolution` inside `BubbleShooterGame.ts`.
-- Produces: `successfulShots` in state, stats, and game data.
-- Produces: `collectColorCluster`, `collectCeilingConnected`, `removeUnsupportedBubbles`, `resolveMatches`, `getAvailableBubbleColors`, and `reconcileNextBubbleColor` private methods.
-- Changes: `randomAvailableColor()` chooses from active board colors with the configured palette as fallback.
+- Produces: `successfulShots` in state, end stats, and game data.
+- Produces: `ShotResolution`.
+- Produces: `collectColorCluster`, `collectCeilingConnected`, `removeUnsupportedBubbles`, `resolveMatches`, `getAvailableBubbleColors`, and `reconcileNextBubbleColor`.
 
-- [ ] **Step 1: Write failing drop, accuracy, and active-color tests**
-
-Add a direct-match-plus-drop case:
+- [ ] **Step 1: Write a failing direct-match-plus-drop test**
 
 ```ts
-it('scores direct matches and bubbles disconnected from the ceiling', () => {
+it('scores a direct match and bubbles disconnected from the ceiling', () => {
     const game = makeGame({ rowAddInterval: 99 })
     const grid = Array.from(
         { length: CONSTANTS.GRID_HEIGHT },
         (_, row) =>
-            Array(
-                getRowColumnCount(row, 0, CONSTANTS)
-            ).fill(null) as BubbleShooterState['grid'][number]
+            Array.from(
+                {
+                    length: getRowColumnCount(row, 0, CONSTANTS),
+                },
+                () => null
+            )
     )
-
     grid[0][0] = { color: 0xff0000, x: bubbleX(0, 0), y: bubbleY(0) }
     grid[0][1] = { color: 0xff0000, x: bubbleX(1, 0), y: bubbleY(0) }
     grid[1][0] = { color: 0x0000ff, x: bubbleX(0, 1), y: bubbleY(1) }
@@ -1098,20 +954,28 @@ it('scores direct matches and bubbles disconnected from the ceiling', () => {
 
     game.attachBubble({ kind: 'ceiling' })
 
-    const state = stateOf(game)
-    expect(countGrid(state.grid)).toBe(0)
-    expect(state.bubblesPopped).toBe(4)
-    expect(state.largestCombo).toBe(4)
-    expect(state.successfulShots).toBe(1)
-    expect(state.score).toBe(1_040)
-    expect(game.getGameStats().accuracy).toBe(100)
+    expect(countGrid(stateOf(game).grid)).toBe(0)
+    expect(stateOf(game).bubblesPopped).toBe(4)
+    expect(stateOf(game).largestCombo).toBe(4)
+    expect(stateOf(game).successfulShots).toBe(1)
+    expect(stateOf(game).score).toBe(1_040)
 })
 ```
 
-Add active-color coverage through the private helper:
+- [ ] **Step 2: Write failing active-color and accuracy tests**
 
 ```ts
-it('uses active grid colors and configured colors after an all-clear', () => {
+it('reports accuracy from successful shots rather than popped bubbles', () => {
+    const game = makeGame()
+    setState(game, {
+        shotsFired: 10,
+        successfulShots: 6,
+        bubblesPopped: 18,
+    })
+    expect(game.getGameStats().accuracy).toBe(60)
+})
+
+it('returns active colors and falls back after an all-clear', () => {
     const game = makeGame()
     const internal = game as unknown as {
         getAvailableBubbleColors: () => number[]
@@ -1132,36 +996,19 @@ it('uses active grid colors and configured colors after an all-clear', () => {
 })
 ```
 
-Update existing accuracy tests to set `successfulShots`, and assert that eight popped bubbles across ten shots does not define accuracy:
-
-```ts
-setState(game, {
-    shotsFired: 10,
-    successfulShots: 6,
-    bubblesPopped: 18,
-})
-expect(game.getGameStats().accuracy).toBe(60)
-```
-
-- [ ] **Step 2: Run focused tests and verify they fail**
+- [ ] **Step 3: Verify the tests fail**
 
 ```bash
-bun run test:run src/lib/games/bubble-shooter/BubbleShooterGame.test.ts -t "disconnected|active grid colors|accuracy"
+bun run test:run src/lib/games/bubble-shooter/BubbleShooterGame.test.ts -t "disconnected|successful shots|active colors"
 ```
 
-Expected: FAIL because unsupported bubbles remain, active colors are not scanned, and accuracy still uses popped bubbles.
+Expected: FAIL because unsupported bubbles remain, accuracy uses pop count, and available colors are not scanned.
 
-- [ ] **Step 3: Add state/stat contracts**
+- [ ] **Step 4: Add state and stat contracts**
 
-In `types.ts`, add `successfulShots: number` to:
+Add `successfulShots: number` to `BubbleShooterState`, `BubbleShooterEndGameStats`, and `BubbleShooterStats`. Initialize it to zero and include it in `getGameData()`.
 
-- `BubbleShooterState`,
-- `BubbleShooterEndGameStats`,
-- `BubbleShooterStats`.
-
-Initialize it to zero in `createInitialState()` and include it in `getGameData()`.
-
-Replace accuracy calculation with:
+Use:
 
 ```ts
 const accuracy =
@@ -1170,11 +1017,11 @@ const accuracy =
         : 0
 ```
 
-Return `accuracy` and `successfulShots` from `getGameStats()`.
+Return `successfulShots` and `accuracy` from `getGameStats()`.
 
-- [ ] **Step 4: Implement graph helpers and shot resolution**
+- [ ] **Step 5: Implement direct-cluster and ceiling-connectivity traversal**
 
-Add key serialization helpers inside the class methods using `${row},${col}`. Implement same-color collection:
+Use iterative DFS/BFS and phase-aware `getNeighbors`.
 
 ```ts
 private collectColorCluster(
@@ -1186,9 +1033,9 @@ private collectColorCluster(
         return []
     }
 
-    const result: GridPosition[] = []
     const visited = new Set<string>()
     const pending: GridPosition[] = [start]
+    const result: GridPosition[] = []
 
     while (pending.length > 0) {
         const current = pending.pop()!
@@ -1217,76 +1064,17 @@ private collectColorCluster(
 }
 ```
 
-Implement ceiling reachability:
+Implement `collectCeilingConnected(constants)` with the same traversal, seeded by every occupied row-zero cell and without a color predicate. Implement `removeUnsupportedBubbles(constants)` by nulling each occupied cell not present in the connected-key set and then calling `syncBubbleCount()`.
+
+- [ ] **Step 6: Replace `checkMatches` with one shot resolution**
 
 ```ts
-private collectCeilingConnected(
-    constants: GameConstants
-): Set<string> {
-    const connected = new Set<string>()
-    const pending: GridPosition[] = []
-    const topColumnCount = getRowColumnCount(
-        0,
-        this.state.rowPhase,
-        constants
-    )
-
-    for (let col = 0; col < topColumnCount; col++) {
-        if (this.state.grid[0]?.[col]) {
-            pending.push({ row: 0, col })
-        }
-    }
-
-    while (pending.length > 0) {
-        const current = pending.pop()!
-        const key = `${current.row},${current.col}`
-        if (connected.has(key) || !this.state.grid[current.row]?.[current.col]) {
-            continue
-        }
-        connected.add(key)
-        pending.push(
-            ...getNeighbors(
-                current.row,
-                current.col,
-                this.state.rowPhase,
-                constants
-            )
-        )
-    }
-
-    return connected
+interface ShotResolution {
+    directMatches: GridPosition[]
+    dropped: GridPosition[]
+    removedCount: number
 }
-```
 
-Implement unsupported removal:
-
-```ts
-private removeUnsupportedBubbles(
-    constants: GameConstants
-): GridPosition[] {
-    const connected = this.collectCeilingConnected(constants)
-    const removed: GridPosition[] = []
-
-    for (let row = 0; row < this.state.grid.length; row++) {
-        for (let col = 0; col < this.state.grid[row].length; col++) {
-            if (
-                this.state.grid[row][col] &&
-                !connected.has(`${row},${col}`)
-            ) {
-                this.state.grid[row][col] = null
-                removed.push({ row, col })
-            }
-        }
-    }
-
-    this.syncBubbleCount()
-    return removed
-}
-```
-
-Replace `checkMatches` with:
-
-```ts
 private resolveMatches(
     attached: GridPosition,
     constants: GameConstants
@@ -1318,11 +1106,9 @@ private resolveMatches(
 }
 ```
 
-Call `resolveMatches(attachPosition, constants)` immediately after attachment. Call `removeUnsupportedBubbles(constants)` without score/stat updates after `initializeGrid()` and after `addRowAtTop()` so retained state always satisfies ceiling connectivity.
+Call this after attachment. After initialization and after row insertion, call `removeUnsupportedBubbles(constants)` without score/stat changes so retained bubbles always connect to row zero.
 
-- [ ] **Step 5: Implement active-color queue reconciliation**
-
-Add:
+- [ ] **Step 7: Implement active-color selection without generation feedback**
 
 ```ts
 private getAvailableBubbleColors(): number[] {
@@ -1337,11 +1123,6 @@ private getAvailableBubbleColors(): number[] {
     return colors.size > 0 ? [...colors] : [...this.config.colors]
 }
 
-private randomAvailableColor(): number {
-    const colors = this.getAvailableBubbleColors()
-    return colors[Math.floor(Math.random() * colors.length)]
-}
-
 private reconcileNextBubbleColor(): void {
     const colors = this.getAvailableBubbleColors()
     if (
@@ -1349,29 +1130,30 @@ private reconcileNextBubbleColor(): void {
         !colors.includes(this.state.nextBubble.color)
     ) {
         this.state.nextBubble = {
-            color: colors[Math.floor(Math.random() * colors.length)],
+            color: this.randomColor(colors),
         }
     }
 }
 ```
 
-Use `randomAvailableColor()` in `generateBubble`, `generateNextBubble`, initial row creation, and new row creation. After match resolution and interval-row insertion, call:
+Use `randomColor(this.getAvailableBubbleColors())` in `generateBubble()` and `generateNextBubble()`.
 
-```ts
-this.reconcileNextBubbleColor()
-```
+Keep these separate generation snapshots:
 
-Do not reroll `currentBubble`; it was already previewed to the player.
+- `initializeGrid`: `const generationColors = [...config.colors]` before filling any cell.
+- `addRowAtTop`: `const generationColors = getAvailableBubbleColors()` before shifting or creating row zero.
 
-- [ ] **Step 6: Run game tests**
+After shot resolution and any interval row insertion, call `reconcileNextBubbleColor()`. Never reroll `currentBubble`.
+
+- [ ] **Step 8: Verify game tests**
 
 ```bash
 bun run test:run src/lib/games/bubble-shooter/BubbleShooterGame.test.ts
 ```
 
-Expected: PASS, including updated all-clear expectations and `successfulShots` fields.
+Expected: PASS, including revised all-clear and accuracy cases.
 
-- [ ] **Step 7: Commit the resolution/stat unit**
+- [ ] **Step 9: Commit**
 
 ```bash
 git add src/lib/games/bubble-shooter/types.ts \
@@ -1382,34 +1164,31 @@ git commit -m "fix: resolve bubble shooter clusters and stats"
 
 ---
 
-### Task 6: Reset ended runs, clear previews, and align rules copy
+### Task 6: Reset ended runs, clear previews, and align rules
 
 **Files:**
-- Modify: `src/lib/games/bubble-shooter/initFramework.ts:70-540`
-- Modify: `src/lib/games/bubble-shooter/initFramework.test.ts:1-650`
-- Modify: `src/pages/bubble-shooter/index.astro:1-135`
-- Modify: `src/pages/game-board-markup.test.ts:1-60`
+- Modify: `src/lib/games/bubble-shooter/initFramework.ts:70-550`
+- Modify: `src/lib/games/bubble-shooter/initFramework.test.ts:1-700`
+- Modify: `src/pages/bubble-shooter/index.astro:1-140`
+- Modify: `src/pages/game-board-markup.test.ts:1-70`
 
 **Interfaces:**
-- Consumes: `BubbleShooterState.successfulShots` and `rowPhase` in initializer mocks.
-- Produces: null-aware preview drawing and `resetPreviewState()` local helper.
-- Changes: Start after an ended run calls `reset()` before `start()`.
-- Changes: rules copy reads `DEFAULT_BUBBLE_SHOOTER_CONFIG.rowAddInterval`.
+- Consumes: `rowPhase` and `successfulShots` in initializer state.
+- Produces: `drawBubblePreview(...)` and `resetPreviewState()` local helpers.
+- Changes: ended-run Start calls `reset()` before `start()`.
 
-- [ ] **Step 1: Extend initializer mock state**
+- [ ] **Step 1: Extend the initializer mock state**
 
-In `initFramework.test.ts`, add to the mocked `getState()` result:
+Add:
 
 ```ts
 rowPhase: 0,
 successfulShots: 0,
 ```
 
-Add `beginPath`, `arc`, `fill`, `stroke`, `strokeStyle`, and `lineWidth` to the canvas context mock so preview drawing can be asserted without replacing `drawBubbleOnCanvas` behavior if the existing utility mock is later narrowed.
+Keep all existing pointer and RAF mock behavior.
 
-- [ ] **Step 2: Write failing ended-run start and preview-clear tests**
-
-Add:
+- [ ] **Step 2: Write a failing ended-run Start test**
 
 ```ts
 it('resets an ended run before starting again', async () => {
@@ -1432,49 +1211,21 @@ it('resets an ended run before starting again', async () => {
     expect(gameMock.reset).toHaveBeenCalledBefore(gameMock.start)
     expect(gameMock.start).toHaveBeenCalledTimes(1)
 })
-
-it('clears current and next previews when state resets to null', async () => {
-    const { BubbleShooterGame } = await import('./BubbleShooterGame')
-    const { drawBubbleOnCanvas } = await import('./utils')
-    result = await initBubbleShooterGameFramework()
-    const callbacks = vi.mocked(BubbleShooterGame).mock.calls[0][1] as {
-        onStateChange: (state: unknown) => void
-    }
-
-    callbacks.onStateChange({
-        bubblesRemaining: 2,
-        currentBubble: { color: 0xff0000 },
-        nextBubble: { color: 0x00ff00 },
-    })
-    callbacks.onStateChange({
-        bubblesRemaining: 0,
-        currentBubble: null,
-        nextBubble: null,
-    })
-
-    expect(vi.mocked(drawBubbleOnCanvas)).toHaveBeenCalledTimes(2)
-    const currentContext = (
-        document.getElementById('current-bubble') as HTMLCanvasElement
-    ).getContext('2d')
-    const nextContext = (
-        document.getElementById('next-bubble') as HTMLCanvasElement
-    ).getContext('2d')
-    expect(currentContext?.fillRect).toHaveBeenCalledTimes(2)
-    expect(nextContext?.fillRect).toHaveBeenCalledTimes(2)
-})
 ```
 
-- [ ] **Step 3: Run initializer tests and verify they fail**
+- [ ] **Step 3: Write a failing null-preview test**
+
+Invoke the captured `onStateChange` first with current/next colors and then with both values null. Assert each preview context's `fillRect` runs twice while `drawBubbleOnCanvas` runs only for the colored state.
+
+- [ ] **Step 4: Verify the initializer tests fail**
 
 ```bash
-bun run test:run src/lib/games/bubble-shooter/initFramework.test.ts -t "ended run|previews"
+bun run test:run src/lib/games/bubble-shooter/initFramework.test.ts -t "ended run|preview"
 ```
 
-Expected: FAIL because Start does not reset and undefined preview colors return before clearing.
+Expected: FAIL because Start does not reset and undefined colors return before clearing.
 
-- [ ] **Step 4: Make preview drawing null-aware**
-
-Replace the duplicated preview functions with one local helper:
+- [ ] **Step 5: Consolidate preview drawing**
 
 ```ts
 const drawBubblePreview = (
@@ -1505,12 +1256,9 @@ const drawBubblePreview = (
 }
 ```
 
-Use `number | undefined` caches:
+Track `number | undefined` colors. Add:
 
 ```ts
-let lastCurrentColor: number | undefined
-let lastNextColor: number | undefined
-
 const resetPreviewState = (): void => {
     lastCurrentColor = undefined
     lastNextColor = undefined
@@ -1519,27 +1267,11 @@ const resetPreviewState = (): void => {
 }
 ```
 
-In `onStateChange`, compare both defined and undefined colors and always call `drawBubblePreview` when the value changes.
+Call `drawBubblePreview` whenever a defined or undefined color differs from its cached value. Call `resetPreviewState()` from reset, restart, returned `restart()`, and ended-run Start.
 
-Call `resetPreviewState()` from reset, restart, the returned `restart()` method, and before resetting an ended run.
+- [ ] **Step 6: Reset before starting a previous run**
 
-- [ ] **Step 5: Reset before starting an ended run**
-
-Replace the Start handler:
-
-```ts
-const startHandler = (): void => {
-    const state = game.getState()
-    if (state.gameStarted && !state.isActive) {
-        game.reset()
-        resetPreviewState()
-        resetButtonVisibility()
-    }
-    game.start()
-}
-```
-
-Pass `resetPreviewState` into `setupButtonHandlers` or define the button setup closure where the helper is in scope. Prefer adding a callback parameter rather than moving unrelated initializer code:
+Pass `resetPreviewState` into `setupButtonHandlers`:
 
 ```ts
 function setupButtonHandlers(
@@ -1548,7 +1280,23 @@ function setupButtonHandlers(
 ): () => void
 ```
 
-- [ ] **Step 6: Update rules copy and pin it in the page test**
+Use:
+
+```ts
+const startHandler = (): void => {
+    const state = game.getState()
+    if (state.gameStarted && !state.isActive) {
+        game.reset()
+        resetPreviews()
+        resetButtonVisibility()
+    }
+    game.start()
+}
+```
+
+Reset and restart handlers call `game.reset()`, `resetPreviews()`, and `resetButtonVisibility()` in that order.
+
+- [ ] **Step 7: Update and test rules copy**
 
 In Astro frontmatter:
 
@@ -1558,7 +1306,7 @@ import { DEFAULT_BUBBLE_SHOOTER_CONFIG } from '@/lib/games/bubble-shooter/Bubble
 const rowAddInterval = DEFAULT_BUBBLE_SHOOTER_CONFIG.rowAddInterval
 ```
 
-Replace the rules with:
+Use:
 
 ```astro
 <p>• Match 3+ bubbles of the same color</p>
@@ -1568,38 +1316,9 @@ Replace the rules with:
 <p>• Accuracy counts shots that clear bubbles</p>
 ```
 
-In `game-board-markup.test.ts`, load the page once near the other markup constants:
+In `game-board-markup.test.ts`, load the Bubble Shooter page and assert those source strings plus absence of `New row appears after each shot`.
 
-```ts
-const bubbleShooterMarkup = readFileSync(
-    resolve(process.cwd(), 'src/pages/bubble-shooter/index.astro'),
-    'utf-8'
-)
-```
-
-Add:
-
-```ts
-it('keeps Bubble Shooter rules aligned with configured mechanics', () => {
-    expect(bubbleShooterMarkup).toContain(
-        'DEFAULT_BUBBLE_SHOOTER_CONFIG.rowAddInterval'
-    )
-    expect(bubbleShooterMarkup).toContain(
-        'New row appears every {rowAddInterval} shots'
-    )
-    expect(bubbleShooterMarkup).toContain(
-        'Disconnected bubbles fall after a match'
-    )
-    expect(bubbleShooterMarkup).toContain(
-        'Accuracy counts shots that clear bubbles'
-    )
-    expect(bubbleShooterMarkup).not.toContain(
-        'New row appears after each shot'
-    )
-})
-```
-
-- [ ] **Step 7: Run initializer and page tests**
+- [ ] **Step 8: Verify initializer and page tests**
 
 ```bash
 bun run test:run \
@@ -1607,9 +1326,9 @@ bun run test:run \
   src/pages/game-board-markup.test.ts
 ```
 
-Expected: PASS while the existing pointerdown-before-shooting and RAF tests remain green.
+Expected: PASS with existing pointerdown-before-shoot and RAF tests still green.
 
-- [ ] **Step 8: Commit the lifecycle/UI unit**
+- [ ] **Step 9: Commit**
 
 ```bash
 git add src/lib/games/bubble-shooter/initFramework.ts \
@@ -1621,17 +1340,17 @@ git commit -m "fix: reset bubble shooter runs and rules"
 
 ---
 
-### Task 7: Verify the complete single-PR story
+### Task 7: Verify the complete single-PR change
 
 **Files:**
-- Review: all production and test files listed in the file map.
-- Update only when a verification command reveals a concrete issue.
+- Review: every file in the file map.
+- Modify only when a command exposes a concrete defect.
 
 **Interfaces:**
-- Verifies every acceptance criterion from `docs/superpowers/specs/2026-08-10-bubble-shooter-mechanics-correction-design.md`.
-- Produces no new architecture or feature scope.
+- Verifies: `docs/superpowers/specs/2026-08-10-bubble-shooter-mechanics-correction-design.md`.
+- Produces: no new scope.
 
-- [ ] **Step 1: Run all focused Bubble Shooter and page tests**
+- [ ] **Step 1: Run focused tests**
 
 ```bash
 bun run test:run \
@@ -1644,21 +1363,14 @@ bun run test:run \
 
 Expected: PASS.
 
-- [ ] **Step 2: Search for stale state fields and old helper signatures**
+- [ ] **Step 2: Search for stale state and signatures**
 
 ```bash
-rg -n "rowOffset|getBubbleY\([^,]+,[^,]+,[^,]+\)|getBubbleX\([^,]+,[^,]+,[^,]+\)|getNeighbors\([^,]+,[^,]+,[^,]+\)" \
-  src/lib/games/bubble-shooter src/pages/bubble-shooter
+rg -n "rowOffset" src/lib/games/bubble-shooter
+rg -n "getBubbleX|getBubbleY|getNeighbors" src/lib/games/bubble-shooter
 ```
 
-Expected:
-
-- no `rowOffset`,
-- no old three-argument `getBubbleX`,
-- no old three-argument `getNeighbors`,
-- no old row-offset `getBubbleY`.
-
-Inspect any matches manually because multiline calls can make regex results approximate; every production/test call must use the Task 1 signatures.
+Expected: no `rowOffset`; manually confirm every geometry call has the Task 1 signature.
 
 - [ ] **Step 3: Run the full unit suite**
 
@@ -1668,7 +1380,7 @@ bun run test:run
 
 Expected: PASS.
 
-- [ ] **Step 4: Run type and code-quality checks**
+- [ ] **Step 4: Run type, lint, format, and diff checks**
 
 ```bash
 bun run typecheck
@@ -1677,7 +1389,7 @@ bun run format:check
 git diff --check
 ```
 
-Expected: all commands exit successfully with no new lint errors, formatting differences, or whitespace errors.
+Expected: all commands exit successfully with no new errors.
 
 - [ ] **Step 5: Run the production build**
 
@@ -1687,17 +1399,15 @@ bun run build
 
 Expected: successful Astro production build.
 
-- [ ] **Step 6: Run the existing game happy-path E2E coverage**
+- [ ] **Step 6: Run existing game E2E coverage**
 
 ```bash
 bun run test:e2e -- e2e/games/play-coverage.spec.ts
 ```
 
-Expected: PASS for the Bubble Shooter start, play interaction, end, and restart path. If the suite cannot run because the required browser or local database service is unavailable, record the exact command and error in the PR body rather than claiming it passed.
+Expected: Bubble Shooter start, interaction, end, and restart path passes. If the browser or local database service is unavailable, record the exact command and error in the PR body rather than claiming success.
 
-- [ ] **Step 7: Review the diff against the design acceptance criteria**
-
-Use:
+- [ ] **Step 7: Review the diff against invariants**
 
 ```bash
 git diff main...HEAD -- \
@@ -1706,25 +1416,28 @@ git diff main...HEAD -- \
   src/pages/game-board-markup.test.ts
 ```
 
-Confirm explicitly:
+Confirm:
 
-- phase toggles on each inserted row,
-- every geometry call receives `rowPhase`,
-- movement uses elapsed seconds and bounded substeps,
-- attachment candidates are local to the impact,
+- row phase toggles on insertion,
+- rows contain explicit `null` cells rather than sparse holes,
+- initial and added rows use fixed color snapshots,
+- all geometry calls use row phase,
+- projectile movement uses elapsed time and bounded substeps,
+- reflected positions remain inside walls,
+- impact candidates are local and empty,
 - blocked attachment cannot mutate the grid,
-- counts are scanned after board mutations,
-- direct matches drop unsupported bubbles,
+- `bubblesRemaining` equals occupied cells,
+- successful direct matches drop unsupported bubbles,
 - maintenance connectivity cleanup does not score,
-- next colors use active board colors,
-- successful-shot accuracy is used,
+- future colors come from active board colors,
+- accuracy uses successful shots,
 - ended runs reset before Start,
-- previews clear on null/reset,
-- page copy matches configuration.
+- previews clear when colors become null,
+- rules match configured behavior.
 
-- [ ] **Step 8: Commit only concrete verification fixes**
+- [ ] **Step 8: Commit only verification fixes**
 
-If formatting or verification required file changes:
+If verification changed files:
 
 ```bash
 git add src/lib/games/bubble-shooter \
@@ -1733,8 +1446,8 @@ git add src/lib/games/bubble-shooter \
 git commit -m "chore: finalize bubble shooter mechanics fix"
 ```
 
-If no files changed, do not create an empty commit.
+Do not create an empty commit.
 
-- [ ] **Step 9: Update the draft PR body and Linear issue**
+- [ ] **Step 9: Update tracking state**
 
-Add the final command results to the PR test plan. Link the PR on `HPA-121`, retain the issue in `In Progress` during implementation, move it to `In Review` only after all required checks pass and the PR is marked ready, and move it to `Done` only after merge.
+Add command results to the PR body. Keep `HPA-121` in `In Progress` while implementation is underway, move it to `In Review` only after required checks pass and the PR is marked ready, and move it to `Done` only after merge.

--- a/docs/superpowers/specs/2026-08-10-bubble-shooter-mechanics-correction-design.md
+++ b/docs/superpowers/specs/2026-08-10-bubble-shooter-mechanics-correction-design.md
@@ -6,172 +6,182 @@
 
 ## Summary
 
-Bubble Shooter currently lets its logical hex grid, stored bubble coordinates, projectile simulation, and attachment rules drift apart. That explains the reported bubbles overlapping and visually valid groups sometimes failing to clear.
+Bubble Shooter currently lets its logical hex grid, stored bubble coordinates, projectile simulation, and attachment rules drift apart. That explains the reported bubble overlap and cases where a visually connected group of three does not clear.
 
-This design corrects the game in one PR without introducing a physics engine or a reusable cross-game grid framework. The implementation stays inside the existing Bubble Shooter module and its page:
+The correction stays small and uses the existing architecture:
 
-- phase-aware hex-grid geometry,
-- elapsed-time projectile movement with collision-safe substeps,
-- impact-specific legal attachment,
-- authoritative bubble-count synchronization,
-- classic removal of ceiling-disconnected clusters,
-- active-board color selection,
-- clean run restart and preview behavior,
-- true successful-shot accuracy,
-- matching rules copy and regression coverage.
+- phase-aware hex geometry in the Bubble Shooter helpers,
+- authoritative board-coordinate/count synchronization,
+- elapsed-time projectile movement with bounded collision substeps,
+- impact-local attachment without teleport/overwrite fallbacks,
+- direct-match plus ceiling-connectivity cleanup,
+- active-board future colors and successful-shot accuracy,
+- one targeted `BaseGame.start()` restart fix shared by every framework-native game,
+- corrected preview/rules behavior and regression coverage.
 
-The existing `BaseGame`, Pixi renderer, initializer, and page boundaries remain intact.
+No physics engine, shared hex-grid package, renderer rewrite, persistence migration, or compatibility shim is added.
 
-## User-visible problems
+## Verified root causes
 
-The current code can produce several related failures:
-
-1. After a new row is inserted, bubbles can overlap because row arrays move to the opposite logical parity while their horizontal coordinates remain unchanged.
-2. Matching uses logical neighbors derived from the new row number, while rendering and collision use the old stored coordinates. A group that looks connected can therefore be disconnected in the match graph.
-3. Projectile speed and collision reliability depend on display refresh rate because velocity is applied once per animation frame and `deltaTime` is ignored.
-4. A blocked collision can attach to an unrelated cell elsewhere on the board, and a completely full grid can overwrite an occupied top-row cell.
-5. A new run started from the game-over Start button can inherit score and Bubble Shooter statistics from the previous run.
-6. Direct matches leave unsupported bubbles floating instead of dropping.
-7. The queue can keep producing colors that no longer exist on the board.
-8. The page says a row is added after every shot even though the configured interval is five shots.
+1. `addRowAtTop()` shifts row arrays down and updates `y`, but the shifted bubble keeps its old `x` while `getBubbleX()` and `getNeighbors()` derive parity from the new logical row number.
+2. `BubbleShooterGame.update()` discards `deltaTime`; projectile velocity is therefore applied once per animation frame.
+3. `findAttachPosition()` can search the whole board and ultimately force a row-zero fallback. `attachBubble()` writes that position without a final occupied-cell contract.
+4. `BaseGame.start()` clears game-over flags but does not reset state, timer history, or `ScoreManager`, so starting an ended framework-native game can retain the previous run unless the initializer manually resets first.
+5. Match resolution removes only the direct same-color cluster and leaves bubbles disconnected from the ceiling suspended.
+6. Bubble generation always samples the configured palette, even after a color no longer exists on the board.
+7. The page says a row appears after every shot while `rowAddInterval` defaults to five.
 
 ## Goals
 
-- Keep rendered coordinates and logical hex neighbors consistent after any number of inserted rows.
-- Make projectile travel deterministic for elapsed time rather than frame count.
-- Prevent tunneling through walls or bubbles under normal and delayed animation frames.
-- Allow attachment only where the impact physically permits it.
-- Make the grid the source of truth for `bubblesRemaining`.
-- Remove all bubbles disconnected from the ceiling after board mutations, while awarding shot score only for removals caused by a successful shot.
-- Preserve the already-previewed current bubble while ensuring future queue colors remain playable.
-- Start every new run with clean game, score, stat, and preview state.
-- Keep the change local, testable, and maintainable.
+- Keep rendered bubble coordinates and logical hex neighbors consistent after any number of inserted rows.
+- Make projectile travel depend on elapsed time, not refresh rate.
+- Keep projectile collision safe when `projectileSpeed` is increased later.
+- Restrict attachment to cells physically reachable from the detected impact.
+- Never overwrite an occupied cell and never teleport a blocked shot elsewhere.
+- Make the grid authoritative for `bubblesRemaining`.
+- Remove bubbles disconnected from the ceiling after successful match resolution and after board-maintenance mutations.
+- Generate the opening queue only after startup connectivity cleanup.
+- Keep future queue colors playable without rerolling the bubble already shown as current.
+- Start a completed `BaseGame` run from clean state without duplicating reset logic in each initializer.
+- Define `BaseGame.update(deltaTime)` in seconds and make Bubble Shooter follow that contract.
+- Keep tests deterministic and implementation-local.
 
 ## Non-goals
 
-- New Pixi assets, animations, sound effects, particles, power-ups, levels, or difficulty modes.
+- New Pixi assets, animations, particles, sounds, power-ups, levels, or difficulty modes.
 - A general-purpose physics engine.
-- A reusable grid package shared by unrelated games.
-- Refactoring `BaseGame` lifecycle semantics for all games.
-- Persistence or database schema changes.
-- Backward compatibility for the current internal Bubble Shooter state shape.
+- A shared hex-grid or graph package.
+- Reusing `src/lib/games/shared/match3.ts`; it models rectangular run matching/gravity, not hex connectivity.
+- A broad `BaseGame` lifecycle redesign beyond resetting a completed run before `start()` begins the next run and documenting the `deltaTime` unit.
+- Database/schema changes or score-history migration.
+- Backward compatibility for the internal Bubble Shooter state/helper signatures.
 
-## Existing boundaries
+## Existing boundaries and reuse
 
-The implementation already has useful responsibility boundaries:
+- `src/lib/games/core/BaseGame.ts` owns generic run lifecycle. The PR adds only completed-run reset semantics and the `deltaTime` unit contract.
+- `src/lib/games/bubble-shooter/types.ts` owns Bubble Shooter state/config types.
+- `src/lib/games/bubble-shooter/utils.ts` already owns hex coordinates/neighbors and is extended in place.
+- `src/lib/games/shared/geometry.ts` already provides `distance`; attachment and collision continue to reuse it.
+- `src/lib/games/bubble-shooter/BubbleShooterGame.ts` owns projectile, board mutation, matching, scoring, row insertion, and queue decisions.
+- `src/lib/games/bubble-shooter/BubbleShooterRenderer.ts` remains coordinate-driven and unchanged.
+- `src/lib/games/bubble-shooter/initFramework.ts` owns the RAF loop, pointer controls, previews, and DOM synchronization.
+- `src/pages/bubble-shooter/index.astro` owns static rules copy.
 
-- `types.ts` defines Bubble Shooter state and configuration.
-- `utils.ts` contains pure hex-grid coordinate and neighbor helpers.
-- `BubbleShooterGame.ts` owns state transitions, projectile movement, attachment, matching, scoring, and row insertion.
-- `BubbleShooterRenderer.ts` draws the coordinates supplied by game state and should not calculate game geometry.
-- `initFramework.ts` owns RAF timing, pointer input, button lifecycle, preview canvases, and DOM synchronization.
-- `src/pages/bubble-shooter/index.astro` owns static structure and rules copy.
+## 1. Shared completed-run restart semantics
 
-The PR preserves these boundaries. No new production source file is required.
-
-## Design
-
-### 1. Phase-aware hex-grid geometry
-
-Add a `RowPhase` type and `rowPhase` field to `BubbleShooterState`:
+`BaseGame.start()` should reset an ended run before starting the new run:
 
 ```ts
-export type RowPhase = 0 | 1
+start(): void {
+    if (this.state.isActive) {
+        return
+    }
 
-interface BubbleShooterState {
-    rowPhase: RowPhase
-    // existing fields...
+    if (this.state.gameStarted && this.state.isGameOver) {
+        this.reset()
+    }
+
+    this.runGuard.next()
+    // existing start flow...
 }
 ```
 
-`rowPhase` describes the physical parity of logical row zero. The physical parity of any row is:
+This fixes the lifecycle at the owning abstraction instead of adding another initializer workaround. Existing initializers that already call `reset()` before `start()` remain safe: their reset produces `gameStarted: false`, so the new BaseGame guard is a no-op.
+
+The implementation adds a core regression proving state and `ScoreManager` are reset when `start()` follows an ended run. It does not remove unrelated initializer guards in this PR.
+
+## 2. `deltaTime` contract
+
+`BaseGame.update(deltaTime)` is documented as receiving **elapsed seconds**.
+
+Evader already uses this convention. Bubble Shooter's RAF loop must therefore convert `performance.now()` milliseconds to seconds before calling `game.update(deltaTimeSeconds)`.
+
+Bubble Shooter keeps its own defensive clamp inside game logic:
+
+```ts
+const MAX_PROJECTILE_FRAME_SECONDS = 0.05
+const deltaSeconds = Math.min(Math.max(deltaTime, 0), 0.05)
+```
+
+Keeping the clamp inside the game makes the physics behavior unit-testable without a browser loop.
+
+## 3. Phase-aware centered hex geometry
+
+Add:
+
+```ts
+export type RowPhase = 0 | 1
+```
+
+and `rowPhase: RowPhase` to `BubbleShooterState`. Physical parity is:
 
 ```ts
 const parity = ((row + rowPhase) % 2) as RowPhase
 ```
 
-All geometry and bounds checks must use this parity through pure helpers:
+All row width, coordinate, neighbor, bounds, and candidate calculations use that physical parity through Bubble Shooter-local helpers:
 
 ```ts
-getRowParity(row: number, rowPhase: RowPhase): RowPhase
-getRowColumnCount(
-    row: number,
-    rowPhase: RowPhase,
-    constants: GameConstants
-): number
-getBubbleX(
-    col: number,
-    row: number,
-    rowPhase: RowPhase,
-    constants: GameConstants
-): number
-getBubbleY(row: number, constants: GameConstants): number
-getNeighbors(
-    row: number,
-    col: number,
-    rowPhase: RowPhase,
-    constants: GameConstants
-): GridPosition[]
+getRowParity(row, rowPhase)
+getRowColumnCount(row, rowPhase, constants)
+getBubbleX(col, row, rowPhase, constants)
+getBubbleY(row, constants)
+getNeighbors(row, col, rowPhase, constants)
 ```
 
-The board is centered horizontally. With `diameter = radius * 2`:
+The board is horizontally centered. For the default 600px canvas, 20px radius, and 14-column full row, the 560px grid occupies x=20..580 at its bubble edges. That matches the projectile wall bounds exactly. Today the left-aligned grid leaves an attachability mismatch at the right edge, so centering is part of geometry correctness rather than visual polish.
+
+`rowOffset` is removed because it is always zero and is not needed by the phase model.
+
+When inserting a row:
+
+1. snapshot the active color set used to generate the new row,
+2. shift rows downward,
+3. toggle `rowPhase`,
+4. create the new row-zero shape,
+5. recompute all occupied bubble coordinates from row/column/phase,
+6. remove bubbles no longer connected to row zero,
+7. synchronize `bubblesRemaining`,
+8. only then reconcile the future queue.
+
+## 4. Dense authoritative board state
+
+Use dense `(Bubble | null)[]` rows; empty cells are explicit `null`, never sparse holes.
+
+Add private helpers:
 
 ```ts
-const boardWidth = constants.GRID_WIDTH * diameter
-const boardLeft = (constants.GAME_WIDTH - boardWidth) / 2
-const x =
-    boardLeft +
-    constants.BUBBLE_RADIUS +
-    parity * constants.BUBBLE_RADIUS +
-    col * diameter
+private createEmptyRow(row: number, constants: GameConstants): (Bubble | null)[]
+private refreshBubbleCoordinates(constants: GameConstants): void
+private syncBubbleCount(): number
 ```
 
-For the default 600px canvas and fourteen 40px cells, full rows occupy the centered 560px board region. Offset rows retain the standard one-radius stagger.
+`refreshBubbleCoordinates` recalculates every occupied `x/y` from row/column/phase. `syncBubbleCount` scans the at-most-280 cells and writes the occupied count to state.
 
-`rowOffset` is removed because it is always zero and is not part of the row-insertion model.
+The scan intentionally replaces distributed increment/decrement bookkeeping because mutation paths now include row shifts and cluster drops.
 
-When inserting a new row:
+## 5. Elapsed-time projectile simulation
 
-1. shift existing row arrays down by one,
-2. toggle `rowPhase`,
-3. create logical row zero using its new physical column count,
-4. recompute every occupied bubble's `x` and `y` from row, column, and phase,
-5. normalize `bubblesRemaining` from the grid.
+Treat `projectileSpeed` as pixels per second. Change the default from `12` pixels/frame to `720` pixels/second to preserve approximately the 60Hz feel.
 
-Toggling the phase preserves the physical parity of every shifted existing row. Recomputing coordinates makes the invariant explicit and prevents stale stored positions.
+For one `update(deltaTimeSeconds)`:
 
-### 2. Elapsed-time projectile simulation
+1. clamp elapsed time to `0.05s`,
+2. compute travel from current velocity,
+3. split the frame so each substep travels at most `bubbleRadius / 2`,
+4. move one substep,
+5. reflect the projectile position and velocity inside side-wall bounds,
+6. check bubble collision first,
+7. check ceiling collision second,
+8. stop immediately after the projectile resolves.
 
-Treat `projectileSpeed` as pixels per second. Change the default from `12` pixels per frame to `720` pixels per second, preserving approximately the current 60Hz feel.
+Bubble collision must remain higher priority than ceiling collision. With a valid dense top row, a projectile approaching an occupied ceiling cell should collide with that bubble before being classified as a bare ceiling impact.
 
-`update(deltaTime)` passes elapsed milliseconds into:
+The substep loop is retained even though 720px/s × 0.05s = 36px is smaller than the default 40px collision diameter. It protects the existing speed configuration knob. The regression therefore uses a deliberately higher speed (4000px/s) so a single 50ms step would travel 200px and tunnel through a bubble without substeps.
 
-```ts
-updateProjectile(deltaTimeMs: number): boolean
-```
+## 6. Impact-local attachment
 
-Simulation rules:
-
-- Clamp one RAF delta to `50ms` so tab suspension cannot create an unbounded jump.
-- Calculate total travel from velocity and elapsed seconds.
-- Split the frame into enough equal substeps that one substep travels no farther than `bubbleRadius / 2`.
-- After each substep, reflect at side walls, then check bubble collision and ceiling collision.
-- Stop processing immediately after attachment or game over.
-
-The side-wall reflection updates both direction and position. For the left wall:
-
-```ts
-projectile.x = minX + (minX - projectile.x)
-projectile.vx = Math.abs(projectile.vx)
-```
-
-The right wall uses the symmetric calculation. The projectile must finish every substep inside `[radius, gameWidth - radius]`.
-
-This is sufficient for the current speeds and bubble sizes; continuous swept-circle collision or an external physics library would add complexity without meaningful benefit.
-
-### 3. Impact-specific legal attachment
-
-Represent the reason for attachment explicitly inside `BubbleShooterGame.ts`:
+Use:
 
 ```ts
 type ProjectileImpact =
@@ -179,38 +189,34 @@ type ProjectileImpact =
     | { kind: 'bubble'; anchor: GridPosition }
 ```
 
-Attachment candidates depend on impact type:
+Candidate rules:
 
-- **Bubble impact:** only empty neighbors of the collided anchor are candidates.
-- **Ceiling impact:** only empty cells in logical row zero are candidates.
+- bubble impact: only empty in-bounds neighbors of the collided anchor,
+- ceiling impact: only empty cells in logical row zero.
 
-Choose the legal candidate whose center is nearest the projectile. Remove the current whole-board search and forced row-zero-center fallback.
+The closest candidate is selected with the existing shared `distance` helper.
 
-Before writing a bubble, verify that the selected cell is still empty. If no legal candidate exists:
+Remove the whole-board search and forced top-center fallback.
 
-1. clear the projectile,
-2. mark the state for redraw,
-3. end the run through the existing caught `end()` path,
-4. do not modify any grid cell or bubble count.
+### Blocked impact behavior
 
-A shot must never teleport to an unrelated location or replace an occupied bubble.
+No legal candidate is **not** itself a game-over condition. A blocked projectile:
 
-### 4. Authoritative board synchronization
+1. is cleared,
+2. marks redraw,
+3. writes no bubble,
+4. creates no match and does not increment `successfulShots`,
+5. is still a consumed shot (`shotsFired` was already incremented by `shoot()`),
+6. participates in the normal row-add interval bookkeeping,
+7. ends the run only if the existing danger-zone check becomes true after normal shot/row resolution.
 
-Add two private helpers to `BubbleShooterGame`:
+`checkGameOverCondition()` remains the sole gameplay authority for game over. This prevents replacing the old teleport bug with a spurious loss on a locally blocked impact.
 
-```ts
-private refreshBubbleCoordinates(constants: GameConstants): void
-private syncBubbleCount(): number
-```
+A regression uses a locally blocked/partial board that is nowhere near the danger zone and asserts that the projectile is consumed, the grid is unchanged, and the run continues.
 
-`refreshBubbleCoordinates` derives every occupied bubble position from the current row, column, and phase. `syncBubbleCount` scans the at-most-280 grid cells, stores the total in `state.bubblesRemaining`, and returns it.
+## 7. Match resolution and unsupported drops
 
-Call these helpers after initialization, attachment, match removal, unsupported-cluster removal, and row insertion. The small scan is preferable to distributed increment/decrement bookkeeping that can drift when rows are shifted, cells are dropped, or attachment fails.
-
-### 5. Matching and unsupported-cluster removal
-
-Replace the current void match check with a resolution that distinguishes direct matches and dropped bubbles:
+Use local iterative hex traversal; do not introduce a shared graph abstraction.
 
 ```ts
 interface ShotResolution {
@@ -220,164 +226,173 @@ interface ShotResolution {
 }
 ```
 
-Resolution flow:
-
-1. Flood-fill same-color neighbors from the attached bubble.
-2. If fewer than three bubbles are connected, remove nothing and return an empty resolution.
-3. Remove the direct same-color cluster.
-4. Flood-fill through all remaining colors from every occupied top-row cell.
-5. Remove every occupied cell not reached from the ceiling.
-6. Synchronize the bubble count.
-7. Award ten points for each bubble removed by the shot, including dropped bubbles.
-8. Increment `successfulShots` once.
-9. Add the full removed count to `bubblesPopped` and use it for `largestCombo`.
-10. Award the all-clear bonus only after direct and dropped removals are complete.
-
-Ceiling connectivity is also normalized after random initialization and row insertion. Those maintenance removals do not award points or change successful-shot statistics; only a successful player shot does.
-
-### 6. Future bubble colors
-
-Add a helper that scans the grid for unique active colors:
+Contracts:
 
 ```ts
-private getAvailableBubbleColors(): number[]
+private collectColorCluster(start, constants): GridPosition[]
+private collectCeilingConnected(constants): Set<string>
+private removeUnsupportedBubbles(constants): GridPosition[]
+private resolveMatches(attached, constants): ShotResolution
 ```
 
-If the board contains bubbles, it returns only colors present in the grid. If the board is empty, it returns a copy of `config.colors`.
+`removeUnsupportedBubbles()` only nulls disconnected occupied cells and returns their positions. It does **not** synchronize counts. The caller owns one `syncBubbleCount()` after its complete board mutation sequence.
 
-The current queue behavior is retained so the already-previewed next bubble becomes current as soon as the player shoots. After shot resolution and any row insertion, reconcile `nextBubble`:
+Successful shot resolution:
 
-- keep it when its color remains available,
-- reroll it from the available colors when its color disappeared,
-- use the configured palette after an all-clear.
+1. collect the attached bubble's same-color cluster,
+2. if fewer than three, remove nothing,
+3. remove the direct match,
+4. remove every remaining bubble not connected to row zero,
+5. synchronize count once,
+6. score `10 × (direct + dropped)`,
+7. increment `successfulShots` once,
+8. add the full removed count to `bubblesPopped`,
+9. update `largestCombo` with the full removed count,
+10. add the 1000-point all-clear bonus after both removal phases.
 
-This avoids changing a bubble the player has already been shown while preventing later unplayable colors.
+Startup and added-row connectivity cleanup use the same drop primitive but award no score/stat changes.
 
-### 7. Lifecycle, previews, and statistics
+## 8. Startup ordering and active colors
 
-Add `successfulShots` to state, end-game stats, and game data. Accuracy becomes:
+Startup order is explicit:
+
+```text
+initialize grid
+→ refresh coordinates
+→ remove unsupported bubbles
+→ sync bubble count
+→ generate current bubble
+→ generate next bubble
+```
+
+This prevents a color that exists only on a soon-to-be-culled floating startup bubble from entering the opening queue.
+
+`getAvailableBubbleColors()` returns unique colors currently present on the board, falling back to `config.colors` when the board is empty.
+
+Initial-grid generation samples one fixed copy of `config.colors`; it does not let a partially generated board feed back into later cells.
+
+Added-row generation snapshots active colors **before** mutating the row. After match resolution and any interval row insertion have completed, `reconcileNextBubbleColor()` runs exactly once:
+
+- keep `nextBubble` when its color still exists,
+- reroll only `nextBubble` when its color disappeared,
+- use the configured palette after an all-clear,
+- never reroll `currentBubble` after it has been shown to the player.
+
+## 9. Statistics and rules
+
+Add `successfulShots` to Bubble Shooter state, end stats, and game data.
+
+Accuracy becomes:
 
 ```ts
 shotsFired > 0 ? (successfulShots / shotsFired) * 100 : 0
 ```
 
-The Start button handler checks the current state before starting. If a previous run has already started and is no longer active, it resets the game first so both `BaseGame` state and `ScoreManager` are clean.
+The page imports `DEFAULT_BUBBLE_SHOOTER_CONFIG.rowAddInterval` and states the configured interval rather than hardcoding "after each shot". It also explains that unsupported bubbles fall and that accuracy means shots that clear bubbles.
 
-Preview drawing is made null-aware:
+Preview canvases are cleared when current/next becomes null and on reset/restart. No Bubble Shooter-specific ended-run reset is added because `BaseGame.start()` now owns that behavior.
 
-- always clear the preview canvas when the current or next color changes,
-- draw a bubble only when a color exists,
-- reset cached preview colors on reset, restart, and ended-run start.
+## State transition for one shot
 
-The page imports `DEFAULT_BUBBLE_SHOOTER_CONFIG.rowAddInterval` in Astro frontmatter and renders the actual default interval in the rules copy. The rules also state that unsupported bubbles fall and that accuracy means the percentage of shots that clear bubbles.
-
-### 8. Renderer behavior
-
-`BubbleShooterRenderer` remains coordinate-driven and does not gain grid knowledge. Its responsibility is still to draw the state it receives. Correcting state coordinates is sufficient to fix rendered overlap.
-
-No renderer refactor or animation work is included.
-
-## State transition flow
-
-For one shot:
-
-1. `shoot()` creates the projectile, promotes the previewed next bubble, and increments `shotsFired`.
-2. RAF calls `update(deltaTimeMs)`.
-3. Projectile simulation runs bounded substeps until no impact occurs or an impact is found.
-4. The impact-specific candidate resolver selects a legal empty cell.
-5. The projectile attaches, coordinates and count synchronize, and the direct match resolves.
-6. A successful match removes ceiling-disconnected bubbles and updates score/statistics.
-7. `shotCount` increments; a configured interval row is inserted only when the board is still non-empty.
-8. Ceiling connectivity and count synchronize after any row insertion.
-9. The future queue color is reconciled against active board colors.
-10. Game-over checks run against the corrected coordinates.
-11. The projectile is cleared and the state is emitted for rendering.
+1. `shoot()` creates the projectile, promotes the previewed next bubble, generates a future next bubble, and increments `shotsFired`.
+2. RAF passes elapsed seconds to `update()`.
+3. Projectile simulation runs bounded substeps.
+4. Bubble collision is checked before ceiling collision.
+5. Impact-local candidates are evaluated.
+6. If a legal cell exists, insert and resolve direct/drop matches; otherwise consume the blocked projectile without writing a cell.
+7. Increment the row-interval shot counter for the resolved shot.
+8. Add/normalize a row when the configured interval is reached and the board is non-empty.
+9. Synchronize board count after mutation/cleanup.
+10. Reconcile only `nextBubble` against active colors.
+11. Clear the projectile.
+12. `checkGameOverCondition()` decides whether to call `end()`.
 
 ## Invariants
 
-The implementation and tests enforce these invariants:
-
-- Every row's length matches `getRowColumnCount(row, rowPhase, constants)`.
-- Every occupied bubble's coordinates equal the geometry helpers for its row and column.
-- Neighbor relations use the same physical parity as rendered coordinates.
-- Adjacent grid neighbors are one bubble diameter apart within floating-point tolerance.
+- Every row length equals `getRowColumnCount(row, rowPhase, constants)`.
+- Every index inside a row exists and contains either `Bubble` or `null`.
+- Every occupied bubble coordinate equals the geometry helper result for its row/column/phase.
+- Logical neighbor relations use the same physical parity as rendered geometry.
+- Every geometric neighbor is one bubble diameter away within floating-point tolerance.
+- Projectile `x` remains within side-wall bounds after each substep.
+- Bubble collision takes precedence over ceiling collision.
 - No attachment writes into an occupied cell.
-- `bubblesRemaining` equals the number of occupied grid cells after every mutation.
-- A projectile is either in flight or has been cleared after attachment/blockage; it is never left outside wall bounds.
-- Every retained bubble is connected to an occupied top-row cell.
+- No blocked impact teleports to another region or ends the run by itself.
+- `bubblesRemaining` equals occupied grid cells after every board mutation sequence.
+- Every retained bubble is connected to row zero after maintenance cleanup.
+- Opening queue colors are sampled only after startup connectivity cleanup.
 - `nextBubble` uses an active color unless the board is empty.
-- `successfulShots <= shotsFired`, so accuracy remains between 0% and 100%.
-
-## Error handling
-
-- Existing asynchronous `end()` calls remain caught and logged.
-- A blocked attachment is treated as a normal game-over condition, not an exception.
-- Invalid geometry should be prevented through helper bounds and regression tests rather than hidden with a global fallback.
-- No new network, persistence, or renderer failure paths are introduced.
+- `successfulShots <= shotsFired`.
+- `BaseGame.start()` after an ended run starts from reset state and score.
+- `BaseGame.update(deltaTime)` uses seconds.
 
 ## Testing strategy
 
-### Pure geometry tests
+### Core framework
 
-- Full and offset rows are centered correctly for both row phases.
-- Column counts alternate correctly as `rowPhase` changes.
-- Neighbor sets and bounds use physical parity.
-- Neighbor center distances equal the bubble diameter.
+- End a minimal `BaseGame`, add score/state before end, call `start()`, and assert the second run begins with initial state and zero `ScoreManager` score.
+- Preserve the existing `start()` no-op while already active.
 
-### Game mechanics tests
+### Geometry and board
 
-- One and two row insertions preserve coordinates, widths, connectivity, and bubble counts.
-- Simulating equal elapsed time at 30Hz, 60Hz, and 120Hz produces approximately equal projectile positions.
-- Wall bounces leave the projectile inside legal bounds.
-- A clamped delayed frame cannot tunnel through a bubble.
-- Bubble impacts attach only to an empty anchor neighbor.
-- Ceiling impacts attach only to row zero.
-- A blocked/full board ends without overwriting a cell.
-- A direct match removes unsupported clusters and scores the combined removal.
-- Connectivity normalization does not award points during initialization or row insertion.
-- Queue colors are drawn from active colors and fall back to the configured palette on an empty board.
-- Accuracy uses successful shots.
+- Rewrite existing utility suites to the phase-aware signatures and centered coordinates.
+- Assert both row phases, row widths, neighbor bounds, and neighbor distances.
+- Assert dense rows with indexed checks (`col in row` and `row[col] !== undefined`).
+- Insert one and two rows and assert phase, coordinates, widths, and counts.
 
-### Initializer and page tests
+### Projectile and attachment
 
-- Starting after game over resets score and Bubble Shooter statistics before calling `start()`.
-- Reset/restart clears preview canvases and cached colors.
-- Existing pointer controls and RAF behavior remain intact.
-- Static page markup contains the configured row interval and corrected rules.
+- Simulate equal elapsed seconds at 30Hz/60Hz/120Hz and compare positions.
+- Test wall reflection keeps the projectile in bounds.
+- At 4000px/s, use one 50ms update with a bubble 100px along the path and assert attachment; this fails without substeps.
+- Fill only the local impact candidate set while keeping the board below the danger zone; assert shot consumed, grid unchanged, game active.
+- Assert bubble impact is evaluated before ceiling impact when both thresholds are reached in one substep.
 
-### Final validation
+### Match/drop/colors
 
-- targeted Bubble Shooter unit and initializer tests,
-- full unit suite,
-- typecheck,
-- lint,
-- formatting check,
-- production build,
-- existing Bubble Shooter E2E happy-path coverage.
+- Direct match removes the cluster plus unsupported bubbles and scores both.
+- Maintenance connectivity cleanup awards no points.
+- A floating-only startup color is removed before opening current/next generation.
+- Added-row ordering removes unsupported colors before next-bubble reconciliation.
+- Empty board falls back to configured colors.
+- Accuracy uses `successfulShots / shotsFired`.
 
-## Risks and mitigations
+### Initializer/page
 
-### Random-board tests
+- RAF converts elapsed milliseconds to seconds before `game.update()`.
+- Preview canvases clear when colors become null/reset.
+- Rules render the configured row interval and no stale "after each shot" text.
 
-Random initial and added rows can make assertions flaky. Tests will stub `Math.random` or inject deterministic state before invoking mechanics.
+## Risks
 
-### Floating-point comparisons
+### Scoring-era comparability
 
-Hex vertical spacing uses `Math.sqrt(3)`. Geometry tests use `toBeCloseTo` rather than strict equality for distances and coordinates involving that value.
+Dropped bubbles will now award points and accuracy changes to a true hit-rate metric. New Bubble Shooter score/stat rows therefore use slightly different semantics from historical rows. No migration/versioning is included in this mechanics PR; leaderboard history may mix the two scoring eras.
 
-### Large change in one PR
+### Shared restart semantics
 
-The user explicitly requested one implementation PR. The plan keeps review manageable by sequencing commits around independently testable mechanics: geometry, physics, attachment, match resolution, lifecycle/UI, then full verification. No unrelated refactor is bundled.
+Changing `BaseGame.start()` affects all framework-native games. The change is intentionally narrow and must run the full unit/E2E suite. Existing initializer-level reset guards are left in place to avoid unrelated cleanup churn.
+
+### Random generation
+
+Tests stub `Math.random` or inject deterministic board state.
+
+### Floating point
+
+Hex vertical spacing uses `Math.sqrt(3)`; geometry tests use approximate assertions where appropriate.
 
 ## Acceptance criteria
 
-- The original overlap and visually-connected-but-not-matching failure cannot be reproduced after row insertion.
-- Geometry, collision, matching, and rendering agree after any tested number of row additions.
-- Projectile behavior is refresh-rate independent and collision-safe under bounded delayed frames.
+- Original overlap and visually-connected-but-not-matching failures are covered by regression tests and corrected by one geometry model.
+- The centered grid aligns its outer bubble edges with projectile wall bounds.
+- Equal elapsed time produces equivalent projectile travel across refresh rates.
+- High configurable projectile speed cannot tunnel through bubbles under the bounded substep model.
 - Attachment never teleports or overwrites.
-- Bubble count never drifts from grid occupancy.
-- Successful matches remove unsupported clusters.
-- Future colors remain playable.
-- A second run starts cleanly.
-- Accuracy and page rules describe the implemented behavior.
-- All planned validation commands pass before the draft PR is marked ready.
+- A locally blocked impact does not cause game over; danger-zone detection remains the only game-over authority.
+- Bubble count cannot drift from grid occupancy.
+- Matches remove unsupported clusters.
+- Opening/future queue colors remain playable after maintenance cleanup.
+- Starting any completed framework-native game through `BaseGame.start()` resets previous run state and score.
+- `BaseGame.update(deltaTime)` is documented/used in seconds.
+- Accuracy and page rules match implemented behavior.
+- Focused tests, full tests, typecheck, lint, format check, build, and existing E2E coverage pass before the draft PR is marked ready.

--- a/docs/superpowers/specs/2026-08-10-bubble-shooter-mechanics-correction-design.md
+++ b/docs/superpowers/specs/2026-08-10-bubble-shooter-mechanics-correction-design.md
@@ -1,0 +1,383 @@
+# HPA-121 Bubble Shooter Mechanics Correction Design
+
+**Issue:** HPA-121  
+**Date:** 2026-08-10  
+**Status:** Approved for a single implementation PR
+
+## Summary
+
+Bubble Shooter currently lets its logical hex grid, stored bubble coordinates, projectile simulation, and attachment rules drift apart. That explains the reported bubbles overlapping and visually valid groups sometimes failing to clear.
+
+This design corrects the game in one PR without introducing a physics engine or a reusable cross-game grid framework. The implementation stays inside the existing Bubble Shooter module and its page:
+
+- phase-aware hex-grid geometry,
+- elapsed-time projectile movement with collision-safe substeps,
+- impact-specific legal attachment,
+- authoritative bubble-count synchronization,
+- classic removal of ceiling-disconnected clusters,
+- active-board color selection,
+- clean run restart and preview behavior,
+- true successful-shot accuracy,
+- matching rules copy and regression coverage.
+
+The existing `BaseGame`, Pixi renderer, initializer, and page boundaries remain intact.
+
+## User-visible problems
+
+The current code can produce several related failures:
+
+1. After a new row is inserted, bubbles can overlap because row arrays move to the opposite logical parity while their horizontal coordinates remain unchanged.
+2. Matching uses logical neighbors derived from the new row number, while rendering and collision use the old stored coordinates. A group that looks connected can therefore be disconnected in the match graph.
+3. Projectile speed and collision reliability depend on display refresh rate because velocity is applied once per animation frame and `deltaTime` is ignored.
+4. A blocked collision can attach to an unrelated cell elsewhere on the board, and a completely full grid can overwrite an occupied top-row cell.
+5. A new run started from the game-over Start button can inherit score and Bubble Shooter statistics from the previous run.
+6. Direct matches leave unsupported bubbles floating instead of dropping.
+7. The queue can keep producing colors that no longer exist on the board.
+8. The page says a row is added after every shot even though the configured interval is five shots.
+
+## Goals
+
+- Keep rendered coordinates and logical hex neighbors consistent after any number of inserted rows.
+- Make projectile travel deterministic for elapsed time rather than frame count.
+- Prevent tunneling through walls or bubbles under normal and delayed animation frames.
+- Allow attachment only where the impact physically permits it.
+- Make the grid the source of truth for `bubblesRemaining`.
+- Remove all bubbles disconnected from the ceiling after board mutations, while awarding shot score only for removals caused by a successful shot.
+- Preserve the already-previewed current bubble while ensuring future queue colors remain playable.
+- Start every new run with clean game, score, stat, and preview state.
+- Keep the change local, testable, and maintainable.
+
+## Non-goals
+
+- New Pixi assets, animations, sound effects, particles, power-ups, levels, or difficulty modes.
+- A general-purpose physics engine.
+- A reusable grid package shared by unrelated games.
+- Refactoring `BaseGame` lifecycle semantics for all games.
+- Persistence or database schema changes.
+- Backward compatibility for the current internal Bubble Shooter state shape.
+
+## Existing boundaries
+
+The implementation already has useful responsibility boundaries:
+
+- `types.ts` defines Bubble Shooter state and configuration.
+- `utils.ts` contains pure hex-grid coordinate and neighbor helpers.
+- `BubbleShooterGame.ts` owns state transitions, projectile movement, attachment, matching, scoring, and row insertion.
+- `BubbleShooterRenderer.ts` draws the coordinates supplied by game state and should not calculate game geometry.
+- `initFramework.ts` owns RAF timing, pointer input, button lifecycle, preview canvases, and DOM synchronization.
+- `src/pages/bubble-shooter/index.astro` owns static structure and rules copy.
+
+The PR preserves these boundaries. No new production source file is required.
+
+## Design
+
+### 1. Phase-aware hex-grid geometry
+
+Add a `RowPhase` type and `rowPhase` field to `BubbleShooterState`:
+
+```ts
+export type RowPhase = 0 | 1
+
+interface BubbleShooterState {
+    rowPhase: RowPhase
+    // existing fields...
+}
+```
+
+`rowPhase` describes the physical parity of logical row zero. The physical parity of any row is:
+
+```ts
+const parity = ((row + rowPhase) % 2) as RowPhase
+```
+
+All geometry and bounds checks must use this parity through pure helpers:
+
+```ts
+getRowParity(row: number, rowPhase: RowPhase): RowPhase
+getRowColumnCount(
+    row: number,
+    rowPhase: RowPhase,
+    constants: GameConstants
+): number
+getBubbleX(
+    col: number,
+    row: number,
+    rowPhase: RowPhase,
+    constants: GameConstants
+): number
+getBubbleY(row: number, constants: GameConstants): number
+getNeighbors(
+    row: number,
+    col: number,
+    rowPhase: RowPhase,
+    constants: GameConstants
+): GridPosition[]
+```
+
+The board is centered horizontally. With `diameter = radius * 2`:
+
+```ts
+const boardWidth = constants.GRID_WIDTH * diameter
+const boardLeft = (constants.GAME_WIDTH - boardWidth) / 2
+const x =
+    boardLeft +
+    constants.BUBBLE_RADIUS +
+    parity * constants.BUBBLE_RADIUS +
+    col * diameter
+```
+
+For the default 600px canvas and fourteen 40px cells, full rows occupy the centered 560px board region. Offset rows retain the standard one-radius stagger.
+
+`rowOffset` is removed because it is always zero and is not part of the row-insertion model.
+
+When inserting a new row:
+
+1. shift existing row arrays down by one,
+2. toggle `rowPhase`,
+3. create logical row zero using its new physical column count,
+4. recompute every occupied bubble's `x` and `y` from row, column, and phase,
+5. normalize `bubblesRemaining` from the grid.
+
+Toggling the phase preserves the physical parity of every shifted existing row. Recomputing coordinates makes the invariant explicit and prevents stale stored positions.
+
+### 2. Elapsed-time projectile simulation
+
+Treat `projectileSpeed` as pixels per second. Change the default from `12` pixels per frame to `720` pixels per second, preserving approximately the current 60Hz feel.
+
+`update(deltaTime)` passes elapsed milliseconds into:
+
+```ts
+updateProjectile(deltaTimeMs: number): boolean
+```
+
+Simulation rules:
+
+- Clamp one RAF delta to `50ms` so tab suspension cannot create an unbounded jump.
+- Calculate total travel from velocity and elapsed seconds.
+- Split the frame into enough equal substeps that one substep travels no farther than `bubbleRadius / 2`.
+- After each substep, reflect at side walls, then check bubble collision and ceiling collision.
+- Stop processing immediately after attachment or game over.
+
+The side-wall reflection updates both direction and position. For the left wall:
+
+```ts
+projectile.x = minX + (minX - projectile.x)
+projectile.vx = Math.abs(projectile.vx)
+```
+
+The right wall uses the symmetric calculation. The projectile must finish every substep inside `[radius, gameWidth - radius]`.
+
+This is sufficient for the current speeds and bubble sizes; continuous swept-circle collision or an external physics library would add complexity without meaningful benefit.
+
+### 3. Impact-specific legal attachment
+
+Represent the reason for attachment explicitly inside `BubbleShooterGame.ts`:
+
+```ts
+type ProjectileImpact =
+    | { kind: 'ceiling' }
+    | { kind: 'bubble'; anchor: GridPosition }
+```
+
+Attachment candidates depend on impact type:
+
+- **Bubble impact:** only empty neighbors of the collided anchor are candidates.
+- **Ceiling impact:** only empty cells in logical row zero are candidates.
+
+Choose the legal candidate whose center is nearest the projectile. Remove the current whole-board search and forced row-zero-center fallback.
+
+Before writing a bubble, verify that the selected cell is still empty. If no legal candidate exists:
+
+1. clear the projectile,
+2. mark the state for redraw,
+3. end the run through the existing caught `end()` path,
+4. do not modify any grid cell or bubble count.
+
+A shot must never teleport to an unrelated location or replace an occupied bubble.
+
+### 4. Authoritative board synchronization
+
+Add two private helpers to `BubbleShooterGame`:
+
+```ts
+private refreshBubbleCoordinates(constants: GameConstants): void
+private syncBubbleCount(): number
+```
+
+`refreshBubbleCoordinates` derives every occupied bubble position from the current row, column, and phase. `syncBubbleCount` scans the at-most-280 grid cells, stores the total in `state.bubblesRemaining`, and returns it.
+
+Call these helpers after initialization, attachment, match removal, unsupported-cluster removal, and row insertion. The small scan is preferable to distributed increment/decrement bookkeeping that can drift when rows are shifted, cells are dropped, or attachment fails.
+
+### 5. Matching and unsupported-cluster removal
+
+Replace the current void match check with a resolution that distinguishes direct matches and dropped bubbles:
+
+```ts
+interface ShotResolution {
+    directMatches: GridPosition[]
+    dropped: GridPosition[]
+    removedCount: number
+}
+```
+
+Resolution flow:
+
+1. Flood-fill same-color neighbors from the attached bubble.
+2. If fewer than three bubbles are connected, remove nothing and return an empty resolution.
+3. Remove the direct same-color cluster.
+4. Flood-fill through all remaining colors from every occupied top-row cell.
+5. Remove every occupied cell not reached from the ceiling.
+6. Synchronize the bubble count.
+7. Award ten points for each bubble removed by the shot, including dropped bubbles.
+8. Increment `successfulShots` once.
+9. Add the full removed count to `bubblesPopped` and use it for `largestCombo`.
+10. Award the all-clear bonus only after direct and dropped removals are complete.
+
+Ceiling connectivity is also normalized after random initialization and row insertion. Those maintenance removals do not award points or change successful-shot statistics; only a successful player shot does.
+
+### 6. Future bubble colors
+
+Add a helper that scans the grid for unique active colors:
+
+```ts
+private getAvailableBubbleColors(): number[]
+```
+
+If the board contains bubbles, it returns only colors present in the grid. If the board is empty, it returns a copy of `config.colors`.
+
+The current queue behavior is retained so the already-previewed next bubble becomes current as soon as the player shoots. After shot resolution and any row insertion, reconcile `nextBubble`:
+
+- keep it when its color remains available,
+- reroll it from the available colors when its color disappeared,
+- use the configured palette after an all-clear.
+
+This avoids changing a bubble the player has already been shown while preventing later unplayable colors.
+
+### 7. Lifecycle, previews, and statistics
+
+Add `successfulShots` to state, end-game stats, and game data. Accuracy becomes:
+
+```ts
+shotsFired > 0 ? (successfulShots / shotsFired) * 100 : 0
+```
+
+The Start button handler checks the current state before starting. If a previous run has already started and is no longer active, it resets the game first so both `BaseGame` state and `ScoreManager` are clean.
+
+Preview drawing is made null-aware:
+
+- always clear the preview canvas when the current or next color changes,
+- draw a bubble only when a color exists,
+- reset cached preview colors on reset, restart, and ended-run start.
+
+The page imports `DEFAULT_BUBBLE_SHOOTER_CONFIG.rowAddInterval` in Astro frontmatter and renders the actual default interval in the rules copy. The rules also state that unsupported bubbles fall and that accuracy means the percentage of shots that clear bubbles.
+
+### 8. Renderer behavior
+
+`BubbleShooterRenderer` remains coordinate-driven and does not gain grid knowledge. Its responsibility is still to draw the state it receives. Correcting state coordinates is sufficient to fix rendered overlap.
+
+No renderer refactor or animation work is included.
+
+## State transition flow
+
+For one shot:
+
+1. `shoot()` creates the projectile, promotes the previewed next bubble, and increments `shotsFired`.
+2. RAF calls `update(deltaTimeMs)`.
+3. Projectile simulation runs bounded substeps until no impact occurs or an impact is found.
+4. The impact-specific candidate resolver selects a legal empty cell.
+5. The projectile attaches, coordinates and count synchronize, and the direct match resolves.
+6. A successful match removes ceiling-disconnected bubbles and updates score/statistics.
+7. `shotCount` increments; a configured interval row is inserted only when the board is still non-empty.
+8. Ceiling connectivity and count synchronize after any row insertion.
+9. The future queue color is reconciled against active board colors.
+10. Game-over checks run against the corrected coordinates.
+11. The projectile is cleared and the state is emitted for rendering.
+
+## Invariants
+
+The implementation and tests enforce these invariants:
+
+- Every row's length matches `getRowColumnCount(row, rowPhase, constants)`.
+- Every occupied bubble's coordinates equal the geometry helpers for its row and column.
+- Neighbor relations use the same physical parity as rendered coordinates.
+- Adjacent grid neighbors are one bubble diameter apart within floating-point tolerance.
+- No attachment writes into an occupied cell.
+- `bubblesRemaining` equals the number of occupied grid cells after every mutation.
+- A projectile is either in flight or has been cleared after attachment/blockage; it is never left outside wall bounds.
+- Every retained bubble is connected to an occupied top-row cell.
+- `nextBubble` uses an active color unless the board is empty.
+- `successfulShots <= shotsFired`, so accuracy remains between 0% and 100%.
+
+## Error handling
+
+- Existing asynchronous `end()` calls remain caught and logged.
+- A blocked attachment is treated as a normal game-over condition, not an exception.
+- Invalid geometry should be prevented through helper bounds and regression tests rather than hidden with a global fallback.
+- No new network, persistence, or renderer failure paths are introduced.
+
+## Testing strategy
+
+### Pure geometry tests
+
+- Full and offset rows are centered correctly for both row phases.
+- Column counts alternate correctly as `rowPhase` changes.
+- Neighbor sets and bounds use physical parity.
+- Neighbor center distances equal the bubble diameter.
+
+### Game mechanics tests
+
+- One and two row insertions preserve coordinates, widths, connectivity, and bubble counts.
+- Simulating equal elapsed time at 30Hz, 60Hz, and 120Hz produces approximately equal projectile positions.
+- Wall bounces leave the projectile inside legal bounds.
+- A clamped delayed frame cannot tunnel through a bubble.
+- Bubble impacts attach only to an empty anchor neighbor.
+- Ceiling impacts attach only to row zero.
+- A blocked/full board ends without overwriting a cell.
+- A direct match removes unsupported clusters and scores the combined removal.
+- Connectivity normalization does not award points during initialization or row insertion.
+- Queue colors are drawn from active colors and fall back to the configured palette on an empty board.
+- Accuracy uses successful shots.
+
+### Initializer and page tests
+
+- Starting after game over resets score and Bubble Shooter statistics before calling `start()`.
+- Reset/restart clears preview canvases and cached colors.
+- Existing pointer controls and RAF behavior remain intact.
+- Static page markup contains the configured row interval and corrected rules.
+
+### Final validation
+
+- targeted Bubble Shooter unit and initializer tests,
+- full unit suite,
+- typecheck,
+- lint,
+- formatting check,
+- production build,
+- existing Bubble Shooter E2E happy-path coverage.
+
+## Risks and mitigations
+
+### Random-board tests
+
+Random initial and added rows can make assertions flaky. Tests will stub `Math.random` or inject deterministic state before invoking mechanics.
+
+### Floating-point comparisons
+
+Hex vertical spacing uses `Math.sqrt(3)`. Geometry tests use `toBeCloseTo` rather than strict equality for distances and coordinates involving that value.
+
+### Large change in one PR
+
+The user explicitly requested one implementation PR. The plan keeps review manageable by sequencing commits around independently testable mechanics: geometry, physics, attachment, match resolution, lifecycle/UI, then full verification. No unrelated refactor is bundled.
+
+## Acceptance criteria
+
+- The original overlap and visually-connected-but-not-matching failure cannot be reproduced after row insertion.
+- Geometry, collision, matching, and rendering agree after any tested number of row additions.
+- Projectile behavior is refresh-rate independent and collision-safe under bounded delayed frames.
+- Attachment never teleports or overwrites.
+- Bubble count never drifts from grid occupancy.
+- Successful matches remove unsupported clusters.
+- Future colors remain playable.
+- A second run starts cleanly.
+- Accuracy and page rules describe the implemented behavior.
+- All planned validation commands pass before the draft PR is marked ready.

--- a/e2e/homepage.spec.ts
+++ b/e2e/homepage.spec.ts
@@ -48,7 +48,11 @@ test.describe('Homepage', () => {
         const homePage = new HomePage(page)
         await homePage.goto()
 
-        const h1Count = await page.locator('h1').count()
+        // Use the page document directly so Astro's dev-toolbar shadow DOM does
+        // not contribute its internal headings to the application markup count.
+        const h1Count = await page.evaluate(
+            () => document.querySelectorAll('h1').length
+        )
         expect(h1Count).toBe(1)
     })
 })

--- a/src/lib/games/bubble-shooter/BubbleShooterGame.test.ts
+++ b/src/lib/games/bubble-shooter/BubbleShooterGame.test.ts
@@ -194,18 +194,33 @@ describe('BubbleShooterGame', () => {
     })
 
     describe('getGameStats / accuracy', () => {
-        it('computes accuracy from bubblesPopped / shotsFired', () => {
+        it('computes accuracy from successfulShots / shotsFired', () => {
             const game = makeGame()
-            setState(game, { shotsFired: 10, bubblesPopped: 8 })
+            setState(game, {
+                shotsFired: 10,
+                successfulShots: 8,
+                bubblesPopped: 18,
+            })
             const stats = game.getGameStats()
             expect(stats.accuracy).toBe(80)
-            expect(stats.bubblesPopped).toBe(8)
+            expect(stats.bubblesPopped).toBe(18)
             expect(stats.shotsFired).toBe(10)
+            expect(stats.successfulShots).toBe(8)
         })
 
         it('returns zero accuracy when no shots fired', () => {
             const game = makeGame()
             expect(game.getGameStats().accuracy).toBe(0)
+        })
+
+        it('reports successful-shot accuracy', () => {
+            const game = makeGame()
+            setState(game, {
+                shotsFired: 10,
+                successfulShots: 6,
+                bubblesPopped: 18,
+            })
+            expect(game.getGameStats().accuracy).toBe(60)
         })
     })
 
@@ -216,6 +231,7 @@ describe('BubbleShooterGame', () => {
                 bubblesPopped: 7,
                 shotsFired: 12,
                 largestCombo: 4,
+                successfulShots: 5,
             })
             const data = (
                 game as unknown as {
@@ -226,6 +242,7 @@ describe('BubbleShooterGame', () => {
                 bubblesPopped: 7,
                 shotsFired: 12,
                 largestCombo: 4,
+                successfulShots: 5,
             })
         })
     })
@@ -919,6 +936,137 @@ describe('BubbleShooterGame', () => {
             expect(stateOf(game).bubblesRemaining).toBe(2)
             expect(stateOf(game).score).toBe(0)
             expect(stateOf(game).successfulShots).toBe(0)
+        })
+    })
+
+    describe('active colors', () => {
+        it('drops floating-only opening colors before queue generation', () => {
+            const game = makeGame({ colors: [0xff0000, 0x0000ff] })
+            // Stub initializeGrid() to produce a top-connected red bubble and
+            // an isolated blue bubble. onGameStart's cleanup must drop the
+            // blue before generateBubble/generateNextBubble run, so both
+            // queue bubbles are rolled from active colors (red only).
+            const internal = game as unknown as {
+                initializeGrid: () => void
+                onGameStart: () => void
+            }
+            vi.spyOn(internal, 'initializeGrid').mockImplementation(() => {
+                const grid: (Bubble | null)[][] = Array.from(
+                    { length: CONSTANTS.GRID_HEIGHT },
+                    (_, row) =>
+                        Array.from(
+                            { length: getRowColumnCount(row, 0, CONSTANTS) },
+                            () => null
+                        )
+                )
+                grid[0][0] = {
+                    color: 0xff0000,
+                    x: bubbleX(0, 0),
+                    y: bubbleY(0),
+                }
+                grid[2][5] = {
+                    color: 0x0000ff,
+                    x: bubbleX(5, 2),
+                    y: bubbleY(2),
+                }
+                setState(game, { grid, rowPhase: 0 })
+            })
+
+            vi.spyOn(Math, 'random').mockReturnValue(0)
+            internal.onGameStart()
+
+            expect(stateOf(game).grid[2][5]).toBeNull()
+            expect(stateOf(game).bubblesRemaining).toBe(1)
+            expect(stateOf(game).currentBubble?.color).toBe(0xff0000)
+            expect(stateOf(game).nextBubble?.color).toBe(0xff0000)
+        })
+
+        it('drops an unsupported color before reconciling nextBubble', () => {
+            const game = makeGame({
+                colors: [0xff0000, 0x0000ff],
+                rowAddInterval: 5,
+                newRowFillChance: 0.5,
+            })
+            const grid: (Bubble | null)[][] = Array.from(
+                { length: CONSTANTS.GRID_HEIGHT },
+                (_, row) =>
+                    Array.from(
+                        { length: getRowColumnCount(row, 0, CONSTANTS) },
+                        () => null
+                    )
+            )
+            grid[0][0] = { color: 0xff0000, x: bubbleX(0, 0), y: bubbleY(0) }
+            grid[0][12] = { color: 0x0000ff, x: bubbleX(12, 0), y: bubbleY(0) }
+
+            setState(game, {
+                grid,
+                rowPhase: 0,
+                bubblesRemaining: 2,
+                shotCount: 4,
+                projectile: {
+                    x: bubbleX(1, 0),
+                    y: bubbleY(0),
+                    vx: 0,
+                    vy: -720,
+                    color: 0xff0000,
+                },
+                nextBubble: { color: 0x0000ff },
+            })
+
+            let randomCall = 0
+            vi.spyOn(Math, 'random').mockImplementation(() => {
+                randomCall++
+                if (randomCall === 1 || randomCall === 2 || randomCall === 15) {
+                    return 0
+                }
+                return 1
+            })
+
+            game.attachBubble({ kind: 'ceiling' })
+
+            expect(
+                stateOf(game)
+                    .grid.flat()
+                    .some(bubble => bubble?.color === 0x0000ff)
+            ).toBe(false)
+            expect(stateOf(game).bubblesRemaining).toBe(
+                countGrid(stateOf(game).grid)
+            )
+            expect(stateOf(game).nextBubble?.color).toBe(0xff0000)
+        })
+
+        it('reports unique active colors from the board', () => {
+            const game = makeGame()
+            const grid: (Bubble | null)[][] = Array.from(
+                { length: CONSTANTS.GRID_HEIGHT },
+                (_, row) =>
+                    Array.from(
+                        { length: getRowColumnCount(row, 0, CONSTANTS) },
+                        () => null
+                    )
+            )
+            grid[0][0] = { color: 0xff0000, x: bubbleX(0, 0), y: bubbleY(0) }
+            grid[0][1] = { color: 0xff0000, x: bubbleX(1, 0), y: bubbleY(0) }
+            grid[1][0] = { color: 0x00ff00, x: bubbleX(0, 1), y: bubbleY(1) }
+            setState(game, { grid, rowPhase: 0 })
+
+            const internal = game as unknown as {
+                getAvailableBubbleColors: () => number[]
+            }
+            expect(internal.getAvailableBubbleColors()).toEqual([
+                0xff0000, 0x00ff00,
+            ])
+        })
+
+        it('falls back to config colors when the grid is empty', () => {
+            const game = makeGame()
+            setState(game, { grid: [] })
+            const internal = game as unknown as {
+                getAvailableBubbleColors: () => number[]
+            }
+            expect(internal.getAvailableBubbleColors()).toEqual(
+                CONSTANTS.COLORS
+            )
         })
     })
 

--- a/src/lib/games/bubble-shooter/BubbleShooterGame.test.ts
+++ b/src/lib/games/bubble-shooter/BubbleShooterGame.test.ts
@@ -805,31 +805,120 @@ describe('BubbleShooterGame', () => {
 
     describe('game over detection', () => {
         it('triggers end when a bubble enters the danger zone after a new row', () => {
+            // The danger-zone bubble must remain ceiling-connected after the
+            // row insertion; otherwise removeUnsupportedBubbles drops it and
+            // no game-over is triggered. A col-0 chain from row 0 to row 17
+            // stays connected after shifting to rows 1..18.
+            vi.spyOn(Math, 'random').mockReturnValue(0)
             const game = makeGame()
-            const dangerousY = getBubbleY(17, CONSTANTS)
-            const grid: ({
-                color: number
-                x: number
-                y: number
-            } | null)[][] = []
-            for (let r = 0; r < 18; r++) {
-                grid.push([])
-            }
-            grid[17] = [
-                {
+            const grid: (Bubble | null)[][] = Array.from(
+                { length: CONSTANTS.GRID_HEIGHT },
+                (_, row) =>
+                    Array.from(
+                        { length: getRowColumnCount(row, 0, CONSTANTS) },
+                        () => null
+                    )
+            )
+            for (let r = 0; r <= 17; r++) {
+                grid[r][0] = {
                     color: 0xff0000,
-                    x: getBubbleX(0, 17, 0, CONSTANTS),
-                    y: dangerousY,
-                },
-            ]
+                    x: bubbleX(0, r),
+                    y: bubbleY(r),
+                }
+            }
             setState(game, {
                 isActive: true, // allow end() to proceed to score save (fetch mocked)
                 projectile: { x: 300, y: 50, vx: 0, vy: -5, color: 0xff0000 },
                 grid,
+                rowPhase: 0,
                 shotCount: 4,
+                bubblesRemaining: 18,
             })
             const ended = game.attachBubble({ kind: 'ceiling' })
             expect(ended).toBe(true)
+        })
+    })
+
+    describe('ceiling-connectivity drops', () => {
+        it('drops bubbles disconnected from the ceiling after a direct match', () => {
+            const game = makeGame()
+            const grid: (Bubble | null)[][] = Array.from(
+                { length: CONSTANTS.GRID_HEIGHT },
+                (_, row) =>
+                    Array.from(
+                        { length: getRowColumnCount(row, 0, CONSTANTS) },
+                        () => null
+                    )
+            )
+            // Two top red bubbles with one blue supported only by the reds.
+            grid[0][0] = { color: 0xff0000, x: bubbleX(0, 0), y: bubbleY(0) }
+            grid[0][1] = { color: 0xff0000, x: bubbleX(1, 0), y: bubbleY(0) }
+            grid[1][0] = { color: 0x0000ff, x: bubbleX(0, 1), y: bubbleY(1) }
+            setState(game, {
+                isActive: false,
+                projectile: {
+                    x: bubbleX(2, 0),
+                    y: CONSTANTS.BUBBLE_RADIUS,
+                    vx: 0,
+                    vy: -720,
+                    color: 0xff0000,
+                },
+                grid,
+                rowPhase: 0,
+                bubblesRemaining: 3,
+                score: 0,
+            })
+            game.attachBubble({ kind: 'ceiling' })
+            expect(countGrid(stateOf(game).grid)).toBe(0)
+            expect(stateOf(game).bubblesPopped).toBe(4)
+            expect(stateOf(game).largestCombo).toBe(4)
+            expect(stateOf(game).successfulShots).toBe(1)
+            expect(stateOf(game).score).toBe(1_040)
+        })
+
+        it('returns dropped positions without score or count side effects', () => {
+            const game = makeGame()
+            const grid: (Bubble | null)[][] = Array.from(
+                { length: CONSTANTS.GRID_HEIGHT },
+                (_, row) =>
+                    Array.from(
+                        { length: getRowColumnCount(row, 0, CONSTANTS) },
+                        () => null
+                    )
+            )
+            const isolated = { row: 3, col: 5 }
+            grid[0][0] = {
+                color: 0xff0000,
+                x: bubbleX(0, 0),
+                y: bubbleY(0),
+            }
+            grid[isolated.row][isolated.col] = {
+                color: 0x0000ff,
+                x: bubbleX(isolated.col, isolated.row),
+                y: bubbleY(isolated.row),
+            }
+            setState(game, {
+                grid,
+                rowPhase: 0,
+                bubblesRemaining: 2,
+                score: 0,
+                successfulShots: 0,
+            })
+
+            const internal = game as unknown as {
+                removeUnsupportedBubbles: (
+                    constants: GameConstants
+                ) => GridPosition[]
+            }
+            const dropped = internal.removeUnsupportedBubbles(
+                game.getConstantsView()
+            )
+
+            expect(dropped).toEqual([isolated])
+            expect(stateOf(game).grid[3][5]).toBeNull()
+            expect(stateOf(game).bubblesRemaining).toBe(2)
+            expect(stateOf(game).score).toBe(0)
+            expect(stateOf(game).successfulShots).toBe(0)
         })
     })
 
@@ -998,15 +1087,6 @@ describe('BubbleShooterGame', () => {
                 ) => unknown
             }
             expect(internal.findClosestPosition(constants, [])).toBeNull()
-        })
-
-        it('checkMatches is a no-op when the start cell is empty', () => {
-            const game = makeGame()
-            setState(game, { grid: [[null, null]] })
-            const internal = game as unknown as {
-                checkMatches: (row: number, col: number) => void
-            }
-            expect(() => internal.checkMatches(0, 0)).not.toThrow()
         })
 
         it('checkBubbleCollision skips empty rows and null cells', () => {

--- a/src/lib/games/bubble-shooter/BubbleShooterGame.test.ts
+++ b/src/lib/games/bubble-shooter/BubbleShooterGame.test.ts
@@ -8,6 +8,7 @@ import type {
     BubbleShooterConfig,
     GameConstants,
     GridPosition,
+    Bubble,
 } from './types'
 import {
     getBubbleX,
@@ -103,6 +104,35 @@ function expectGridInvariant(game: BubbleShooterGame): void {
     }
 
     expect(state.bubblesRemaining).toBe(countGrid(state.grid))
+}
+
+function simulateProjectile(frameCount: number): number {
+    const game = makeGame({
+        gameHeight: 12_000,
+        shooterY: 10_000,
+        projectileSpeed: 720,
+    })
+    setState(game, {
+        projectile: {
+            x: 300,
+            y: 5_000,
+            vx: 0,
+            vy: -720,
+            color: 0xff0000,
+        },
+        grid: Array.from({ length: CONSTANTS.GRID_HEIGHT }, (_, row) =>
+            Array.from(
+                { length: getRowColumnCount(row, 0, CONSTANTS) },
+                () => null
+            )
+        ),
+        rowPhase: 0,
+    })
+
+    for (let frame = 0; frame < frameCount; frame++) {
+        game.updateProjectile(1 / frameCount)
+    }
+    return stateOf(game).projectile?.y ?? Number.NaN
 }
 
 describe('BubbleShooterGame', () => {
@@ -366,13 +396,19 @@ describe('BubbleShooterGame', () => {
         it('moves the projectile by its velocity', () => {
             const game = makeGame()
             setState(game, {
-                projectile: { x: 100, y: 200, vx: 5, vy: -10, color: 0xff0000 },
+                projectile: {
+                    x: 100,
+                    y: 200,
+                    vx: 500,
+                    vy: -1000,
+                    color: 0xff0000,
+                },
                 grid: [],
             })
-            game.updateProjectile()
+            game.updateProjectile(0.01)
             const p = stateOf(game).projectile
-            expect(p?.x).toBe(105)
-            expect(p?.y).toBe(190)
+            expect(p?.x).toBeCloseTo(105, 5)
+            expect(p?.y).toBeCloseTo(190, 5)
         })
 
         it('reflects off the left wall', () => {
@@ -381,13 +417,13 @@ describe('BubbleShooterGame', () => {
                 projectile: {
                     x: CONSTANTS.BUBBLE_RADIUS - 1,
                     y: 400,
-                    vx: -5,
-                    vy: -10,
+                    vx: -500,
+                    vy: -1000,
                     color: 0xff0000,
                 },
                 grid: [],
             })
-            game.updateProjectile()
+            game.updateProjectile(0.01)
             expect(stateOf(game).projectile?.vx).toBeGreaterThan(0)
         })
 
@@ -397,13 +433,13 @@ describe('BubbleShooterGame', () => {
                 projectile: {
                     x: CONSTANTS.GAME_WIDTH - CONSTANTS.BUBBLE_RADIUS + 1,
                     y: 400,
-                    vx: 5,
-                    vy: -10,
+                    vx: 500,
+                    vy: -1000,
                     color: 0xff0000,
                 },
                 grid: [],
             })
-            game.updateProjectile()
+            game.updateProjectile(0.01)
             expect(stateOf(game).projectile?.vx).toBeLessThan(0)
         })
 
@@ -415,19 +451,75 @@ describe('BubbleShooterGame', () => {
                     x: 300,
                     y: CONSTANTS.BUBBLE_RADIUS - 1,
                     vx: 0,
-                    vy: -5,
+                    vy: -500,
                     color: 0xff0000,
                 },
                 grid: [],
             })
-            game.updateProjectile()
+            game.updateProjectile(0.01)
             expect(stateOf(game).projectile).toBeNull()
         })
 
         it('does nothing without a projectile', () => {
             const game = makeGame()
             setState(game, { projectile: null, needsRedraw: false })
-            expect(game.updateProjectile()).toBe(false)
+            expect(game.updateProjectile(0.016)).toBe(false)
+        })
+    })
+
+    describe('updateProjectile (time-based physics)', () => {
+        it('moves equally for one second at 30Hz 60Hz and 120Hz', () => {
+            const at30 = simulateProjectile(30)
+            const at60 = simulateProjectile(60)
+            const at120 = simulateProjectile(120)
+            expect(at30).toBeCloseTo(4_280, 5)
+            expect(at60).toBeCloseTo(at30, 5)
+            expect(at120).toBeCloseTo(at30, 5)
+        })
+
+        it('does not tunnel at 4000 pixels per second', () => {
+            const game = makeGame({ projectileSpeed: 4_000 })
+            const grid: (Bubble | null)[][] = Array.from(
+                { length: CONSTANTS.GRID_HEIGHT },
+                (_, row) =>
+                    Array.from(
+                        { length: getRowColumnCount(row, 0, CONSTANTS) },
+                        () => null
+                    )
+            )
+            grid[8][6] = { color: 0x00ff00, x: 300, y: 300 }
+
+            setState(game, {
+                grid,
+                rowPhase: 0,
+                projectile: {
+                    x: 300,
+                    y: 400,
+                    vx: 0,
+                    vy: -4_000,
+                    color: 0xff0000,
+                },
+            })
+
+            game.updateProjectile(0.05)
+            expect(stateOf(game).projectile).toBeNull()
+        })
+
+        it('reflects back inside the right wall', () => {
+            const game = makeGame({ projectileSpeed: 720 })
+            setState(game, {
+                projectile: {
+                    x: 578,
+                    y: 400,
+                    vx: 720,
+                    vy: 0,
+                    color: 0xff0000,
+                },
+                grid: [],
+            })
+            game.updateProjectile(0.016)
+            expect(stateOf(game).projectile?.x).toBeLessThanOrEqual(580)
+            expect(stateOf(game).projectile?.vx).toBeLessThan(0)
         })
     })
 
@@ -455,7 +547,7 @@ describe('BubbleShooterGame', () => {
                 bubblesRemaining: 5,
                 score: 0,
             })
-            game.attachBubble()
+            game.attachBubble({ kind: 'ceiling' })
             const state = stateOf(game)
             expect(state.score).toBeGreaterThanOrEqual(30) // 3 * 10
             expect(state.bubblesPopped).toBe(3)
@@ -490,7 +582,7 @@ describe('BubbleShooterGame', () => {
                 ],
                 bubblesRemaining: 2,
             })
-            game.attachBubble()
+            game.attachBubble({ kind: 'ceiling' })
             // No match: blue added, bubblesRemaining = 2 + 1 = 3, nothing popped
             expect(stateOf(game).bubblesRemaining).toBe(3)
             expect(stateOf(game).bubblesPopped).toBe(0)
@@ -528,7 +620,7 @@ describe('BubbleShooterGame', () => {
                 bubblesRemaining: 3,
                 score: 0,
             })
-            game.attachBubble()
+            game.attachBubble({ kind: 'ceiling' })
             // 4 matched → 40 points + 1000 all clear bonus
             expect(stateOf(game).score).toBeGreaterThanOrEqual(1000)
         })
@@ -548,7 +640,7 @@ describe('BubbleShooterGame', () => {
                 shotCount: 4,
             })
             const before = stateOf(game).grid.length
-            game.attachBubble()
+            game.attachBubble({ kind: 'ceiling' })
             expect(stateOf(game).shotCount).toBe(5)
             expect(stateOf(game).grid.length).toBeGreaterThan(before)
         })
@@ -560,7 +652,7 @@ describe('BubbleShooterGame', () => {
                 projectile: { x: 300, y: 50, vx: 0, vy: -5, color: 0xff0000 },
                 grid: [],
             })
-            game.attachBubble()
+            game.attachBubble({ kind: 'ceiling' })
             expect(stateOf(game).projectile).toBeNull()
         })
 
@@ -590,7 +682,7 @@ describe('BubbleShooterGame', () => {
                 grid: realGrid,
                 bubblesRemaining: 1,
             })
-            game.attachBubble(anchor)
+            game.attachBubble({ kind: 'bubble', anchor })
             const filledNeighbor = getNeighbors(
                 anchor.row,
                 anchor.col,
@@ -624,7 +716,7 @@ describe('BubbleShooterGame', () => {
                 projectile: { x: 300, y: 400, vx: 0, vy: -5, color: 0x00ff00 },
                 grid,
             })
-            expect(() => game.attachBubble()).not.toThrow()
+            expect(() => game.attachBubble({ kind: 'ceiling' })).not.toThrow()
             expect(stateOf(game).projectile).toBeNull()
         })
     })
@@ -654,7 +746,7 @@ describe('BubbleShooterGame', () => {
                 grid,
                 shotCount: 4,
             })
-            const ended = game.attachBubble()
+            const ended = game.attachBubble({ kind: 'ceiling' })
             expect(ended).toBe(true)
         })
     })
@@ -738,13 +830,19 @@ describe('BubbleShooterGame', () => {
             game.start()
             // Arm a projectile so updateProjectile does real work.
             setState(game, {
-                projectile: { x: 100, y: 200, vx: 5, vy: -10, color: 0xff0000 },
+                projectile: {
+                    x: 100,
+                    y: 200,
+                    vx: 500,
+                    vy: 0,
+                    color: 0xff0000,
+                },
                 grid: [],
             })
             onStateChange.mockClear()
             // Invoke one update tick (the framework render loop calls this).
-            game.update(16)
-            expect(stateOf(game).projectile?.x).toBe(105)
+            game.update(0.016)
+            expect(stateOf(game).projectile?.x).toBeCloseTo(108, 5)
             expect(onStateChange).toHaveBeenCalled()
         })
 
@@ -753,13 +851,13 @@ describe('BubbleShooterGame', () => {
             game.start()
             game.pause()
             const projectileBefore = stateOf(game).projectile
-            game.update(16)
+            game.update(0.016)
             expect(stateOf(game).projectile).toEqual(projectileBefore)
         })
 
         it('update and render are safe no-ops when not active', () => {
             const game = makeGame()
-            expect(() => game.update(16)).not.toThrow()
+            expect(() => game.update(0.016)).not.toThrow()
             expect(() => game.render()).not.toThrow()
         })
 
@@ -793,7 +891,7 @@ describe('BubbleShooterGame', () => {
         it('attachBubble returns false when there is no projectile', () => {
             const game = makeGame()
             setState(game, { projectile: null })
-            expect(game.attachBubble()).toBe(false)
+            expect(game.attachBubble({ kind: 'ceiling' })).toBe(false)
         })
 
         it('findAttachPosition returns null when there is no projectile', () => {

--- a/src/lib/games/bubble-shooter/BubbleShooterGame.test.ts
+++ b/src/lib/games/bubble-shooter/BubbleShooterGame.test.ts
@@ -7,8 +7,15 @@ import type {
     BubbleShooterState,
     BubbleShooterConfig,
     GameConstants,
+    GridPosition,
 } from './types'
-import { getBubbleX, getBubbleY, getNeighbors } from './utils'
+import {
+    getBubbleX,
+    getBubbleY,
+    getNeighbors,
+    getRowColumnCount,
+    type RowPhase,
+} from './utils'
 
 const CONSTANTS: GameConstants = {
     BUBBLE_RADIUS: 20,
@@ -45,6 +52,57 @@ function setState(
     const internal = stateOf(game)
     Object.assign(internal, overrides)
     return internal
+}
+
+const bubbleX = (col: number, row: number, rowPhase: RowPhase = 0): number =>
+    getBubbleX(col, row, rowPhase, CONSTANTS)
+
+const bubbleY = (row: number): number => getBubbleY(row, CONSTANTS)
+
+const neighbors = (
+    row: number,
+    col: number,
+    rowPhase: RowPhase = 0
+): GridPosition[] => getNeighbors(row, col, rowPhase, CONSTANTS)
+
+function countGrid(grid: BubbleShooterState['grid']): number {
+    let count = 0
+    for (const row of grid) {
+        for (let col = 0; col < row.length; col++) {
+            if (row[col]) {
+                count++
+            }
+        }
+    }
+    return count
+}
+
+function expectGridInvariant(game: BubbleShooterGame): void {
+    const state = stateOf(game)
+    const constants = game.getConstantsView()
+
+    for (let rowIndex = 0; rowIndex < state.grid.length; rowIndex++) {
+        const row = state.grid[rowIndex]
+        expect(row).toHaveLength(
+            getRowColumnCount(rowIndex, state.rowPhase, constants)
+        )
+
+        for (let col = 0; col < row.length; col++) {
+            expect(col in row).toBe(true)
+            expect(row[col]).not.toBeUndefined()
+            const bubble = row[col]
+            if (!bubble) {
+                continue
+            }
+
+            expect(bubble.x).toBe(
+                getBubbleX(col, rowIndex, state.rowPhase, constants)
+            )
+            expect(bubble.y).toBeCloseTo(getBubbleY(rowIndex, constants))
+        }
+    }
+
+    expect(state.bubblesRemaining).toBe(countGrid(state.grid))
 }
 
 describe('BubbleShooterGame', () => {
@@ -231,8 +289,8 @@ describe('BubbleShooterGame', () => {
 
         it('detects collision with a grid bubble', () => {
             const game = makeGame()
-            const bx = getBubbleX(0, 0, CONSTANTS)
-            const by = getBubbleY(0, 0, CONSTANTS)
+            const bx = getBubbleX(0, 0, 0, CONSTANTS)
+            const by = getBubbleY(0, CONSTANTS)
             setState(game, {
                 projectile: {
                     x: bx + 1,
@@ -248,8 +306,8 @@ describe('BubbleShooterGame', () => {
 
         it('returns null when projectile is far from all bubbles', () => {
             const game = makeGame()
-            const bx = getBubbleX(0, 0, CONSTANTS)
-            const by = getBubbleY(0, 0, CONSTANTS)
+            const bx = getBubbleX(0, 0, 0, CONSTANTS)
+            const by = getBubbleY(0, CONSTANTS)
             setState(game, {
                 projectile: { x: 500, y: 500, vx: 0, vy: -5, color: 0xff0000 },
                 grid: [[{ color: 0x00ff00, x: bx, y: by }]],
@@ -261,13 +319,13 @@ describe('BubbleShooterGame', () => {
             const game = makeGame()
             const farBubble = {
                 color: 0x00ff00,
-                x: getBubbleX(0, 0, CONSTANTS),
-                y: getBubbleY(0, 0, CONSTANTS),
+                x: getBubbleX(0, 0, 0, CONSTANTS),
+                y: getBubbleY(0, CONSTANTS),
             }
             const nearBubble = {
                 color: 0x0000ff,
-                x: getBubbleX(1, 0, CONSTANTS),
-                y: getBubbleY(0, 0, CONSTANTS),
+                x: getBubbleX(1, 0, 0, CONSTANTS),
+                y: getBubbleY(0, CONSTANTS),
             }
             const dist = CONSTANTS.BUBBLE_RADIUS * 1.5
             setState(game, {
@@ -376,13 +434,13 @@ describe('BubbleShooterGame', () => {
     describe('attachBubble - matching & scoring', () => {
         it('detects matches of 3+ and awards score', () => {
             const game = makeGame()
-            const bx0 = getBubbleX(0, 0, CONSTANTS)
-            const by0 = getBubbleY(0, 0, CONSTANTS)
-            const bx1 = getBubbleX(1, 0, CONSTANTS)
+            const bx0 = getBubbleX(0, 0, 0, CONSTANTS)
+            const by0 = getBubbleY(0, CONSTANTS)
+            const bx1 = getBubbleX(1, 0, 0, CONSTANTS)
             setState(game, {
                 isActive: false,
                 projectile: {
-                    x: getBubbleX(2, 0, CONSTANTS) - 1,
+                    x: getBubbleX(2, 0, 0, CONSTANTS) - 1,
                     y: by0,
                     vx: 0,
                     vy: -5,
@@ -410,8 +468,8 @@ describe('BubbleShooterGame', () => {
             setState(game, {
                 isActive: false,
                 projectile: {
-                    x: getBubbleX(2, 0, CONSTANTS),
-                    y: getBubbleY(0, 0, CONSTANTS),
+                    x: getBubbleX(2, 0, 0, CONSTANTS),
+                    y: getBubbleY(0, CONSTANTS),
                     vx: 0,
                     vy: -5,
                     color: 0x0000ff, // blue into reds
@@ -420,13 +478,13 @@ describe('BubbleShooterGame', () => {
                     [
                         {
                             color: 0xff0000,
-                            x: getBubbleX(0, 0, CONSTANTS),
-                            y: getBubbleY(0, 0, CONSTANTS),
+                            x: getBubbleX(0, 0, 0, CONSTANTS),
+                            y: getBubbleY(0, CONSTANTS),
                         },
                         {
                             color: 0xff0000,
-                            x: getBubbleX(1, 0, CONSTANTS),
-                            y: getBubbleY(0, 0, CONSTANTS),
+                            x: getBubbleX(1, 0, 0, CONSTANTS),
+                            y: getBubbleY(0, CONSTANTS),
                         },
                     ],
                 ],
@@ -443,25 +501,25 @@ describe('BubbleShooterGame', () => {
             const bubbles = [
                 {
                     color: 0xff0000,
-                    x: getBubbleX(0, 0, CONSTANTS),
-                    y: getBubbleY(0, 0, CONSTANTS),
+                    x: getBubbleX(0, 0, 0, CONSTANTS),
+                    y: getBubbleY(0, CONSTANTS),
                 },
                 {
                     color: 0xff0000,
-                    x: getBubbleX(1, 0, CONSTANTS),
-                    y: getBubbleY(0, 0, CONSTANTS),
+                    x: getBubbleX(1, 0, 0, CONSTANTS),
+                    y: getBubbleY(0, CONSTANTS),
                 },
                 {
                     color: 0xff0000,
-                    x: getBubbleX(2, 0, CONSTANTS),
-                    y: getBubbleY(0, 0, CONSTANTS),
+                    x: getBubbleX(2, 0, 0, CONSTANTS),
+                    y: getBubbleY(0, CONSTANTS),
                 },
             ]
             setState(game, {
                 isActive: false,
                 projectile: {
-                    x: getBubbleX(3, 0, CONSTANTS),
-                    y: getBubbleY(0, 0, CONSTANTS),
+                    x: getBubbleX(3, 0, 0, CONSTANTS),
+                    y: getBubbleY(0, CONSTANTS),
                     vx: 0,
                     vy: -5,
                     color: 0xff0000,
@@ -517,14 +575,14 @@ describe('BubbleShooterGame', () => {
             realGrid[anchor.row] = []
             realGrid[anchor.row][anchor.col] = {
                 color: 0x00ff00,
-                x: getBubbleX(anchor.col, anchor.row, CONSTANTS),
-                y: getBubbleY(anchor.row, 0, CONSTANTS),
+                x: getBubbleX(anchor.col, anchor.row, 0, CONSTANTS),
+                y: getBubbleY(anchor.row, CONSTANTS),
             }
             setState(game, {
                 isActive: false,
                 projectile: {
-                    x: getBubbleX(0, 0, CONSTANTS),
-                    y: getBubbleY(0, 0, CONSTANTS),
+                    x: getBubbleX(0, 0, 0, CONSTANTS),
+                    y: getBubbleY(0, CONSTANTS),
                     vx: 0,
                     vy: -5,
                     color: 0xff0000,
@@ -536,6 +594,7 @@ describe('BubbleShooterGame', () => {
             const filledNeighbor = getNeighbors(
                 anchor.row,
                 anchor.col,
+                0,
                 CONSTANTS
             ).find(
                 ({ row, col }) =>
@@ -553,7 +612,7 @@ describe('BubbleShooterGame', () => {
             } | null)[][] = Array(CONSTANTS.GRID_HEIGHT)
                 .fill(null)
                 .map((_, row) => {
-                    const cols = CONSTANTS.GRID_WIDTH - (row % 2)
+                    const cols = getRowColumnCount(row, 0, CONSTANTS)
                     return Array(cols).fill({
                         color: 0xff0000,
                         x: 0,
@@ -573,7 +632,7 @@ describe('BubbleShooterGame', () => {
     describe('game over detection', () => {
         it('triggers end when a bubble enters the danger zone after a new row', () => {
             const game = makeGame()
-            const dangerousY = getBubbleY(17, 0, CONSTANTS)
+            const dangerousY = getBubbleY(17, CONSTANTS)
             const grid: ({
                 color: number
                 x: number
@@ -585,7 +644,7 @@ describe('BubbleShooterGame', () => {
             grid[17] = [
                 {
                     color: 0xff0000,
-                    x: getBubbleX(0, 17, CONSTANTS),
+                    x: getBubbleX(0, 17, 0, CONSTANTS),
                     y: dangerousY,
                 },
             ]
@@ -772,8 +831,8 @@ describe('BubbleShooterGame', () => {
 
         it('checkBubbleCollision skips empty rows and null cells', () => {
             const game = makeGame()
-            const bx = getBubbleX(0, 0, CONSTANTS)
-            const by = getBubbleY(0, 0, CONSTANTS)
+            const bx = getBubbleX(0, 0, 0, CONSTANTS)
+            const by = getBubbleY(0, CONSTANTS)
             // Row 0 has a real bubble; row 1 is undefined; row 2 has a null cell.
             setState(game, {
                 projectile: {
@@ -799,9 +858,38 @@ describe('BubbleShooterGame', () => {
                 bubblesRemaining: 0,
             })
             const internal = game as unknown as {
-                addRowAtTop: (c: typeof constants) => void
+                addRowAtTop: (
+                    constants: GameConstants,
+                    generationColors: number[]
+                ) => void
             }
-            expect(() => internal.addRowAtTop(constants)).not.toThrow()
+            expect(() =>
+                internal.addRowAtTop(constants, CONSTANTS.COLORS)
+            ).not.toThrow()
+        })
+    })
+
+    describe('phase-aware dense grid', () => {
+        it('preserves dense geometry through two inserted rows', () => {
+            vi.spyOn(Math, 'random').mockReturnValue(0)
+            const game = makeGame({ newRowFillChance: 1 })
+            game.start()
+
+            const internal = game as unknown as {
+                addRowAtTop: (
+                    constants: GameConstants,
+                    colors: number[]
+                ) => void
+            }
+            const constants = game.getConstantsView()
+
+            expectGridInvariant(game)
+            internal.addRowAtTop(constants, CONSTANTS.COLORS)
+            expect(stateOf(game).rowPhase).toBe(1)
+            expectGridInvariant(game)
+            internal.addRowAtTop(constants, CONSTANTS.COLORS)
+            expect(stateOf(game).rowPhase).toBe(0)
+            expectGridInvariant(game)
         })
     })
 })

--- a/src/lib/games/bubble-shooter/BubbleShooterGame.test.ts
+++ b/src/lib/games/bubble-shooter/BubbleShooterGame.test.ts
@@ -794,7 +794,7 @@ describe('BubbleShooterGame', () => {
             expect(endSpy).not.toHaveBeenCalled()
         })
 
-        it('uses fallback position when grid is fully filled', () => {
+        it('consumes a fully-blocked ceiling impact without throwing', () => {
             const game = makeGame()
             const grid: ({
                 color: number

--- a/src/lib/games/bubble-shooter/BubbleShooterGame.test.ts
+++ b/src/lib/games/bubble-shooter/BubbleShooterGame.test.ts
@@ -460,6 +460,45 @@ describe('BubbleShooterGame', () => {
             expect(stateOf(game).projectile).toBeNull()
         })
 
+        it('prefers bubble collision when the projectile is also at the ceiling', () => {
+            const game = makeGame()
+            const targetCol = 6
+            const grid: (Bubble | null)[][] = Array.from(
+                { length: CONSTANTS.GRID_HEIGHT },
+                (_, row) =>
+                    Array.from(
+                        { length: getRowColumnCount(row, 0, CONSTANTS) },
+                        () => null
+                    )
+            )
+            grid[0][targetCol] = {
+                color: 0x00ff00,
+                x: bubbleX(targetCol, 0),
+                y: bubbleY(0),
+            }
+            setState(game, {
+                grid,
+                rowPhase: 0,
+                projectile: {
+                    x: bubbleX(targetCol, 0),
+                    y: CONSTANTS.BUBBLE_RADIUS,
+                    vx: 0,
+                    vy: -720,
+                    color: 0xff0000,
+                },
+            })
+            const attachSpy = vi
+                .spyOn(game, 'attachBubble')
+                .mockReturnValue(false)
+
+            game.updateProjectile(0)
+
+            expect(attachSpy).toHaveBeenCalledWith({
+                kind: 'bubble',
+                anchor: { row: 0, col: targetCol },
+            })
+        })
+
         it('does nothing without a projectile', () => {
             const game = makeGame()
             setState(game, { projectile: null, needsRedraw: false })
@@ -693,6 +732,49 @@ describe('BubbleShooterGame', () => {
                     stateOf(game).grid[row]?.[col]?.color === 0xff0000
             )
             expect(filledNeighbor).toBeDefined()
+        })
+
+        it('consumes a locally blocked impact without ending the run', () => {
+            const game = makeGame({ rowAddInterval: 99 })
+            const anchor = { row: 2, col: 5 }
+            const grid: (Bubble | null)[][] = Array.from(
+                { length: CONSTANTS.GRID_HEIGHT },
+                (_, row) =>
+                    Array.from(
+                        { length: getRowColumnCount(row, 0, CONSTANTS) },
+                        () => null
+                    )
+            )
+
+            for (const position of [anchor, ...neighbors(2, 5)]) {
+                grid[position.row][position.col] = {
+                    color: 0x00ff00,
+                    x: bubbleX(position.col, position.row),
+                    y: bubbleY(position.row),
+                }
+            }
+            const before = JSON.stringify(grid)
+            const endSpy = vi.spyOn(game, 'end').mockResolvedValue(undefined)
+
+            setState(game, {
+                isActive: true,
+                grid,
+                rowPhase: 0,
+                projectile: {
+                    x: bubbleX(5, 2),
+                    y: bubbleY(2) + 30,
+                    vx: 0,
+                    vy: -720,
+                    color: 0xff0000,
+                },
+                bubblesRemaining: countGrid(grid),
+            })
+
+            expect(game.attachBubble({ kind: 'bubble', anchor })).toBe(false)
+            expect(JSON.stringify(stateOf(game).grid)).toBe(before)
+            expect(stateOf(game).projectile).toBeNull()
+            expect(stateOf(game).isActive).toBe(true)
+            expect(endSpy).not.toHaveBeenCalled()
         })
 
         it('uses fallback position when grid is fully filled', () => {

--- a/src/lib/games/bubble-shooter/BubbleShooterGame.ts
+++ b/src/lib/games/bubble-shooter/BubbleShooterGame.ts
@@ -10,7 +10,12 @@ import type {
     GameConstants,
     GridPosition,
 } from './types'
-import { getBubbleX, getBubbleY, getNeighbors } from './utils'
+import {
+    getBubbleX,
+    getBubbleY,
+    getNeighbors,
+    getRowColumnCount,
+} from './utils'
 import { distance } from '@/lib/games/shared/geometry'
 
 // Default configuration for Bubble Shooter game
@@ -89,7 +94,7 @@ export class BubbleShooterGame extends BaseGame<
             aimAngle: -Math.PI / 2,
             projectile: null,
             bubblesRemaining: 0,
-            rowOffset: 0,
+            rowPhase: 0,
             shotCount: 0,
             shotsFired: 0,
             bubblesPopped: 0,
@@ -276,37 +281,73 @@ export class BubbleShooterGame extends BaseGame<
 
     private initializeGrid(): void {
         const constants = this.getConstantsView()
+        const generationColors = [...this.config.colors]
         this.state.grid = []
-        this.state.bubblesRemaining = 0
 
         for (let row = 0; row < this.config.initialRows; row++) {
-            this.state.grid[row] = []
-            const cols = constants.GRID_WIDTH - (row % 2)
-            for (let col = 0; col < cols; col++) {
+            const rowCells = this.createEmptyRow(row, constants)
+            for (let col = 0; col < rowCells.length; col++) {
                 if (Math.random() < this.config.bubbleFillChance) {
-                    this.state.grid[row][col] = {
-                        color: constants.COLORS[
-                            Math.floor(Math.random() * constants.COLORS.length)
+                    rowCells[col] = {
+                        color: generationColors[
+                            Math.floor(Math.random() * generationColors.length)
                         ],
-                        x: getBubbleX(col, row, constants),
-                        y: getBubbleY(row, this.state.rowOffset, constants),
+                        x: 0,
+                        y: 0,
                     }
-                    this.state.bubblesRemaining++
-                } else {
-                    this.state.grid[row][col] = null
+                }
+            }
+            this.state.grid[row] = rowCells
+        }
+
+        this.refreshBubbleCoordinates(constants)
+        this.syncBubbleCount()
+        this.state.needsRedraw = true
+    }
+
+    private createEmptyRow(
+        row: number,
+        constants: GameConstants
+    ): (Bubble | null)[] {
+        return Array.from(
+            {
+                length: getRowColumnCount(row, this.state.rowPhase, constants),
+            },
+            () => null
+        )
+    }
+
+    private refreshBubbleCoordinates(constants: GameConstants): void {
+        for (let row = 0; row < constants.GRID_HEIGHT; row++) {
+            const width = getRowColumnCount(row, this.state.rowPhase, constants)
+            const oldRow = this.state.grid[row] ?? []
+            this.state.grid[row] = Array.from(
+                { length: width },
+                (_, col) => oldRow[col] ?? null
+            )
+
+            for (let col = 0; col < width; col++) {
+                const bubble = this.state.grid[row][col]
+                if (!bubble) {
+                    continue
+                }
+                bubble.x = getBubbleX(col, row, this.state.rowPhase, constants)
+                bubble.y = getBubbleY(row, constants)
+            }
+        }
+    }
+
+    private syncBubbleCount(): number {
+        let count = 0
+        for (const row of this.state.grid) {
+            for (let col = 0; col < row.length; col++) {
+                if (row[col]) {
+                    count++
                 }
             }
         }
-
-        for (
-            let row = this.config.initialRows;
-            row < constants.GRID_HEIGHT;
-            row++
-        ) {
-            this.state.grid[row] = []
-        }
-
-        this.state.needsRedraw = true
+        this.state.bubblesRemaining = count
+        return count
     }
 
     private generateBubble(): Bubble {
@@ -429,8 +470,13 @@ export class BubbleShooterGame extends BaseGame<
         if (attachPos) {
             this.state.grid[attachPos.row][attachPos.col] = {
                 color: this.state.projectile.color,
-                x: getBubbleX(attachPos.col, attachPos.row, constants),
-                y: getBubbleY(attachPos.row, this.state.rowOffset, constants),
+                x: getBubbleX(
+                    attachPos.col,
+                    attachPos.row,
+                    this.state.rowPhase,
+                    constants
+                ),
+                y: getBubbleY(attachPos.row, constants),
             }
             this.state.bubblesRemaining++
 
@@ -470,7 +516,12 @@ export class BubbleShooterGame extends BaseGame<
         if (anchorPosition) {
             const anchoredPosition = this.findClosestPosition(
                 constants,
-                getNeighbors(anchorPosition.row, anchorPosition.col, constants)
+                getNeighbors(
+                    anchorPosition.row,
+                    anchorPosition.col,
+                    this.state.rowPhase,
+                    constants
+                )
             )
             if (anchoredPosition) {
                 return anchoredPosition
@@ -479,7 +530,7 @@ export class BubbleShooterGame extends BaseGame<
 
         const candidates: GridPosition[] = []
         for (let row = 0; row < constants.GRID_HEIGHT; row++) {
-            const cols = constants.GRID_WIDTH - (row % 2)
+            const cols = getRowColumnCount(row, this.state.rowPhase, constants)
             for (let col = 0; col < cols; col++) {
                 candidates.push({ row, col })
             }
@@ -488,7 +539,9 @@ export class BubbleShooterGame extends BaseGame<
         return (
             this.findClosestPosition(constants, candidates) || {
                 row: 0,
-                col: Math.floor((constants.GRID_WIDTH - (0 % 2)) / 2),
+                col: Math.floor(
+                    getRowColumnCount(0, this.state.rowPhase, constants) / 2
+                ),
             }
         )
     }
@@ -510,8 +563,8 @@ export class BubbleShooterGame extends BaseGame<
             }
 
             if (!this.state.grid[row][col]) {
-                const x = getBubbleX(col, row, constants)
-                const y = getBubbleY(row, this.state.rowOffset, constants)
+                const x = getBubbleX(col, row, this.state.rowPhase, constants)
+                const y = getBubbleY(row, constants)
                 const dist = distance(this.state.projectile, { x, y })
 
                 if (
@@ -533,7 +586,7 @@ export class BubbleShooterGame extends BaseGame<
         }
 
         const constants = this.getConstantsView()
-        const neighbors = getNeighbors(row, col, constants)
+        const neighbors = getNeighbors(row, col, this.state.rowPhase, constants)
         return neighbors.some(({ row: nRow, col: nCol }) => {
             return this.state.grid[nRow] && this.state.grid[nRow][nCol]
         })
@@ -565,7 +618,12 @@ export class BubbleShooterGame extends BaseGame<
             visited.add(key)
             matches.push({ row, col })
 
-            const neighbors = getNeighbors(row, col, constants)
+            const neighbors = getNeighbors(
+                row,
+                col,
+                this.state.rowPhase,
+                constants
+            )
             neighbors.forEach(({ row: nRow, col: nCol }) => {
                 dfs(nRow, nCol)
             })
@@ -598,50 +656,37 @@ export class BubbleShooterGame extends BaseGame<
     }
 
     private addNewRow(constants: GameConstants): void {
-        this.addRowAtTop(constants)
+        this.addRowAtTop(constants, [...this.config.colors])
 
         if (this.checkGameOverCondition(constants)) {
             this.state.needsRedraw = true
         }
     }
 
-    private addRowAtTop(constants: GameConstants): void {
+    private addRowAtTop(
+        constants: GameConstants,
+        generationColors: number[]
+    ): void {
         for (let row = constants.GRID_HEIGHT - 1; row > 0; row--) {
-            this.state.grid[row] = this.state.grid[row - 1]
-                ? [...this.state.grid[row - 1]]
-                : []
-
-            if (this.state.grid[row]) {
-                for (let col = 0; col < this.state.grid[row].length; col++) {
-                    const bubble = this.state.grid[row][col]
-                    if (bubble) {
-                        bubble.y = getBubbleY(
-                            row,
-                            this.state.rowOffset,
-                            constants
-                        )
-                    }
-                }
-            }
+            this.state.grid[row] = [...(this.state.grid[row - 1] ?? [])]
         }
 
-        this.state.grid[0] = []
-        const cols = constants.GRID_WIDTH - (0 % 2)
-        for (let col = 0; col < cols; col++) {
+        this.state.rowPhase = this.state.rowPhase === 0 ? 1 : 0
+        const topRow = this.createEmptyRow(0, constants)
+        for (let col = 0; col < topRow.length; col++) {
             if (Math.random() < this.config.newRowFillChance) {
-                this.state.grid[0][col] = {
-                    color: constants.COLORS[
-                        Math.floor(Math.random() * constants.COLORS.length)
+                topRow[col] = {
+                    color: generationColors[
+                        Math.floor(Math.random() * generationColors.length)
                     ],
-                    x: getBubbleX(col, 0, constants),
-                    y: getBubbleY(0, this.state.rowOffset, constants),
+                    x: 0,
+                    y: 0,
                 }
-                this.state.bubblesRemaining++
-            } else {
-                this.state.grid[0][col] = null
             }
         }
-
+        this.state.grid[0] = topRow
+        this.refreshBubbleCoordinates(constants)
+        this.syncBubbleCount()
         this.state.needsRedraw = true
     }
 

--- a/src/lib/games/bubble-shooter/BubbleShooterGame.ts
+++ b/src/lib/games/bubble-shooter/BubbleShooterGame.ts
@@ -55,6 +55,14 @@ const MAX_PROJECTILE_FRAME_SECONDS = 0.05
 // fast projectile can never tunnel past a bubble between collision checks.
 const MAX_PROJECTILE_SUBSTEP_RATIO = 0.5
 
+// Outcome of resolving a single shot: direct color matches, ceiling-
+// disconnected drops, and the combined removed count used for scoring.
+interface ShotResolution {
+    directMatches: GridPosition[]
+    dropped: GridPosition[]
+    removedCount: number
+}
+
 export class BubbleShooterGame extends BaseGame<
     BubbleShooterState,
     BubbleShooterConfig,
@@ -106,13 +114,18 @@ export class BubbleShooterGame extends BaseGame<
             shotsFired: 0,
             bubblesPopped: 0,
             largestCombo: 0,
+            successfulShots: 0,
             needsRedraw: true,
         }
     }
 
     protected onGameStart(): void {
-        // Build the initial grid and load the first bubbles.
+        // Build the initial grid, drop any ceiling-disconnected clusters
+        // the random fill may have produced, then load the first bubbles.
+        const constants = this.getConstantsView()
         this.initializeGrid()
+        this.removeUnsupportedBubbles(constants)
+        this.syncBubbleCount()
         this.generateBubble()
         this.generateNextBubble()
     }
@@ -177,6 +190,7 @@ export class BubbleShooterGame extends BaseGame<
             shotsFired,
             accuracy: Math.min(rawAccuracy, 100),
             largestCombo: this.state.largestCombo,
+            successfulShots: this.state.successfulShots,
         }
     }
 
@@ -517,7 +531,7 @@ export class BubbleShooterGame extends BaseGame<
             }
             this.state.bubblesRemaining++
 
-            this.checkMatches(attachPos.row, attachPos.col)
+            this.resolveMatches(attachPos, constants)
         }
 
         this.state.shotCount++
@@ -611,61 +625,138 @@ export class BubbleShooterGame extends BaseGame<
         return bestPosition
     }
 
-    private checkMatches(startRow: number, startCol: number): void {
-        const bubble = this.state.grid[startRow][startCol]
-        if (!bubble) {
-            return
+    /**
+     * Iteratively collect the same-color cluster containing `start`, using
+     * phase-aware getNeighbors. Returns an empty list when the start cell is
+     * empty so resolveMatches can early-return without side effects.
+     */
+    private collectColorCluster(
+        start: GridPosition,
+        constants: GameConstants
+    ): GridPosition[] {
+        const startBubble = this.state.grid[start.row]?.[start.col]
+        if (!startBubble) {
+            return []
         }
-
-        const constants = this.getConstantsView()
-        const color = bubble.color
+        const color = startBubble.color
         const visited = new Set<string>()
-        const matches: GridPosition[] = []
+        const cluster: GridPosition[] = []
+        const stack: GridPosition[] = [start]
 
-        const dfs = (row: number, col: number): void => {
-            const key = `${row},${col}`
+        while (stack.length > 0) {
+            const current = stack.pop()!
+            const key = `${current.row},${current.col}`
             if (visited.has(key)) {
-                return
+                continue
             }
-            if (!this.state.grid[row] || !this.state.grid[row][col]) {
-                return
+            const bubble = this.state.grid[current.row]?.[current.col]
+            if (!bubble || bubble.color !== color) {
+                continue
             }
-            if (this.state.grid[row][col]?.color !== color) {
-                return
-            }
-
             visited.add(key)
-            matches.push({ row, col })
-
+            cluster.push(current)
             const neighbors = getNeighbors(
-                row,
-                col,
+                current.row,
+                current.col,
                 this.state.rowPhase,
                 constants
             )
-            neighbors.forEach(({ row: nRow, col: nCol }) => {
-                dfs(nRow, nCol)
-            })
+            for (const neighbor of neighbors) {
+                if (!visited.has(`${neighbor.row},${neighbor.col}`)) {
+                    stack.push(neighbor)
+                }
+            }
+        }
+        return cluster
+    }
+
+    /**
+     * Collect every cell reachable from occupied row-zero cells via occupied
+     * neighbors. Color is ignored — this is the ceiling-support set.
+     */
+    private collectCeilingConnected(constants: GameConstants): Set<string> {
+        const connected = new Set<string>()
+        const stack: GridPosition[] = []
+
+        const topRow = this.state.grid[0]
+        if (topRow) {
+            for (let col = 0; col < topRow.length; col++) {
+                if (topRow[col]) {
+                    stack.push({ row: 0, col })
+                }
+            }
         }
 
-        dfs(startRow, startCol)
-
-        if (matches.length >= MATCH_THRESHOLD) {
-            this.removeBubbles(matches)
-            this.addScore(matches.length * POINTS_PER_BUBBLE, 'bubble_pop')
-            this.state.bubblesPopped += matches.length
-            this.state.largestCombo = Math.max(
-                this.state.largestCombo,
-                matches.length
+        while (stack.length > 0) {
+            const current = stack.pop()!
+            const key = `${current.row},${current.col}`
+            if (connected.has(key)) {
+                continue
+            }
+            const bubble = this.state.grid[current.row]?.[current.col]
+            if (!bubble) {
+                continue
+            }
+            connected.add(key)
+            const neighbors = getNeighbors(
+                current.row,
+                current.col,
+                this.state.rowPhase,
+                constants
             )
-            this.state.bubblesRemaining -= matches.length
-            this.state.needsRedraw = true
+            for (const neighbor of neighbors) {
+                if (!connected.has(`${neighbor.row},${neighbor.col}`)) {
+                    stack.push(neighbor)
+                }
+            }
+        }
+        return connected
+    }
+
+    private removeUnsupportedBubbles(constants: GameConstants): GridPosition[] {
+        const connected = this.collectCeilingConnected(constants)
+        const dropped: GridPosition[] = []
+
+        for (let row = 0; row < this.state.grid.length; row++) {
+            for (let col = 0; col < this.state.grid[row].length; col++) {
+                if (
+                    this.state.grid[row][col] &&
+                    !connected.has(`${row},${col}`)
+                ) {
+                    dropped.push({ row, col })
+                    this.state.grid[row][col] = null
+                }
+            }
+        }
+        return dropped
+    }
+
+    private resolveMatches(
+        attached: GridPosition,
+        constants: GameConstants
+    ): ShotResolution {
+        const directMatches = this.collectColorCluster(attached, constants)
+        if (directMatches.length < MATCH_THRESHOLD) {
+            return { directMatches: [], dropped: [], removedCount: 0 }
         }
 
+        this.removeBubbles(directMatches)
+        const dropped = this.removeUnsupportedBubbles(constants)
+        this.syncBubbleCount()
+        const removedCount = directMatches.length + dropped.length
+
+        this.addScore(removedCount * POINTS_PER_BUBBLE, 'bubble_pop')
+        this.state.successfulShots++
+        this.state.bubblesPopped += removedCount
+        this.state.largestCombo = Math.max(
+            this.state.largestCombo,
+            removedCount
+        )
         if (this.state.bubblesRemaining === 0) {
             this.addScore(ALL_CLEAR_BONUS, 'all_clear')
-            this.state.needsRedraw = true
         }
+
+        return { directMatches, dropped, removedCount }
     }
 
     private removeBubbles(bubbles: GridPosition[]): void {
@@ -676,6 +767,8 @@ export class BubbleShooterGame extends BaseGame<
 
     private addNewRow(constants: GameConstants): void {
         this.addRowAtTop(constants, [...this.config.colors])
+        this.removeUnsupportedBubbles(constants)
+        this.syncBubbleCount()
 
         if (this.checkGameOverCondition(constants)) {
             this.state.needsRedraw = true

--- a/src/lib/games/bubble-shooter/BubbleShooterGame.ts
+++ b/src/lib/games/bubble-shooter/BubbleShooterGame.ts
@@ -489,8 +489,10 @@ export class BubbleShooterGame extends BaseGame<
     /**
      * Attach the projectile to the grid, then resolve matches and game-over.
      * The impact disambiguates the trigger: 'bubble' snaps to a neighbor of
-     * the collided anchor; 'ceiling' falls back to the global nearest-cell
-     * search. Returns true if the game ended as a result.
+     * the collided anchor; 'ceiling' snaps to a row-zero cell. Candidates are
+     * strictly impact-local; a blocked impact (no unoccupied local candidate)
+     * consumes the shot but does not by itself end the run — only the danger-
+     * zone check in checkGameOverCondition can. Returns true if the game ended.
      */
     attachBubble(impact: ProjectileImpact): boolean {
         if (!this.state.projectile) {
@@ -516,24 +518,22 @@ export class BubbleShooterGame extends BaseGame<
             this.state.bubblesRemaining++
 
             this.checkMatches(attachPos.row, attachPos.col)
+        }
 
-            this.state.shotCount++
-            // Skip adding a new row when the board was just cleared by this
-            // shot (all-clear bonus awarded) so the board stays empty.
-            if (
-                this.state.bubblesRemaining > 0 &&
-                this.state.shotCount % this.config.rowAddInterval === 0
-            ) {
-                this.addNewRow(constants)
-            }
+        this.state.shotCount++
+        if (
+            this.state.bubblesRemaining > 0 &&
+            this.state.shotCount % this.config.rowAddInterval === 0
+        ) {
+            this.addNewRow(constants)
         }
 
         this.state.projectile = null
         this.state.needsRedraw = true
 
         if (this.checkGameOverCondition(constants)) {
-            this.end().catch(err =>
-                console.error('BubbleShooter end failed', err)
+            this.end().catch(error =>
+                console.error('BubbleShooter end failed', error)
             )
             return true
         }
@@ -548,37 +548,36 @@ export class BubbleShooterGame extends BaseGame<
             return null
         }
 
+        let candidates: GridPosition[]
         if (anchorPosition) {
-            const anchoredPosition = this.findClosestPosition(
-                constants,
-                getNeighbors(
-                    anchorPosition.row,
-                    anchorPosition.col,
-                    this.state.rowPhase,
-                    constants
-                )
+            // Bubble impact: only neighbors of the collided anchor are valid.
+            candidates = getNeighbors(
+                anchorPosition.row,
+                anchorPosition.col,
+                this.state.rowPhase,
+                constants
             )
-            if (anchoredPosition) {
-                return anchoredPosition
+        } else {
+            // Ceiling impact: only row-zero cells are valid attachment points.
+            const topRowCols = getRowColumnCount(
+                0,
+                this.state.rowPhase,
+                constants
+            )
+            candidates = []
+            for (let col = 0; col < topRowCols; col++) {
+                candidates.push({ row: 0, col })
             }
         }
 
-        const candidates: GridPosition[] = []
-        for (let row = 0; row < constants.GRID_HEIGHT; row++) {
-            const cols = getRowColumnCount(row, this.state.rowPhase, constants)
-            for (let col = 0; col < cols; col++) {
-                candidates.push({ row, col })
-            }
-        }
+        // Locality comes from the candidate set; filter occupied cells so the
+        // projectile never overwrites an existing bubble. No global or fixed
+        // fallback — a blocked impact returns null and is handled by the caller.
+        const unoccupied = candidates.filter(({ row, col }) => {
+            return !this.state.grid[row] || !this.state.grid[row][col]
+        })
 
-        return (
-            this.findClosestPosition(constants, candidates) || {
-                row: 0,
-                col: Math.floor(
-                    getRowColumnCount(0, this.state.rowPhase, constants) / 2
-                ),
-            }
-        )
+        return this.findClosestPosition(constants, unoccupied)
     }
 
     private findClosestPosition(
@@ -602,10 +601,7 @@ export class BubbleShooterGame extends BaseGame<
                 const y = getBubbleY(row, constants)
                 const dist = distance(this.state.projectile, { x, y })
 
-                if (
-                    this.isValidAttachPosition(row, col) &&
-                    dist < minDistance
-                ) {
+                if (dist < minDistance) {
                     minDistance = dist
                     bestPosition = { row, col }
                 }
@@ -613,18 +609,6 @@ export class BubbleShooterGame extends BaseGame<
         }
 
         return bestPosition
-    }
-
-    private isValidAttachPosition(row: number, col: number): boolean {
-        if (row === 0) {
-            return true
-        }
-
-        const constants = this.getConstantsView()
-        const neighbors = getNeighbors(row, col, this.state.rowPhase, constants)
-        return neighbors.some(({ row: nRow, col: nCol }) => {
-            return this.state.grid[nRow] && this.state.grid[nRow][nCol]
-        })
     }
 
     private checkMatches(startRow: number, startCol: number): void {

--- a/src/lib/games/bubble-shooter/BubbleShooterGame.ts
+++ b/src/lib/games/bubble-shooter/BubbleShooterGame.ts
@@ -178,19 +178,21 @@ export class BubbleShooterGame extends BaseGame<
         const timerStatus = this.getTimerStatus()
         const shotsFired = this.state.shotsFired
         const bubblesPopped = this.state.bubblesPopped
-        // Cap at 100%: a single shot can pop multiple bubbles, so a raw
-        // bubblesPopped/shotsFired ratio would exceed 100%.
-        const rawAccuracy =
-            shotsFired > 0 ? (bubblesPopped / shotsFired) * 100 : 0
+        const successfulShots = this.state.successfulShots
+        // Accuracy is the successful-shot rate (shots that popped at least one
+        // bubble / total shots). No cap is needed: successfulShots cannot
+        // exceed shotsFired, so the ratio is already in [0, 100].
+        const accuracy =
+            shotsFired > 0 ? (successfulShots / shotsFired) * 100 : 0
         return {
             finalScore: this.state.score,
             timeElapsed: Math.floor(timerStatus.elapsedTime || 0),
             gameCompleted: this.state.isGameOver,
             bubblesPopped,
             shotsFired,
-            accuracy: Math.min(rawAccuracy, 100),
+            accuracy,
             largestCombo: this.state.largestCombo,
-            successfulShots: this.state.successfulShots,
+            successfulShots,
         }
     }
 
@@ -199,6 +201,7 @@ export class BubbleShooterGame extends BaseGame<
             bubblesPopped: this.state.bubblesPopped,
             shotsFired: this.state.shotsFired,
             largestCombo: this.state.largestCombo,
+            successfulShots: this.state.successfulShots,
         }
     }
 
@@ -373,9 +376,9 @@ export class BubbleShooterGame extends BaseGame<
 
     private generateBubble(): Bubble {
         const constants = this.getConstantsView()
-        const colorIndex = Math.floor(Math.random() * constants.COLORS.length)
+        const color = this.randomColor(this.getAvailableBubbleColors())
         const bubble: Bubble = {
-            color: constants.COLORS[colorIndex],
+            color,
             x: this.state.shooter.x,
             y: this.state.shooter.y - constants.BUBBLE_RADIUS * 1.5,
         }
@@ -385,15 +388,52 @@ export class BubbleShooterGame extends BaseGame<
     }
 
     private generateNextBubble(): { color: number } {
-        const constants = this.getConstantsView()
         const nextBubble = {
-            color: constants.COLORS[
-                Math.floor(Math.random() * constants.COLORS.length)
-            ],
+            color: this.randomColor(this.getAvailableBubbleColors()),
         }
         this.state.nextBubble = nextBubble
         this.state.needsRedraw = true
         return nextBubble
+    }
+
+    /**
+     * Unique colors currently present on the board. Used so the queue and new
+     * rows only produce colors the player can actually match. Falls back to
+     * the full config palette when the grid is empty (e.g. on reset).
+     */
+    private getAvailableBubbleColors(): number[] {
+        const colors = new Set<number>()
+        for (const row of this.state.grid) {
+            if (!row) {
+                continue
+            }
+            for (let col = 0; col < row.length; col++) {
+                const bubble = row[col]
+                if (bubble) {
+                    colors.add(bubble.color)
+                }
+            }
+        }
+        return colors.size > 0 ? [...colors] : [...this.config.colors]
+    }
+
+    private randomColor(colors: number[]): number {
+        return colors[Math.floor(Math.random() * colors.length)]
+    }
+
+    /**
+     * Re-roll nextBubble if its color is no longer present on the board (for
+     * example, after the last bubble of a color was just popped or dropped).
+     * Preserves the current bubble — only future shots are reconciled.
+     */
+    private reconcileNextBubbleColor(): void {
+        const colors = this.getAvailableBubbleColors()
+        if (
+            !this.state.nextBubble ||
+            !colors.includes(this.state.nextBubble.color)
+        ) {
+            this.state.nextBubble = { color: this.randomColor(colors) }
+        }
     }
 
     // --- Projectile physics ---
@@ -544,6 +584,9 @@ export class BubbleShooterGame extends BaseGame<
 
         this.state.projectile = null
         this.state.needsRedraw = true
+        // Reconcile nextBubble exactly once after match resolution and any
+        // row insertion so the upcoming shot is always a playable color.
+        this.reconcileNextBubbleColor()
 
         if (this.checkGameOverCondition(constants)) {
             this.end().catch(error =>
@@ -766,7 +809,11 @@ export class BubbleShooterGame extends BaseGame<
     }
 
     private addNewRow(constants: GameConstants): void {
-        this.addRowAtTop(constants, [...this.config.colors])
+        // Snapshot the active palette BEFORE the shift: addRowAtTop changes
+        // which bubbles occupy the top row, so a post-shift reading would
+        // seed the new row with colors that may have just been displaced.
+        const generationColors = this.getAvailableBubbleColors()
+        this.addRowAtTop(constants, generationColors)
         this.removeUnsupportedBubbles(constants)
         this.syncBubbleCount()
 

--- a/src/lib/games/bubble-shooter/BubbleShooterGame.ts
+++ b/src/lib/games/bubble-shooter/BubbleShooterGame.ts
@@ -9,6 +9,7 @@ import type {
     Bubble,
     GameConstants,
     GridPosition,
+    ProjectileImpact,
 } from './types'
 import {
     getBubbleX,
@@ -34,7 +35,7 @@ export const DEFAULT_BUBBLE_SHOOTER_CONFIG: BubbleShooterConfig = {
     gameWidth: 600,
     gameHeight: 800,
     shooterY: 800 - 60,
-    projectileSpeed: 12,
+    projectileSpeed: 720,
     initialRows: 5,
     rowAddInterval: 5,
     bubbleFillChance: 0.8,
@@ -47,6 +48,12 @@ const POINTS_PER_BUBBLE = 10
 const ALL_CLEAR_BONUS = 1000
 // Match threshold (number of same-color connected bubbles required to pop).
 const MATCH_THRESHOLD = 3
+// Cap a single physics update to this many seconds so a long frame (or a tab
+// suspended in the background) cannot teleport the projectile across the board.
+const MAX_PROJECTILE_FRAME_SECONDS = 0.05
+// Each collision substep travels at most this fraction of BUBBLE_RADIUS so a
+// fast projectile can never tunnel past a bubble between collision checks.
+const MAX_PROJECTILE_SUBSTEP_RATIO = 0.5
 
 export class BubbleShooterGame extends BaseGame<
     BubbleShooterState,
@@ -129,7 +136,7 @@ export class BubbleShooterGame extends BaseGame<
         this.emitStateChange()
     }
 
-    update(_deltaTime: number): void {
+    update(deltaTime: number): void {
         if (
             !this.state.isActive ||
             this.state.isPaused ||
@@ -138,7 +145,7 @@ export class BubbleShooterGame extends BaseGame<
             return
         }
 
-        this.updateProjectile()
+        this.updateProjectile(deltaTime)
 
         // Only emit state changes when something actually changed this frame.
         if (this.state.needsRedraw) {
@@ -378,46 +385,70 @@ export class BubbleShooterGame extends BaseGame<
     // --- Projectile physics ---
 
     /**
-     * Advance the projectile one step, handling wall bounces and attachment.
+     * Advance the projectile by elapsed seconds, using collision-safe substeps.
+     * On each substep the bubble collision is checked BEFORE the ceiling so a
+     * projectile grazing a bubble attaches to the bubble, not the ceiling.
      * Returns true if the game ended as a result of this step.
      */
-    updateProjectile(): boolean {
-        if (!this.state.projectile) {
+    updateProjectile(deltaTimeSeconds: number): boolean {
+        const projectile = this.state.projectile
+        if (!projectile) {
             return false
         }
 
         const constants = this.getConstantsView()
-        const oldX = this.state.projectile.x
-        const oldY = this.state.projectile.y
+        const elapsed = Math.min(
+            Math.max(deltaTimeSeconds, 0),
+            MAX_PROJECTILE_FRAME_SECONDS
+        )
+        const speed = Math.hypot(projectile.vx, projectile.vy)
+        const maxStepDistance =
+            constants.BUBBLE_RADIUS * MAX_PROJECTILE_SUBSTEP_RATIO
+        const stepCount = Math.max(
+            1,
+            Math.ceil((speed * elapsed) / maxStepDistance)
+        )
+        const stepSeconds = elapsed / stepCount
 
-        this.state.projectile.x += this.state.projectile.vx
-        this.state.projectile.y += this.state.projectile.vy
+        for (let step = 0; step < stepCount; step++) {
+            projectile.x += projectile.vx * stepSeconds
+            projectile.y += projectile.vy * stepSeconds
+            this.reflectProjectileOffWalls(constants)
 
-        // Wall collisions
-        if (
-            this.state.projectile.x <= constants.BUBBLE_RADIUS ||
-            this.state.projectile.x >=
-                constants.GAME_WIDTH - constants.BUBBLE_RADIUS
-        ) {
-            this.state.projectile.vx *= -1
+            const anchor = this.checkBubbleCollision()
+            if (anchor) {
+                return this.attachBubble({ kind: 'bubble', anchor })
+            }
+            if (projectile.y <= constants.BUBBLE_RADIUS) {
+                return this.attachBubble({ kind: 'ceiling' })
+            }
         }
 
-        if (
-            Math.abs(oldX - this.state.projectile.x) > 0.1 ||
-            Math.abs(oldY - this.state.projectile.y) > 0.1
-        ) {
+        if (elapsed > 0) {
             this.state.needsRedraw = true
         }
-
-        const bubbleCollision = this.checkBubbleCollision()
-        if (
-            this.state.projectile.y <= constants.BUBBLE_RADIUS ||
-            bubbleCollision
-        ) {
-            return this.attachBubble(bubbleCollision ?? undefined)
-        }
-
         return false
+    }
+
+    /**
+     * Mirror the projectile's overshoot back inside the playfield and flip vx
+     * toward the board. Unlike a plain sign flip, this keeps the projectile
+     * within [radius, gameWidth - radius] so it never escapes the board.
+     */
+    private reflectProjectileOffWalls(constants: GameConstants): void {
+        const projectile = this.state.projectile
+        if (!projectile) {
+            return
+        }
+        const minX = constants.BUBBLE_RADIUS
+        const maxX = constants.GAME_WIDTH - constants.BUBBLE_RADIUS
+        if (projectile.x < minX) {
+            projectile.x = 2 * minX - projectile.x
+            projectile.vx = Math.abs(projectile.vx)
+        } else if (projectile.x > maxX) {
+            projectile.x = 2 * maxX - projectile.x
+            projectile.vx = -Math.abs(projectile.vx)
+        }
     }
 
     /**
@@ -457,14 +488,18 @@ export class BubbleShooterGame extends BaseGame<
 
     /**
      * Attach the projectile to the grid, then resolve matches and game-over.
-     * Returns true if the game ended as a result.
+     * The impact disambiguates the trigger: 'bubble' snaps to a neighbor of
+     * the collided anchor; 'ceiling' falls back to the global nearest-cell
+     * search. Returns true if the game ended as a result.
      */
-    attachBubble(anchorPosition?: GridPosition): boolean {
+    attachBubble(impact: ProjectileImpact): boolean {
         if (!this.state.projectile) {
             return false
         }
 
         const constants = this.getConstantsView()
+        const anchorPosition =
+            impact.kind === 'bubble' ? impact.anchor : undefined
         const attachPos = this.findAttachPosition(constants, anchorPosition)
 
         if (attachPos) {

--- a/src/lib/games/bubble-shooter/BubbleShooterRenderer.test.ts
+++ b/src/lib/games/bubble-shooter/BubbleShooterRenderer.test.ts
@@ -100,6 +100,7 @@ function makeState(
         shotsFired: 0,
         bubblesPopped: 0,
         largestCombo: 0,
+        successfulShots: 0,
         needsRedraw: true,
         ...overrides,
     }

--- a/src/lib/games/bubble-shooter/BubbleShooterRenderer.test.ts
+++ b/src/lib/games/bubble-shooter/BubbleShooterRenderer.test.ts
@@ -95,7 +95,7 @@ function makeState(
         aimAngle: -Math.PI / 2,
         projectile: null,
         bubblesRemaining: 0,
-        rowOffset: 0,
+        rowPhase: 0,
         shotCount: 0,
         shotsFired: 0,
         bubblesPopped: 0,

--- a/src/lib/games/bubble-shooter/initFramework.test.ts
+++ b/src/lib/games/bubble-shooter/initFramework.test.ts
@@ -55,7 +55,7 @@ vi.mock('./BubbleShooterGame', () => ({
         gameWidth: 600,
         gameHeight: 800,
         shooterY: 740,
-        projectileSpeed: 12,
+        projectileSpeed: 720,
         initialRows: 5,
         rowAddInterval: 5,
         bubbleFillChance: 0.8,
@@ -739,6 +739,25 @@ describe('initBubbleShooterGameFramework', () => {
                 rafCallbacks[rafCallbacks.length - 1](0)
             }
             expect(rendererMock.render).not.toHaveBeenCalled()
+        })
+
+        it('passes the frame delta to game.update in seconds (not milliseconds)', async () => {
+            const { BubbleShooterGame } = await import('./BubbleShooterGame')
+            result = await initBubbleShooterGameFramework()
+            const gameMock = vi.mocked(BubbleShooterGame).mock.results[0].value
+            vi.mocked(gameMock.update).mockClear()
+
+            // Two RAF frames 16ms apart: the first establishes lastFrame, the
+            // second computes dt = 16ms and must pass it as 0.016 seconds.
+            const base = 1_000
+            vi.spyOn(performance, 'now')
+                .mockReturnValueOnce(base)
+                .mockReturnValueOnce(base + 16)
+
+            rafCallbacks.shift()?.(base)
+            rafCallbacks.shift()?.(base + 16)
+
+            expect(gameMock.update).toHaveBeenLastCalledWith(0.016)
         })
     })
 

--- a/src/lib/games/bubble-shooter/initFramework.test.ts
+++ b/src/lib/games/bubble-shooter/initFramework.test.ts
@@ -135,7 +135,12 @@ function createElement<K extends keyof HTMLElementTagNameMap>(
     return el
 }
 
-function setupDOM() {
+type PreviewCtx = { fillRect: ReturnType<typeof vi.fn>; fillStyle: string }
+
+function setupDOM(): {
+    currentBubbleCtx: PreviewCtx
+    nextBubbleCtx: PreviewCtx
+} {
     const container = createElement('div', { id: 'game-container' })
     const currentBubble = createElement('canvas', {
         id: 'current-bubble',
@@ -209,25 +214,39 @@ function setupDOM() {
         resumeBtn
     )
 
-    // Provide a stub 2D context for the preview canvases
-    const mockCtx = {
+    // Provide separate stub 2D contexts for each preview canvas so tests can
+    // assert on current vs next independently (and detect null clears).
+    const currentBubbleCtx: PreviewCtx = {
         fillRect: vi.fn(),
         fillStyle: '',
     }
-    for (const c of [currentBubble, nextBubble]) {
-        Object.defineProperty(c, 'getContext', {
-            value: vi.fn(() => mockCtx),
-            writable: true,
-        })
+    const nextBubbleCtx: PreviewCtx = {
+        fillRect: vi.fn(),
+        fillStyle: '',
     }
+
+    Object.defineProperty(currentBubble, 'getContext', {
+        value: vi.fn(() => currentBubbleCtx),
+        writable: true,
+    })
+    Object.defineProperty(nextBubble, 'getContext', {
+        value: vi.fn(() => nextBubbleCtx),
+        writable: true,
+    })
+
+    return { currentBubbleCtx, nextBubbleCtx }
 }
 
 describe('initBubbleShooterGameFramework', () => {
     const rafCallbacks: FrameRequestCallback[] = []
     let result: Awaited<ReturnType<typeof initBubbleShooterGameFramework>>
+    let currentBubbleCtx: PreviewCtx
+    let nextBubbleCtx: PreviewCtx
 
     beforeEach(() => {
-        setupDOM()
+        const ctxs = setupDOM()
+        currentBubbleCtx = ctxs.currentBubbleCtx
+        nextBubbleCtx = ctxs.nextBubbleCtx
         vi.clearAllMocks()
         vi.useFakeTimers()
         vi.stubGlobal('requestAnimationFrame', (cb: FrameRequestCallback) => {
@@ -933,6 +952,32 @@ describe('initBubbleShooterGameFramework', () => {
                 nextBubble: { color: 0x00ff00 },
             })
             expect(drawBubbleOnCanvas).not.toHaveBeenCalled()
+        })
+
+        it('clears the preview canvases when currentBubble/nextBubble transition from a color to null', async () => {
+            const { BubbleShooterGame } = await import('./BubbleShooterGame')
+            result = await initBubbleShooterGameFramework()
+            const gameMock = vi.mocked(BubbleShooterGame).mock.results[0].value
+            const callbacksArg = vi.mocked(BubbleShooterGame).mock
+                .calls[0][1] as any
+            const baseState = gameMock.getState()
+            // First a colored bubble on each canvas → one fillRect each
+            // (background) plus the bubble draw.
+            callbacksArg.onStateChange({
+                ...baseState,
+                currentBubble: { x: 300, y: 700, color: 0xff0000 },
+                nextBubble: { color: 0x00ff00 },
+            })
+            // Then null → the canvas must CLEAR (one more fillRect each for
+            // the background wipe; drawBubbleOnCanvas is NOT called).
+            callbacksArg.onStateChange({
+                ...baseState,
+                currentBubble: null,
+                nextBubble: null,
+            })
+
+            expect(currentBubbleCtx.fillRect).toHaveBeenCalledTimes(2)
+            expect(nextBubbleCtx.fillRect).toHaveBeenCalledTimes(2)
         })
     })
 

--- a/src/lib/games/bubble-shooter/initFramework.test.ts
+++ b/src/lib/games/bubble-shooter/initFramework.test.ts
@@ -135,7 +135,11 @@ function createElement<K extends keyof HTMLElementTagNameMap>(
     return el
 }
 
-type PreviewCtx = { fillRect: ReturnType<typeof vi.fn>; fillStyle: string }
+type PreviewCtx = {
+    fillRect: ReturnType<typeof vi.fn>
+    clearRect: ReturnType<typeof vi.fn>
+    fillStyle: string
+}
 
 function setupDOM(): {
     currentBubbleCtx: PreviewCtx
@@ -218,10 +222,12 @@ function setupDOM(): {
     // assert on current vs next independently (and detect null clears).
     const currentBubbleCtx: PreviewCtx = {
         fillRect: vi.fn(),
+        clearRect: vi.fn(),
         fillStyle: '',
     }
     const nextBubbleCtx: PreviewCtx = {
         fillRect: vi.fn(),
+        clearRect: vi.fn(),
         fillStyle: '',
     }
 
@@ -956,28 +962,37 @@ describe('initBubbleShooterGameFramework', () => {
 
         it('clears the preview canvases when currentBubble/nextBubble transition from a color to null', async () => {
             const { BubbleShooterGame } = await import('./BubbleShooterGame')
+            const { drawBubbleOnCanvas } = await import('./utils')
             result = await initBubbleShooterGameFramework()
             const gameMock = vi.mocked(BubbleShooterGame).mock.results[0].value
             const callbacksArg = vi.mocked(BubbleShooterGame).mock
                 .calls[0][1] as any
             const baseState = gameMock.getState()
             // First a colored bubble on each canvas → one fillRect each
-            // (background) plus the bubble draw.
+            // (translucent background) plus the bubble draw.
             callbacksArg.onStateChange({
                 ...baseState,
                 currentBubble: { x: 300, y: 700, color: 0xff0000 },
                 nextBubble: { color: 0x00ff00 },
             })
-            // Then null → the canvas must CLEAR (one more fillRect each for
-            // the background wipe; drawBubbleOnCanvas is NOT called).
+            vi.mocked(drawBubbleOnCanvas).mockClear()
+            currentBubbleCtx.fillRect.mockClear()
+            currentBubbleCtx.clearRect.mockClear()
+            nextBubbleCtx.fillRect.mockClear()
+            nextBubbleCtx.clearRect.mockClear()
+            // Then null → the canvas must CLEAR via clearRect (no background
+            // fillRect, no drawBubbleOnCanvas) on both preview contexts.
             callbacksArg.onStateChange({
                 ...baseState,
                 currentBubble: null,
                 nextBubble: null,
             })
 
-            expect(currentBubbleCtx.fillRect).toHaveBeenCalledTimes(2)
-            expect(nextBubbleCtx.fillRect).toHaveBeenCalledTimes(2)
+            expect(currentBubbleCtx.clearRect).toHaveBeenCalledTimes(1)
+            expect(nextBubbleCtx.clearRect).toHaveBeenCalledTimes(1)
+            expect(currentBubbleCtx.fillRect).not.toHaveBeenCalled()
+            expect(nextBubbleCtx.fillRect).not.toHaveBeenCalled()
+            expect(drawBubbleOnCanvas).not.toHaveBeenCalled()
         })
     })
 

--- a/src/lib/games/bubble-shooter/initFramework.ts
+++ b/src/lib/games/bubble-shooter/initFramework.ts
@@ -90,23 +90,30 @@ export async function initBubbleShooterGameFramework(
         app.canvas.style.borderRadius = '8px'
     }
 
-    // Helpers for the current/next bubble preview canvases
-    const drawCurrentBubblePreview = (color: number | undefined) => {
-        if (!currentBubbleCtx || color === undefined) {
+    // Unified helper for the current/next bubble preview canvases.
+    // Fills the background REGARDLESS so a null/undefined color clears the
+    // canvas (instead of leaving the previous bubble visible), then draws
+    // the bubble only when color is defined.
+    const drawBubblePreview = (
+        canvas: HTMLCanvasElement,
+        context: CanvasRenderingContext2D | null,
+        color: number | undefined
+    ): void => {
+        if (!context) {
             return
         }
-        currentBubbleCtx.fillStyle = 'rgba(0, 0, 0, 0.1)'
-        currentBubbleCtx.fillRect(
-            0,
-            0,
-            currentBubbleCanvas.width,
-            currentBubbleCanvas.height
-        )
-        const centerX = currentBubbleCanvas.width / 2
-        const centerY = currentBubbleCanvas.height / 2
+
+        context.fillStyle = 'rgba(0, 0, 0, 0.1)'
+        context.fillRect(0, 0, canvas.width, canvas.height)
+        if (color === undefined) {
+            return
+        }
+
+        const centerX = canvas.width / 2
+        const centerY = canvas.height / 2
         const radius = Math.min(centerX, centerY) - 4
         drawBubbleOnCanvas(
-            currentBubbleCtx,
+            context,
             centerX,
             centerY,
             radius,
@@ -114,32 +121,18 @@ export async function initBubbleShooterGameFramework(
         )
     }
 
-    const drawNextBubblePreview = (color: number | undefined) => {
-        if (!nextBubbleCtx || color === undefined) {
-            return
-        }
-        nextBubbleCtx.fillStyle = 'rgba(0, 0, 0, 0.1)'
-        nextBubbleCtx.fillRect(
-            0,
-            0,
-            nextBubbleCanvas.width,
-            nextBubbleCanvas.height
-        )
-        const centerX = nextBubbleCanvas.width / 2
-        const centerY = nextBubbleCanvas.height / 2
-        const radius = Math.min(centerX, centerY) - 4
-        drawBubbleOnCanvas(
-            nextBubbleCtx,
-            centerX,
-            centerY,
-            radius,
-            pixiColorToHex(color)
-        )
-    }
+    // Track last-drawn preview colors as `number | undefined` so a transition
+    // from a color to undefined (null bubble) is detected as a change and
+    // triggers a clear via drawBubblePreview(... undefined).
+    let lastCurrentColor: number | undefined
+    let lastNextColor: number | undefined
 
-    // Track last-drawn preview colors to avoid redundant redraws
-    let lastCurrentColor: number | null = null
-    let lastNextColor: number | null = null
+    const clearPreviews = () => {
+        lastCurrentColor = undefined
+        lastNextColor = undefined
+        drawBubblePreview(currentBubbleCanvas, currentBubbleCtx, undefined)
+        drawBubblePreview(nextBubbleCanvas, nextBubbleCtx, undefined)
+    }
 
     // Enhanced callbacks with UI updates
     const enhancedCallbacks: BaseGameCallbacks = {
@@ -149,17 +142,18 @@ export async function initBubbleShooterGameFramework(
             updateUI(bsState)
 
             const currentColor = bsState.currentBubble?.color
-            if (
-                currentColor !== undefined &&
-                currentColor !== lastCurrentColor
-            ) {
+            if (currentColor !== lastCurrentColor) {
                 lastCurrentColor = currentColor
-                drawCurrentBubblePreview(currentColor)
+                drawBubblePreview(
+                    currentBubbleCanvas,
+                    currentBubbleCtx,
+                    currentColor
+                )
             }
             const nextColor = bsState.nextBubble?.color
-            if (nextColor !== undefined && nextColor !== lastNextColor) {
+            if (nextColor !== lastNextColor) {
                 lastNextColor = nextColor
-                drawNextBubblePreview(nextColor)
+                drawBubblePreview(nextBubbleCanvas, nextBubbleCtx, nextColor)
             }
 
             customCallbacks?.onStateChange?.(state)
@@ -233,7 +227,7 @@ export async function initBubbleShooterGameFramework(
     const cleanupCanvasControls = setupCanvasControls(game, renderer)
 
     // Set up button handlers
-    const cleanupButtonHandlers = setupButtonHandlers(game)
+    const cleanupButtonHandlers = setupButtonHandlers(game, clearPreviews)
 
     // Set up keyboard controls (pause toggle)
     const cleanupKeyboardControls = setupKeyboardControls(game)
@@ -294,8 +288,7 @@ export async function initBubbleShooterGameFramework(
             game.destroy()
         },
         restart: () => {
-            lastCurrentColor = null
-            lastNextColor = null
+            clearPreviews()
             game.reset()
         },
         getState: () => game.getState(),
@@ -345,7 +338,10 @@ function showGameOver(finalScore: number, stats: BubbleShooterStats): void {
     }
 }
 
-function setupButtonHandlers(game: BubbleShooterGame): () => void {
+function setupButtonHandlers(
+    game: BubbleShooterGame,
+    clearPreviews: () => void
+): () => void {
     const startBtn = document.getElementById('start-btn')
     const endBtn = document.getElementById('end-btn')
     const pauseBtn = document.getElementById('pause-btn')
@@ -369,11 +365,13 @@ function setupButtonHandlers(game: BubbleShooterGame): () => void {
     }
 
     const resetHandler = () => {
+        clearPreviews()
         game.reset()
         resetButtonVisibility()
     }
 
     const restartHandler = () => {
+        clearPreviews()
         game.reset()
         resetButtonVisibility()
     }

--- a/src/lib/games/bubble-shooter/initFramework.ts
+++ b/src/lib/games/bubble-shooter/initFramework.ts
@@ -253,10 +253,12 @@ export async function initBubbleShooterGameFramework(
             if (lastFrame === 0) {
                 lastFrame = now
             }
-            const dt = now - lastFrame
+            // Convert the RAF millisecond delta to seconds — BaseGame.update
+            // advances by elapsed seconds. The game owns the per-frame clamp.
+            const deltaTimeSeconds = (now - lastFrame) / 1_000
             lastFrame = now
             // Drive game logic from the single rAF loop (no dual-RAF).
-            game.update(dt)
+            game.update(deltaTimeSeconds)
             const state = game.getState()
             if (state.needsRedraw) {
                 renderer.render(state)

--- a/src/lib/games/bubble-shooter/initFramework.ts
+++ b/src/lib/games/bubble-shooter/initFramework.ts
@@ -91,9 +91,10 @@ export async function initBubbleShooterGameFramework(
     }
 
     // Unified helper for the current/next bubble preview canvases.
-    // Fills the background REGARDLESS so a null/undefined color clears the
-    // canvas (instead of leaving the previous bubble visible), then draws
-    // the bubble only when color is defined.
+    // A null/undefined color CLEARS the canvas via clearRect (a translucent
+    // fillRect would only composite over the previous bubble, leaving a
+    // ghost). A defined color paints the translucent background then draws
+    // the bubble on top.
     const drawBubblePreview = (
         canvas: HTMLCanvasElement,
         context: CanvasRenderingContext2D | null,
@@ -103,11 +104,13 @@ export async function initBubbleShooterGameFramework(
             return
         }
 
-        context.fillStyle = 'rgba(0, 0, 0, 0.1)'
-        context.fillRect(0, 0, canvas.width, canvas.height)
         if (color === undefined) {
+            context.clearRect(0, 0, canvas.width, canvas.height)
             return
         }
+
+        context.fillStyle = 'rgba(0, 0, 0, 0.1)'
+        context.fillRect(0, 0, canvas.width, canvas.height)
 
         const centerX = canvas.width / 2
         const centerY = canvas.height / 2

--- a/src/lib/games/bubble-shooter/types.ts
+++ b/src/lib/games/bubble-shooter/types.ts
@@ -43,6 +43,7 @@ export interface BubbleShooterEndGameStats {
     shotsFired: number
     accuracy: number
     largestCombo: number
+    successfulShots: number
 }
 
 // Static game constants shape consumed by the shared grid/physics helpers
@@ -70,6 +71,7 @@ export interface BubbleShooterState extends BaseGameState {
     shotsFired: number
     bubblesPopped: number
     largestCombo: number
+    successfulShots: number
     needsRedraw: boolean
 }
 
@@ -96,4 +98,5 @@ export interface BubbleShooterStats extends BaseGameStats {
     shotsFired: number
     accuracy: number
     largestCombo: number
+    successfulShots: number
 }

--- a/src/lib/games/bubble-shooter/types.ts
+++ b/src/lib/games/bubble-shooter/types.ts
@@ -4,6 +4,7 @@ import type {
     BaseGameConfig,
     BaseGameStats,
 } from '@/lib/games/core/types'
+import type { RowPhase } from './utils'
 
 export interface Bubble {
     color: number
@@ -57,7 +58,7 @@ export interface BubbleShooterState extends BaseGameState {
     aimAngle: number
     projectile: Projectile | null
     bubblesRemaining: number
-    rowOffset: number
+    rowPhase: RowPhase
     shotCount: number
     shotsFired: number
     bubblesPopped: number

--- a/src/lib/games/bubble-shooter/types.ts
+++ b/src/lib/games/bubble-shooter/types.ts
@@ -30,6 +30,13 @@ export interface GridPosition {
     col: number
 }
 
+// Disambiguated outcome of a projectile impact used by attachBubble.
+// 'ceiling' attaches via the global fallback (no anchor); 'bubble' snaps to a
+// neighbor of the collided anchor bubble.
+export type ProjectileImpact =
+    | { kind: 'ceiling' }
+    | { kind: 'bubble'; anchor: GridPosition }
+
 // Stats passed to onGameOver callback
 export interface BubbleShooterEndGameStats {
     bubblesPopped: number

--- a/src/lib/games/bubble-shooter/types.ts
+++ b/src/lib/games/bubble-shooter/types.ts
@@ -31,8 +31,9 @@ export interface GridPosition {
 }
 
 // Disambiguated outcome of a projectile impact used by attachBubble.
-// 'ceiling' attaches via the global fallback (no anchor); 'bubble' snaps to a
-// neighbor of the collided anchor bubble.
+// 'ceiling' means the projectile reached the top wall; it attaches to the
+// nearest unoccupied row-zero cell (no anchor). 'bubble' snaps to a neighbor
+// of the collided anchor bubble.
 export type ProjectileImpact =
     | { kind: 'ceiling' }
     | { kind: 'bubble'; anchor: GridPosition }

--- a/src/lib/games/bubble-shooter/utils.test.ts
+++ b/src/lib/games/bubble-shooter/utils.test.ts
@@ -4,6 +4,8 @@ import {
     getBubbleX,
     getBubbleY,
     getNeighbors,
+    getRowParity,
+    getRowColumnCount,
     drawBubbleOnCanvas,
 } from './utils'
 import type { GameConstants } from './types'
@@ -37,94 +39,37 @@ describe('Bubble Shooter Utils', () => {
         })
     })
 
-    describe('getBubbleX', () => {
-        it('should calculate x position for even row (col=0)', () => {
-            // Even row: offset = 0 * BUBBLE_RADIUS = 0
-            // x = 0 + BUBBLE_RADIUS + 0 * (BUBBLE_RADIUS * 2) = 20
-            expect(getBubbleX(0, 0, constants)).toBe(20)
+    describe('phase-aware hex geometry', () => {
+        it('derives row parity and row width', () => {
+            expect(getRowParity(0, 0)).toBe(0)
+            expect(getRowParity(1, 0)).toBe(1)
+            expect(getRowParity(0, 1)).toBe(1)
+            expect(getRowColumnCount(0, 0, constants)).toBe(14)
+            expect(getRowColumnCount(0, 1, constants)).toBe(13)
         })
 
-        it('should calculate x position for even row (col=1)', () => {
-            // x = 0 + 20 + 1 * 40 = 60
-            expect(getBubbleX(1, 0, constants)).toBe(60)
+        it('centers the full row exactly inside wall bounds', () => {
+            expect(getBubbleX(0, 0, 0, constants)).toBe(40)
+            expect(getBubbleX(13, 0, 0, constants)).toBe(560)
+            expect(getBubbleX(0, 0, 0, constants) - 20).toBe(20)
+            expect(getBubbleX(13, 0, 0, constants) + 20).toBe(580)
         })
 
-        it('should calculate x position for odd row (offset applied)', () => {
-            // Odd row: offset = 1 * BUBBLE_RADIUS = 20
-            // x = 20 + 20 + 0 * 40 = 40
-            expect(getBubbleX(0, 1, constants)).toBe(40)
+        it('uses row-only vertical spacing', () => {
+            expect(getBubbleY(0, constants)).toBe(20)
+            expect(getBubbleY(1, constants)).toBeCloseTo(20 + 20 * Math.sqrt(3))
         })
 
-        it('should calculate x position for odd row col=1', () => {
-            // x = 20 + 20 + 1 * 40 = 80
-            expect(getBubbleX(1, 1, constants)).toBe(80)
-        })
-    })
+        it('keeps each interior neighbor one bubble diameter away', () => {
+            const origin = { row: 5, col: 5 }
+            const originX = getBubbleX(5, 5, 1, constants)
+            const originY = getBubbleY(5, constants)
 
-    describe('getBubbleY', () => {
-        it('should calculate y for row 0 with no offset', () => {
-            // y = BUBBLE_RADIUS + 0 * (BUBBLE_RADIUS * sqrt(3)) + 0
-            expect(getBubbleY(0, 0, constants)).toBe(20)
-        })
-
-        it('should calculate y for row 1 with no offset', () => {
-            const expected = 20 + 1 * (20 * Math.sqrt(3))
-            expect(getBubbleY(1, 0, constants)).toBeCloseTo(expected)
-        })
-
-        it('should include rowOffset in calculation', () => {
-            const withoutOffset = getBubbleY(0, 0, constants)
-            const withOffset = getBubbleY(0, 10, constants)
-            expect(withOffset - withoutOffset).toBe(10)
-        })
-    })
-
-    describe('getNeighbors', () => {
-        it('should return neighbors for even row interior cell', () => {
-            const neighbors = getNeighbors(2, 3, constants)
-            // For even row: offsets are [-1,-1],[-1,0],[0,-1],[0,1],[1,-1],[1,0]
-            expect(neighbors).toContainEqual({ row: 1, col: 2 })
-            expect(neighbors).toContainEqual({ row: 1, col: 3 })
-            expect(neighbors).toContainEqual({ row: 2, col: 2 })
-            expect(neighbors).toContainEqual({ row: 2, col: 4 })
-            expect(neighbors).toContainEqual({ row: 3, col: 2 })
-            expect(neighbors).toContainEqual({ row: 3, col: 3 })
-        })
-
-        it('should return neighbors for odd row interior cell', () => {
-            const neighbors = getNeighbors(3, 3, constants)
-            // For odd row: offsets are [-1,0],[-1,1],[0,-1],[0,1],[1,0],[1,1]
-            expect(neighbors).toContainEqual({ row: 2, col: 3 })
-            expect(neighbors).toContainEqual({ row: 2, col: 4 })
-            expect(neighbors).toContainEqual({ row: 3, col: 2 })
-            expect(neighbors).toContainEqual({ row: 3, col: 4 })
-            expect(neighbors).toContainEqual({ row: 4, col: 3 })
-            expect(neighbors).toContainEqual({ row: 4, col: 4 })
-        })
-
-        it('should filter out out-of-bounds neighbors for top-left corner', () => {
-            const neighbors = getNeighbors(0, 0, constants)
-            // No negative rows or cols
-            expect(neighbors.every(n => n.row >= 0 && n.col >= 0)).toBe(true)
-        })
-
-        it('should filter out neighbors beyond grid boundaries', () => {
-            const neighbors = getNeighbors(0, 0, constants)
-            expect(
-                neighbors.every(
-                    n =>
-                        n.row < constants.GRID_HEIGHT &&
-                        n.col < constants.GRID_WIDTH - (n.row % 2)
-                )
-            ).toBe(true)
-        })
-
-        it('should return fewer neighbors for edge cells', () => {
-            const cornerNeighbors = getNeighbors(0, 0, constants)
-            const interiorNeighbors = getNeighbors(5, 5, constants)
-            expect(cornerNeighbors.length).toBeLessThan(
-                interiorNeighbors.length
-            )
+            for (const neighbor of getNeighbors(5, 5, 1, constants)) {
+                const x = getBubbleX(neighbor.col, neighbor.row, 1, constants)
+                const y = getBubbleY(neighbor.row, constants)
+                expect(Math.hypot(x - originX, y - originY)).toBeCloseTo(40)
+            }
         })
     })
 

--- a/src/lib/games/bubble-shooter/utils.ts
+++ b/src/lib/games/bubble-shooter/utils.ts
@@ -4,55 +4,89 @@ import { pixiColorToHex } from '@/lib/games/shared/types'
 
 export { pixiColorToHex }
 
+/**
+ * Board-wide row parity phase. Flipped every time a row is inserted at the
+ * top, because insertion shifts every row down by one and therefore flips
+ * the parity of every row simultaneously.
+ */
+export type RowPhase = 0 | 1
+
+/** Parity of an individual row given the board-wide phase. 0 = wide, 1 = narrow. */
+export function getRowParity(row: number, rowPhase: RowPhase): RowPhase {
+    return ((row + rowPhase) % 2) as RowPhase
+}
+
+/** Number of columns (dense width) in a row for the current board phase. */
+export function getRowColumnCount(
+    row: number,
+    rowPhase: RowPhase,
+    constants: GameConstants
+): number {
+    return constants.GRID_WIDTH - getRowParity(row, rowPhase)
+}
+
+/**
+ * X coordinate of a bubble center. Full (parity-0) rows are centered exactly
+ * inside the projectile wall bounds; narrow (parity-1) rows are shifted right
+ * by one radius.
+ */
 export function getBubbleX(
     col: number,
     row: number,
+    rowPhase: RowPhase,
     constants: GameConstants
 ): number {
-    const offset = (row % 2) * constants.BUBBLE_RADIUS
+    const diameter = constants.BUBBLE_RADIUS * 2
+    const boardLeft =
+        (constants.GAME_WIDTH - constants.GRID_WIDTH * diameter) / 2
     return (
-        offset + constants.BUBBLE_RADIUS + col * (constants.BUBBLE_RADIUS * 2)
-    )
-}
-
-export function getBubbleY(
-    row: number,
-    rowOffset: number,
-    constants: GameConstants
-): number {
-    return (
+        boardLeft +
         constants.BUBBLE_RADIUS +
-        row * (constants.BUBBLE_RADIUS * Math.sqrt(3)) +
-        rowOffset
+        getRowParity(row, rowPhase) * constants.BUBBLE_RADIUS +
+        col * diameter
     )
 }
 
+/** Y coordinate of a bubble center — depends only on the row. */
+export function getBubbleY(row: number, constants: GameConstants): number {
+    return (
+        constants.BUBBLE_RADIUS + row * constants.BUBBLE_RADIUS * Math.sqrt(3)
+    )
+}
+
+/**
+ * All valid hex neighbors of a cell. Parity is derived from the board-wide
+ * phase (not the row index alone) so the neighbor graph stays consistent
+ * after rows are inserted, and bounds respect the dense row width.
+ */
 export function getNeighbors(
     row: number,
     col: number,
+    rowPhase: RowPhase,
     constants: GameConstants
 ): GridPosition[] {
     const neighbors: GridPosition[] = []
-    const isEvenRow = row % 2 === 0
+    const parity = getRowParity(row, rowPhase)
 
-    // Standard hexagonal grid neighbors
-    const offsets = isEvenRow
-        ? [
-              [-1, -1],
-              [-1, 0],
-              [0, -1],
-              [0, 1],
-              [1, -1],
-              [1, 0],
-          ]
-        : [
-              [-1, 0],
-              [-1, 1],
-              [0, -1],
-              [0, 1],
-              [1, 0],
-              [1, 1],
-          ]
+    // Standard hexagonal grid neighbor offsets, indexed by row parity.
+    const offsets =
+        parity === 0
+            ? ([
+                  [-1, -1],
+                  [-1, 0],
+                  [0, -1],
+                  [0, 1],
+                  [1, -1],
+                  [1, 0],
+              ] as const)
+            : ([
+                  [-1, 0],
+                  [-1, 1],
+                  [0, -1],
+                  [0, 1],
+                  [1, 0],
+                  [1, 1],
+              ] as const)
 
     offsets.forEach(([dRow, dCol]) => {
         const newRow = row + dRow
@@ -61,7 +95,7 @@ export function getNeighbors(
             newRow >= 0 &&
             newRow < constants.GRID_HEIGHT &&
             newCol >= 0 &&
-            newCol < constants.GRID_WIDTH - (newRow % 2)
+            newCol < getRowColumnCount(newRow, rowPhase, constants)
         ) {
             neighbors.push({ row: newRow, col: newCol })
         }

--- a/src/lib/games/core/BaseGame.ts
+++ b/src/lib/games/core/BaseGame.ts
@@ -87,7 +87,10 @@ export abstract class BaseGame<
         }
 
         if (this.state.gameStarted && this.state.isGameOver) {
-            this.reset()
+            // Bypass the public resettable guard: a completed run must be
+            // cleared before the next run starts even when manual reset() is
+            // disabled. reset() still enforces config.resettable for callers.
+            this.resetInternal()
         }
 
         this.runGuard.next()
@@ -207,6 +210,16 @@ export abstract class BaseGame<
             return
         }
 
+        this.resetInternal()
+    }
+
+    /**
+     * Internal reset sequence shared by reset() and the completed-run branch
+     * of start(). Does NOT enforce config.resettable — callers are responsible
+     * for the guard (reset() checks it; start() bypasses it intentionally so a
+     * completed run is always cleared before the next one).
+     */
+    private resetInternal(): void {
         this.runGuard.next()
         this.timer.reset()
         this.scoreManager.reset()

--- a/src/lib/games/core/BaseGame.ts
+++ b/src/lib/games/core/BaseGame.ts
@@ -70,6 +70,9 @@ export abstract class BaseGame<
      * Abstract methods that each game must implement
      */
     abstract createInitialState(): TState
+    /**
+     * Advance game logic by elapsed time in seconds.
+     */
     abstract update(deltaTime: number): void
     abstract render(): void
     abstract getGameStats(): TStats
@@ -81,6 +84,10 @@ export abstract class BaseGame<
     start(): void {
         if (this.state.isActive) {
             return
+        }
+
+        if (this.state.gameStarted && this.state.isGameOver) {
+            this.reset()
         }
 
         this.runGuard.next()

--- a/src/lib/games/core/GameTimer.ts
+++ b/src/lib/games/core/GameTimer.ts
@@ -99,10 +99,22 @@ export class GameTimer extends GameEventEmitter {
     }
 
     /**
-     * Reset the timer
+     * Reset the timer to its initial state without emitting an end event.
+     *
+     * Reset is not completion, so it must stay silent with respect to end.
+     * BaseGame forwards timer end as a game-level end; emitting here would
+     * leak an extra empty end event when a completed run is cleared before
+     * the next start (and when manual reset() runs during a save). Call
+     * stop() explicitly when a genuine end signal is required.
      */
     reset(): void {
-        this.stop()
+        if (this.intervalId !== null) {
+            clearInterval(this.intervalId)
+            this.intervalId = null
+        }
+
+        this.isRunning = false
+        this.isPaused = false
         this.startTime = 0
         this.pausedTime = 0
         this.totalPausedDuration = 0

--- a/src/lib/games/core/core.test.ts
+++ b/src/lib/games/core/core.test.ts
@@ -791,6 +791,43 @@ describe('BaseGame default hooks', () => {
 
         expect(resetSpy).not.toHaveBeenCalled()
     })
+
+    it('restarts from game over with fresh state even when resettable is false', async () => {
+        const game = new MinimalGame(
+            GameID.QUICK_MATH,
+            {
+                duration: 60,
+                achievementIntegration: false,
+                pausable: true,
+                resettable: false,
+            },
+            {}
+        )
+
+        game.start()
+        game.addScore(75, 'first-run')
+        expect(game.getState().score).toBe(75)
+
+        await game.end()
+        expect(game.getState().isGameOver).toBe(true)
+
+        // Manual reset() is blocked by the resettable guard...
+        game.reset()
+        expect(game.getScoreManager().getScore()).toBe(75)
+
+        // ...but start() must still clear the completed run so the next run
+        // does not inherit stale score/state.
+        game.start()
+
+        expect(game.getState()).toMatchObject({
+            score: 0,
+            isActive: true,
+            isGameOver: false,
+            gameStarted: true,
+        })
+        expect(game.getScoreManager().getScore()).toBe(0)
+        game.destroy()
+    })
 })
 
 describe('BaseGame stale-run guard', () => {

--- a/src/lib/games/core/core.test.ts
+++ b/src/lib/games/core/core.test.ts
@@ -742,6 +742,55 @@ describe('BaseGame default hooks', () => {
         expect(startListener.mock.calls.length).toBe(countAfterFirstStart)
         game.destroy()
     })
+
+    it('resets state and score before starting after game over', async () => {
+        const game = new MinimalGame(
+            GameID.QUICK_MATH,
+            {
+                duration: 60,
+                achievementIntegration: false,
+                pausable: true,
+                resettable: true,
+            },
+            {}
+        )
+
+        game.start()
+        game.addScore(75, 'first-run')
+        expect(game.getState().score).toBe(75)
+
+        await game.end()
+        expect(game.getState().isGameOver).toBe(true)
+
+        game.start()
+
+        expect(game.getState()).toMatchObject({
+            score: 0,
+            isActive: true,
+            isGameOver: false,
+            gameStarted: true,
+        })
+        expect(game.getScoreManager().getScore()).toBe(0)
+    })
+
+    it('does not reset when start is called while already active', () => {
+        const game = new MinimalGame(
+            GameID.QUICK_MATH,
+            {
+                duration: 60,
+                achievementIntegration: false,
+                pausable: true,
+                resettable: true,
+            },
+            {}
+        )
+        const resetSpy = vi.spyOn(game, 'reset')
+
+        game.start()
+        game.start()
+
+        expect(resetSpy).not.toHaveBeenCalled()
+    })
 })
 
 describe('BaseGame stale-run guard', () => {

--- a/src/lib/games/core/core.test.ts
+++ b/src/lib/games/core/core.test.ts
@@ -1089,10 +1089,10 @@ describe('BaseGame stale-run guard', () => {
             },
             {}
         )
-        const endEvents: Array<{ data: unknown }> = []
-        const startEvents: Array<{ data: unknown }> = []
-        game.on('end', e => endEvents.push(e as any))
-        game.on('start', e => startEvents.push(e as any))
+        const endEvents: unknown[] = []
+        const startEvents: unknown[] = []
+        game.on('end', e => endEvents.push(e))
+        game.on('start', e => startEvents.push(e))
 
         game.start()
         const startsPerStart = startEvents.length

--- a/src/lib/games/core/core.test.ts
+++ b/src/lib/games/core/core.test.ts
@@ -1049,6 +1049,68 @@ describe('BaseGame stale-run guard', () => {
         vi.unstubAllGlobals()
     })
 
+    it('does not emit an extra end event when restarting a completed run', async () => {
+        // Regression: previously start() on a completed run called
+        // resetInternal() -> timer.reset() -> timer.stop(), whose
+        // unconditional emit('end') was forwarded as a game-level end with
+        // an empty payload, firing before the new run's start event.
+        const fetchMock = vi.fn().mockResolvedValue({
+            ok: true,
+            json: () => Promise.resolve({ newAchievements: [] }),
+        })
+        vi.stubGlobal('fetch', fetchMock)
+
+        class MiniGame extends BaseGame {
+            createInitialState() {
+                return {
+                    score: 0,
+                    timeRemaining: 60,
+                    isActive: false,
+                    isPaused: false,
+                    isGameOver: false,
+                    gameStarted: false,
+                }
+            }
+            update() {}
+            render() {}
+            cleanup() {}
+            getGameStats() {
+                return { finalScore: 0, timeElapsed: 0, gameCompleted: false }
+            }
+        }
+
+        const game = new MiniGame(
+            GameID.QUICK_MATH,
+            {
+                duration: 60,
+                achievementIntegration: false,
+                pausable: false,
+                resettable: false,
+            },
+            {}
+        )
+        const endEvents: Array<{ data: unknown }> = []
+        const startEvents: Array<{ data: unknown }> = []
+        game.on('end', e => endEvents.push(e as any))
+        game.on('start', e => startEvents.push(e as any))
+
+        game.start()
+        const startsPerStart = startEvents.length
+        await game.end()
+        const endCountAfterFirstRun = endEvents.length
+
+        // Restart the completed run — must not emit an extra end. The
+        // restart should emit the same start events as a normal start and
+        // zero end events.
+        game.start()
+
+        expect(endEvents.length).toBe(endCountAfterFirstRun)
+        expect(startEvents.length).toBe(startsPerStart * 2)
+
+        game.destroy()
+        vi.unstubAllGlobals()
+    })
+
     it('invokes onEnd callback and onGameEnd hook when the run is not stale', async () => {
         const fetchMock = vi.fn().mockResolvedValue({
             ok: true,

--- a/src/pages/bubble-shooter/index.astro
+++ b/src/pages/bubble-shooter/index.astro
@@ -3,6 +3,8 @@ import GamePage from '@/components/games/GamePage.astro'
 import Card from '@/components/ui/Card.astro'
 import Badge from '@/components/ui/Badge.astro'
 import Button from '@/components/ui/Button.astro'
+import { DEFAULT_BUBBLE_SHOOTER_CONFIG } from '@/lib/games/bubble-shooter/BubbleShooterGame'
+const rowAddInterval = DEFAULT_BUBBLE_SHOOTER_CONFIG.rowAddInterval
 ---
 
 <GamePage
@@ -109,10 +111,10 @@ import Button from '@/components/ui/Button.astro'
       </h3>
       <div class="space-y-2 text-sm text-cetus-ink">
         <p>• Match 3+ bubbles of the same color</p>
-        <p>• Bubbles must be connected to pop</p>
-        <p>• New row appears after each shot</p>
-        <p>• Game ends when bubbles reach bottom</p>
-        <p>• Higher combos = more points</p>
+        <p>• Disconnected bubbles fall after a match</p>
+        <p>• New row appears every {rowAddInterval} shots</p>
+        <p>• Game ends when bubbles reach the danger zone</p>
+        <p>• Accuracy counts shots that clear bubbles</p>
       </div>
     </Card>
   </div>

--- a/src/pages/game-board-markup.test.ts
+++ b/src/pages/game-board-markup.test.ts
@@ -14,6 +14,10 @@ const circuitHackerMarkup = readFileSync(
     resolve(process.cwd(), 'src/pages/circuit-hacker/index.astro'),
     'utf-8'
 )
+const bubbleShooterMarkup = readFileSync(
+    resolve(process.cwd(), 'src/pages/bubble-shooter/index.astro'),
+    'utf-8'
+)
 
 const games = [
     'tetris',
@@ -42,6 +46,20 @@ describe('Game board page markup', () => {
     it('exposes the Circuit Hacker canvas container and difficulty select', () => {
         expect(circuitHackerMarkup).toContain('id="game-canvas-container"')
         expect(circuitHackerMarkup).toContain('id="difficulty-select"')
+    })
+})
+
+describe('Bubble Shooter rules copy', () => {
+    it('sources rowAddInterval from config and reflects Tasks 4-6 mechanics', () => {
+        expect(bubbleShooterMarkup).toContain(
+            'DEFAULT_BUBBLE_SHOOTER_CONFIG.rowAddInterval'
+        )
+        expect(bubbleShooterMarkup).toContain(
+            'Disconnected bubbles fall after a match'
+        )
+        expect(bubbleShooterMarkup).not.toContain(
+            'New row appears after each shot'
+        )
     })
 })
 


### PR DESCRIPTION
## Summary

Implements the full Bubble Shooter mechanics correction defined in the design spec and TDD plan from the closed design PR #57. Seven focused commits, each task-scoped and review-gated:

- **`BaseGame.start()` resets completed runs** before starting the next one, and `update(deltaTime)` is documented as elapsed **seconds**. Removes the per-game initializer workaround.
- **Phase-aware hex geometry** (`rowPhase`) with dense rows centered inside the projectile wall bounds. `rowOffset` removed entirely.
- **Delta-time projectile physics** (720 px/s default, internal 0.05s clamp, `radius/2` collision substeps, bubble-before-ceiling priority, wall-overshoot mirror, RAF ms→s). Frame-rate independent; no tunneling at 4000 px/s.
- **Impact-local attachment** (neighbors for bubble impact, row-0 for ceiling); no global/fixed fallback; a locally blocked impact consumes the shot but only the danger zone ends the run.
- **Ceiling-connectivity cluster drops** — when a direct match removes supporting bubbles, disconnected clusters fall. `removeUnsupportedBubbles` returns positions without syncing counts; callers call `syncBubbleCount()`.
- **Active board colors** drive generation + next-bubble reconciliation; accuracy is now `successfulShots / shotsFired` (shots that clear bubbles), capped structurally at 100%.
- **Null-safe preview canvases** clear on null; rules copy is sourced from `DEFAULT_BUBBLE_SHOOTER_CONFIG.rowAddInterval`.

## Root cause

The rendered board and logical hex graph diverged after row insertion because row parity changed without a corresponding geometry model. Frame-count projectile motion and global attachment fallbacks amplified that mismatch, and `BaseGame.start()` started an ended run without resetting its state/`ScoreManager`.

## Tracking

- Linear: [HPA-121](https://linear.app/cwchanap/issue/HPA-121/fix-bubble-shooter-hex-grid-geometry-and-projectile-mechanics)
- Design/plan: closed PR #57 → `docs/superpowers/specs/2026-08-10-bubble-shooter-mechanics-correction-design.md`, `docs/superpowers/plans/2026-08-10-bubble-shooter-mechanics-correction.md`

## Score compatibility note

Bubble Shooter now awards points for dropped unsupported bubbles and reports successful-shot accuracy, so historical and new leaderboard rows may represent different scoring/stat semantics. No score migration or versioning is included.

## Validation

- [x] focused core/Bubble Shooter tests (204/204)
- [x] full unit suite (2755/2755)
- [x] lint (0 errors) and formatting check
- [x] production build
- [ ] typecheck (green for this PR; 2 **pre-existing** errors in `src/lib/games/ice-slide/` exist on `main` and are unrelated to this change)
- [ ] game happy-path E2E (could not run in the dev worktree — no `.env`/database; should be re-run post-merge in a configured environment)

`BubbleShooterRenderer.ts` (renderer source) is intentionally unchanged.

<!-- This is an auto-generated comment: release notes by coderabbit.ai -->
## Summary by CodeRabbit

* **New Features**
  * Improved Bubble Shooter grid positioning, collision handling, and bubble attachment.
  * Unsupported bubbles now drop after matches, with scoring based on all removed bubbles.
  * Projectile movement is smoother and more accurate across frame rates.
  * Next-bubble colors remain playable, and previews clear correctly.
  * Accuracy now reflects shots that successfully remove bubbles.
  * Restarting a completed game now resets it for a fresh run.

* **Documentation**
  * Updated gameplay rules to clarify falling bubbles, row timing, danger zones, and accuracy.
<!-- end of auto-generated comment: release notes by coderabbit.ai -->