### PR TITLE
ci: require 95% Codecov coverage

### DIFF
--- a/codecov.yml
+++ b/codecov.yml
@@ -1,0 +1,12 @@
+coverage:
+  status:
+    project:
+      default:
+        target: 95%
+        threshold: 0%
+        informational: false
+    patch:
+      default:
+        target: 95%
+        threshold: 0%
+        informational: false

--- a/codecov.yml
+++ b/codecov.yml
@@ -5,8 +5,10 @@ coverage:
         target: 95%
         threshold: 0%
         informational: false
+        if_not_found: failure
     patch:
       default:
         target: 95%
         threshold: 0%
         informational: false
+        if_not_found: failure


### PR DESCRIPTION
## Summary

Require Codecov project and patch coverage to be at least 95%, with zero threshold leniency and blocking statuses.

## Validation

- adds only root `codecov.yml`
- no test/build/upload workflow commands changed
