### PR TITLE
docs(ice-slide): design and plan Daily Challenge MVP (HPA-487)

### DIFF
--- a/docs/superpowers/plans/2026-08-12-ice-slide-daily-challenge.md
+++ b/docs/superpowers/plans/2026-08-12-ice-slide-daily-challenge.md
@@ -1,0 +1,1074 @@
+# Ice Slide Daily Challenge MVP Implementation Plan
+
+> **For agentic workers:** REQUIRED SUB-SKILL: Use superpowers:subagent-driven-development (recommended) or superpowers:executing-plans to implement this plan task-by-task. Steps use checkbox (`- [ ]`) syntax for tracking.
+
+**Goal:** Ship HPA-487 by adding a deterministic five-stage Ice Slide Daily mode with seeded objectives/stars, Daily scoring, mode/retry UX, and completed-run contextual submission while preserving Campaign behavior.
+
+**Architecture:** Materialize a complete Daily `IceSlideRunDefinition` from an explicit UTC date before gameplay starts. Keep generation, objectives, and scoring pure; extend `IceSlideGame` only with active-stage attempt facts and Daily score/star application; keep clock capture, exact retry identity, overlays, input gating, and submission ownership in `init.ts`/the page.
+
+**Tech Stack:** Astro 5, TypeScript 6, PixiJS 8, Vitest 3, Playwright, Better Auth client, existing Cetus seeded RNG/run/solver/quality infrastructure.
+
+## Global Constraints
+
+- Campaign remains the default mode and keeps existing scoring, achievements, unscoped submissions, and partial-End submission behavior.
+- Daily is the only additional selectable mode; do not expose Expedition.
+- Daily run identity is UTC-based and versioned exactly as specified by the parent replayability design.
+- `IceSlideGame` must not read the clock or make random choices.
+- Daily generation must not use `Math.random()` or `crypto.getRandomValues()`.
+- `Play Again` retries the exact previously materialized Daily run; a fresh Daily Start captures the current UTC date.
+- Daily has exactly five stages, unique source templates, unique final canonical boards, and one feasible seeded bonus objective per stage.
+- Daily partial End never submits. Only a fully completed Daily run may attempt contextual submission.
+- HPA-488 owns server-side Daily semantic admission and leaderboard UI/query work; do not implement it here.
+- No mutation templates, Expedition, snow, cracked ice, abilities, new persistence layer, mode registry, generic generator framework, or shared overlay abstraction.
+- Stage-clear feedback uses an explicit Continue button; no auto-dismiss timer or forced reduced-motion delay.
+- New/changed code must satisfy the repository's current lint, format, test, build, and 95% coverage gates.
+
+---
+
+## File Structure
+
+### New files
+
+- `src/lib/games/ice-slide/daily.ts` — UTC-keyed deterministic Daily run materialization.
+- `src/lib/games/ice-slide/daily.test.ts` — Daily identity, selection, transforms, quality, determinism tests.
+- `src/lib/games/ice-slide/objectives.ts` — pure objective completion rules and labels.
+- `src/lib/games/ice-slide/objectives.test.ts` — objective-rule tests.
+- `src/lib/games/ice-slide/scoring.test.ts` — Campaign regression plus Daily scoring tests.
+
+### Existing files to modify
+
+- `src/lib/games/ice-slide/types.ts` — active-stage facts, stage-clear payload, playable-mode type.
+- `src/lib/games/ice-slide/run.ts` — export the existing Campaign difficulty mapping for Daily reuse.
+- `src/lib/games/ice-slide/scoring.ts` — additive Daily score functions; Campaign functions unchanged.
+- `src/lib/games/ice-slide/test-fixtures.ts` — valid Daily test-run helper.
+- `src/lib/games/ice-slide/game.ts` — reset/fall counters, Daily stars/scoring, richer clear callback.
+- `src/lib/games/ice-slide/game.test.ts` — Daily runtime/star/scoring tests and callback migration.
+- `src/lib/games/ice-slide/game.hazard.test.ts` — exact hazard counter regression.
+- `src/lib/games/ice-slide/init.ts` — mode-specific fresh/retry lifecycle, input gate, stage-result UI, scoped Daily submission.
+- `src/lib/games/ice-slide/init.test.ts` — lifecycle/rollover/submission/overlay/anonymous tests.
+- `src/pages/ice-slide/index.astro` — selector, Daily HUD, stage-clear markup, Change Mode flow.
+- `src/pages/game-board-markup.test.ts` — Ice Slide markup contract.
+- `e2e/games/play-coverage.spec.ts` — preserve Campaign smoke and add focused Daily/query smoke.
+
+---
+
+### Task 1: Materialize deterministic five-stage Daily runs
+
+**Files:**
+- Create: `src/lib/games/ice-slide/daily.ts`
+- Create: `src/lib/games/ice-slide/daily.test.ts`
+- Modify: `src/lib/games/ice-slide/run.ts`
+
+**Interfaces:**
+- Consumes: `ICE_SLIDE_LEVELS`, `ICE_SLIDE_RULESET_VERSION`, `createIceSlideStageSignature()`, `assertValidIceSlideRunDefinition()`, `createSeededRng()`, `getUniqueBoardTransforms()`, `validateIceSlideStageQuality()`.
+- Produces:
+
+```ts
+export const ICE_SLIDE_DAILY_GENERATOR_VERSION = 1
+export const ICE_SLIDE_DAILY_SOLVER_MAX_STATES = 10_000
+export const ICE_SLIDE_DAILY_STAGE_POOLS: readonly (readonly number[])[]
+
+export function toIceSlideUtcDateKey(date: Date): string
+export function createIceSlideDailyRunDefinition(
+  dateKey: string
+): IceSlideRunDefinition
+```
+
+- Also export the already-existing Campaign level difficulty mapping from `run.ts` as:
+
+```ts
+export const CAMPAIGN_STAGE_DIFFICULTIES: readonly IceSlideDifficulty[]
+```
+
+- [ ] **Step 1: Write failing deterministic-run tests**
+
+Create `daily.test.ts` with tests that lock identity and invariants without hard-coding random internal call counts:
+
+```ts
+import { describe, expect, it } from 'vitest'
+import { serializeBoardRows } from './transforms'
+import { assertValidIceSlideRunDefinition } from './run'
+import {
+  createIceSlideDailyRunDefinition,
+  toIceSlideUtcDateKey,
+} from './daily'
+
+describe('Ice Slide Daily materialization', () => {
+  it('formats UTC date keys and rejects invalid dates', () => {
+    expect(toIceSlideUtcDateKey(new Date('2026-08-12T23:59:59Z'))).toBe(
+      '2026-08-12'
+    )
+    expect(() => toIceSlideUtcDateKey(new Date(Number.NaN))).toThrow(RangeError)
+  })
+
+  it('builds the exact versioned Daily identity', () => {
+    const run = createIceSlideDailyRunDefinition('2026-08-12')
+    expect(run).toMatchObject({
+      schemaVersion: 1,
+      generatorVersion: 1,
+      rulesetVersion: 1,
+      mode: 'daily',
+      seed: 'ice-slide:daily:1:1:2026-08-12',
+      runKey: 'ice-slide:daily:2026-08-12:g1:r1',
+    })
+    expect(run.stages).toHaveLength(5)
+    expect(() => assertValidIceSlideRunDefinition(run)).not.toThrow()
+  })
+
+  it('is byte-equivalent for the same date and versions', () => {
+    const first = createIceSlideDailyRunDefinition('2026-08-12')
+    const second = createIceSlideDailyRunDefinition('2026-08-12')
+    expect(JSON.stringify(second)).toBe(JSON.stringify(first))
+  })
+
+  it('never repeats a source template or final canonical board', () => {
+    const run = createIceSlideDailyRunDefinition('2026-08-12')
+    expect(new Set(run.stages.map(stage => stage.templateId)).size).toBe(5)
+    expect(
+      new Set(run.stages.map(stage => serializeBoardRows(stage.rows))).size
+    ).toBe(5)
+  })
+
+  it('assigns exactly one feasible bonus objective and recomputed par', () => {
+    const run = createIceSlideDailyRunDefinition('2026-08-12')
+    for (const stage of run.stages) {
+      expect(stage.objectiveIds).toHaveLength(1)
+      expect(stage.scoreMultiplierBps).toBe(10_000)
+      expect(stage.mutationIds).toEqual([])
+      expect(stage.parMoves).toBeGreaterThan(0)
+    }
+  })
+
+  it('varies deterministically across representative dates', () => {
+    const signatures = ['2026-08-12', '2026-08-13', '2026-09-01'].map(date =>
+      createIceSlideDailyRunDefinition(date).stages.map(stage => stage.signature)
+    )
+    expect(new Set(signatures.map(value => value.join(','))).size).toBeGreaterThan(1)
+  })
+})
+```
+
+Add a table test proving each stage's template ID is inside its exact required pool and all five source template IDs are unique.
+
+- [ ] **Step 2: Run the new test and verify it fails**
+
+Run:
+
+```bash
+bun run test:run -- src/lib/games/ice-slide/daily.test.ts
+```
+
+Expected: FAIL because `daily.ts`/exports do not exist yet.
+
+- [ ] **Step 3: Export Campaign difficulty metadata instead of duplicating it**
+
+In `run.ts`, rename the private constant and reuse the exported name inside `createCampaignRunDefinition()`:
+
+```ts
+export const CAMPAIGN_STAGE_DIFFICULTIES: readonly IceSlideDifficulty[] = [
+  'tutorial',
+  'easy',
+  'easy',
+  'medium',
+  'medium',
+  'medium',
+  'hard',
+  'hard',
+]
+```
+
+Keep the existing length assertion and Campaign stage output unchanged.
+
+- [ ] **Step 4: Implement the minimal pure Daily materializer**
+
+Use the exact pools:
+
+```ts
+export const ICE_SLIDE_DAILY_STAGE_POOLS = [
+  [1, 2],
+  [2, 3],
+  [3, 4, 5],
+  [5, 6, 7],
+  [7, 8],
+] as const
+```
+
+Implement strict date parsing by requiring `YYYY-MM-DD`, constructing UTC midnight, and round-tripping year/month/day. Do not rely on permissive `Date.parse()` alone.
+
+The stage loop must use these exact labeled streams:
+
+```ts
+const stageRng = rootRng.fork(`stage:${stageNumber}`)
+const templateOrder = stageRng.fork('template').shuffle(pool)
+const variantOrder = stageRng
+  .fork(`transform:${source.id}`)
+  .shuffle(getUniqueBoardTransforms(source.rows))
+```
+
+For each candidate variant, validate it with:
+
+```ts
+const quality = validateIceSlideStageQuality(
+  { id: `daily:${dateKey}:${stageNumber}`, rows: variant.rows, objectiveIds: [] },
+  {
+    parBand: { minMoves: source.parMoves, maxMoves: source.parMoves },
+    maxStates: ICE_SLIDE_DAILY_SOLVER_MAX_STATES,
+    existingCanonicalKeys: usedCanonicalKeys,
+  }
+)
+```
+
+On the first accepted candidate:
+
+```ts
+const eligibleObjectives = DAILY_BONUS_OBJECTIVE_ORDER.filter(
+  objectiveId => quality.objectiveFeasibility[objectiveId]
+)
+const bonusObjective = stageRng.fork('objective').pick(eligibleObjectives)
+```
+
+Create the final stage, compute its signature, add template/canonical identities to their used sets, and break. Throw a descriptive `Error` if the finite authored candidate set produces no accepted candidate.
+
+Finish by validating the full run with `assertValidIceSlideRunDefinition(run)` before returning it.
+
+- [ ] **Step 5: Run Daily + prerequisite deterministic tests**
+
+Run:
+
+```bash
+bun run test:run -- \
+  src/lib/games/ice-slide/daily.test.ts \
+  src/lib/games/ice-slide/run.test.ts \
+  src/lib/games/ice-slide/transforms.test.ts \
+  src/lib/games/ice-slide/quality.test.ts \
+  src/lib/games/ice-slide/solver.test.ts \
+  src/lib/games/shared/seeded-rng.test.ts
+```
+
+Expected: PASS.
+
+- [ ] **Step 6: Commit**
+
+```bash
+git add \
+  src/lib/games/ice-slide/daily.ts \
+  src/lib/games/ice-slide/daily.test.ts \
+  src/lib/games/ice-slide/run.ts
+git commit -m "feat(ice-slide): materialize deterministic daily runs"
+```
+
+---
+
+### Task 2: Add pure objective/star rules and Daily scoring
+
+**Files:**
+- Create: `src/lib/games/ice-slide/objectives.ts`
+- Create: `src/lib/games/ice-slide/objectives.test.ts`
+- Create: `src/lib/games/ice-slide/scoring.test.ts`
+- Modify: `src/lib/games/ice-slide/scoring.ts`
+- Modify: `src/lib/games/ice-slide/types.ts`
+
+**Interfaces:**
+- Produces:
+
+```ts
+export type IceSlidePlayableMode = 'campaign' | 'daily'
+
+export interface IceSlideObjectiveFacts {
+  parMoves: number
+  movesUsed: number
+  crystalsCollected: number
+  totalCrystals: number
+  falls: number
+  resets: number
+}
+
+export function isIceSlideObjectiveComplete(
+  objectiveId: IceSlideObjectiveId,
+  facts: IceSlideObjectiveFacts
+): boolean
+
+export const ICE_SLIDE_OBJECTIVE_LABELS: Record<IceSlideObjectiveId, string>
+
+export interface IceSlideStageClearResult {
+  stageNumber: number
+  stageName: string
+  parMoves: number
+  movesUsed: number
+  crystalsCollected: number
+  scoreGained: number
+  stars: {
+    clear: boolean
+    efficient: boolean
+    bonus: { id: IceSlideObjectiveId; earned: boolean } | null
+    earnedCount: number
+  }
+}
+```
+
+- Add active-stage state fields:
+
+```ts
+parMoves: number
+objectiveIds: IceSlideObjectiveId[]
+levelFalls: number
+levelResets: number
+```
+
+- Change `IceSlideCallbacks.onLevelClear` to `(result: IceSlideStageClearResult) => void`.
+- Produces scoring helpers:
+
+```ts
+export function dailyStageScore(params: {
+  stageNumber: number
+  parMoves: number
+  movesUsed: number
+  crystalsCollected: number
+  optionalStarsEarned: number
+}): number
+
+export function dailyTimeBonus(elapsedSeconds: number): number
+```
+
+- [ ] **Step 1: Write failing objective tests**
+
+Cover every rule directly:
+
+```ts
+it('requires all crystals for collect_all_crystals', () => {
+  expect(isIceSlideObjectiveComplete('collect_all_crystals', {
+    parMoves: 4,
+    movesUsed: 4,
+    crystalsCollected: 2,
+    totalCrystals: 2,
+    falls: 0,
+    resets: 0,
+  })).toBe(true)
+
+  expect(isIceSlideObjectiveComplete('collect_all_crystals', {
+    parMoves: 4,
+    movesUsed: 4,
+    crystalsCollected: 1,
+    totalCrystals: 2,
+    falls: 0,
+    resets: 0,
+  })).toBe(false)
+})
+
+it('requires no falls for no_falls', () => {
+  expect(base({ falls: 0 }, 'no_falls')).toBe(true)
+  expect(base({ falls: 1 }, 'no_falls')).toBe(false)
+})
+
+it('requires no manual or hazard reset for no_reset', () => {
+  expect(base({ resets: 0 }, 'no_reset')).toBe(true)
+  expect(base({ resets: 1 }, 'no_reset')).toBe(false)
+})
+```
+
+Also assert `collect_all_crystals` is false when `totalCrystals === 0`; the generator should not assign it in that case, but runtime policy remains explicit.
+
+- [ ] **Step 2: Write failing Daily scoring tests**
+
+Lock exact boundaries:
+
+```ts
+expect(dailyStageScore({
+  stageNumber: 2,
+  parMoves: 4,
+  movesUsed: 4,
+  crystalsCollected: 1,
+  optionalStarsEarned: 2,
+})).toBe(400 + 25 + 50 + 200)
+
+expect(dailyTimeBonus(0)).toBe(1500)
+expect(dailyTimeBonus(299)).toBe(5)
+expect(dailyTimeBonus(300)).toBe(0)
+expect(dailyTimeBonus(301)).toBe(0)
+```
+
+Copy the current Campaign expectations into this test file for `levelScore()`/`timeBonus()` so additive Daily work cannot silently alter the 360-second Campaign contract.
+
+- [ ] **Step 3: Run tests to verify failure**
+
+```bash
+bun run test:run -- \
+  src/lib/games/ice-slide/objectives.test.ts \
+  src/lib/games/ice-slide/scoring.test.ts
+```
+
+Expected: FAIL because the new interfaces/functions do not exist.
+
+- [ ] **Step 4: Implement objective rules and labels**
+
+Keep `objectives.ts` free of DOM/Pixi/game state. Implement with a switch over the existing objective union:
+
+```ts
+case 'collect_all_crystals':
+  return facts.totalCrystals > 0 &&
+    facts.crystalsCollected === facts.totalCrystals
+case 'no_falls':
+  return facts.falls === 0
+case 'no_reset':
+  return facts.resets === 0
+```
+
+Use concise display labels such as `Collect all crystals`, `No falls`, and `No resets` from the exported record instead of duplicating copy in `init.ts`/Astro.
+
+- [ ] **Step 5: Add Daily scoring without changing Campaign functions**
+
+Add:
+
+```ts
+export const DAILY_SCORING_CONFIG = {
+  objectiveStarBonus: 100,
+  timeBudgetSeconds: 300,
+  timeBonusPerSec: 5,
+} as const
+```
+
+Validate `optionalStarsEarned` as a simple numeric input from game policy and compute:
+
+```ts
+return (
+  levelClearPoints(params.stageNumber) +
+  moveBonus(params.parMoves, params.movesUsed) +
+  crystalBonus(params.crystalsCollected) +
+  params.optionalStarsEarned * DAILY_SCORING_CONFIG.objectiveStarBonus
+)
+```
+
+`dailyTimeBonus()` mirrors the existing `timeBonus()` shape with the 300-second budget.
+
+- [ ] **Step 6: Extend local Ice Slide types**
+
+Add the four active-stage fields and clear-result/playable-mode types. Change only Ice Slide's local callback payload. Do not modify shared platform game types or introduce a generic stage-result abstraction.
+
+- [ ] **Step 7: Run tests and type-focused suite**
+
+```bash
+bun run test:run -- \
+  src/lib/games/ice-slide/objectives.test.ts \
+  src/lib/games/ice-slide/scoring.test.ts \
+  src/lib/games/ice-slide/daily.test.ts
+```
+
+Expected: PASS.
+
+- [ ] **Step 8: Commit**
+
+```bash
+git add \
+  src/lib/games/ice-slide/types.ts \
+  src/lib/games/ice-slide/objectives.ts \
+  src/lib/games/ice-slide/objectives.test.ts \
+  src/lib/games/ice-slide/scoring.ts \
+  src/lib/games/ice-slide/scoring.test.ts
+git commit -m "feat(ice-slide): add daily objectives and scoring"
+```
+
+---
+
+### Task 3: Track stage attempts and apply Daily stars/scoring in `IceSlideGame`
+
+**Files:**
+- Modify: `src/lib/games/ice-slide/test-fixtures.ts`
+- Modify: `src/lib/games/ice-slide/game.ts`
+- Modify: `src/lib/games/ice-slide/game.test.ts`
+- Modify: `src/lib/games/ice-slide/game.hazard.test.ts`
+- Update any Ice Slide tests that compile against the old numeric `onLevelClear` callback.
+
+**Interfaces:**
+- Consumes: `dailyStageScore()`, `dailyTimeBonus()`, `isIceSlideObjectiveComplete()`, `IceSlideStageClearResult`.
+- Produces: exact run/stage counters and clear-result payload for `init.ts`.
+
+- [ ] **Step 1: Add a valid Daily test-run fixture**
+
+In `test-fixtures.ts`, add a helper that derives valid key/seed/version metadata from `dateKey` and calls `createIceSlideStageSignature()` for every override stage. Default it to five one-move stages so Daily completion tests remain short.
+
+```ts
+export function createTestDailyRun(
+  stages: IceSlideStageDefinition[] = fiveSimpleStages(),
+  dateKey = '2026-08-12'
+): IceSlideRunDefinition
+```
+
+Use `ICE_SLIDE_DAILY_GENERATOR_VERSION` and `ICE_SLIDE_RULESET_VERSION`; do not hand-copy version numbers.
+
+- [ ] **Step 2: Write failing counter tests**
+
+Add tests proving:
+
+```ts
+// manual Reset
+expect(after.resets).toBe(before.resets + 1)
+expect(after.levelResets).toBe(1)
+expect(after.levelFalls).toBe(0)
+expect(after.levelMoves).toBe(0)
+
+// hazard entry
+expect(after.falls).toBe(before.falls + 1)
+expect(after.resets).toBe(before.resets + 1)
+expect(after.levelFalls).toBe(1)
+expect(after.levelResets).toBe(1)
+expect(after.levelMoves).toBe(1)
+```
+
+Then clear/advance a test stage and assert `levelFalls`/`levelResets` reset to zero on the next stage while cumulative `falls`/`resets` remain.
+
+- [ ] **Step 3: Write failing Daily clear-result/star tests**
+
+Use small explicit Daily stages to exercise each outcome:
+
+- exact-par + no reset => Clear/Efficient/bonus all earned, `earnedCount === 3`;
+- over-par => Efficient false;
+- manual reset before clear => `no_reset` false;
+- hazard before a later clear => `no_falls` false;
+- collect all vs not all crystals;
+- cumulative `state.starsEarned` equals the sum of Daily stage results.
+
+Assert the callback payload shape, including `scoreGained`, rather than reading private state.
+
+- [ ] **Step 4: Write failing Daily completion-bonus and Campaign regression tests**
+
+With fake timers, complete a five-stage Daily test run and verify the final score adds `dailyTimeBonus(elapsedSeconds)`. Separately retain existing Campaign assertions and add:
+
+```ts
+expect(game.getState().starsEarned).toBe(0)
+```
+
+for Campaign clears.
+
+- [ ] **Step 5: Run focused tests to verify failure**
+
+```bash
+bun run test:run -- \
+  src/lib/games/ice-slide/game.test.ts \
+  src/lib/games/ice-slide/game.hazard.test.ts
+```
+
+Expected: FAIL on missing counters/result behavior.
+
+- [ ] **Step 6: Populate active-stage metadata in `createIdleState()`/`loadLevel()`**
+
+Idle values:
+
+```ts
+parMoves: 0,
+objectiveIds: [],
+levelFalls: 0,
+levelResets: 0,
+```
+
+Loaded values come from the materialized stage:
+
+```ts
+parMoves: stage.parMoves,
+objectiveIds: [...stage.objectiveIds],
+```
+
+`getState()` must clone `objectiveIds`.
+
+Add one `preserveLevelAttemptStats` load option. Manual Reset and hazard reload pass it; normal stage advance does not. Keep the current independent `preserveLevelMoves` behavior so manual Reset still clears `levelMoves` while hazard keeps the hazard move.
+
+- [ ] **Step 7: Increment reset/fall counters exactly once at their event sites**
+
+Before same-stage reload:
+
+```ts
+// manual Reset
+this.state.resets += 1
+this.state.levelResets += 1
+
+// hazard
+this.state.falls += 1
+this.state.resets += 1
+this.state.levelFalls += 1
+this.state.levelResets += 1
+```
+
+Do not derive these values from callbacks or renderer events.
+
+- [ ] **Step 8: Build one clear-result object inside `clearLevel()`**
+
+Count `C` glyphs from `stage.rows` at clear time. For Daily, evaluate exactly one bonus objective and Efficient, then derive:
+
+```ts
+const optionalStarsEarned = Number(efficient) + Number(bonusEarned)
+const earnedCount = 1 + optionalStarsEarned
+```
+
+Use `dailyStageScore()` only when `this.state.mode === 'daily'`; otherwise use the existing `levelScore()` path. Add cumulative stars only for Daily.
+
+Fire `onLevelClear(result)` with the completed stage's facts before the next-stage interaction can occur.
+
+For the final stage, use `dailyTimeBonus()` only for Daily; keep `timeBonus()` for Campaign/non-Daily explicit runs.
+
+- [ ] **Step 9: Run all Ice Slide unit tests**
+
+```bash
+bun run test:run -- src/lib/games/ice-slide
+```
+
+Expected: PASS.
+
+- [ ] **Step 10: Commit**
+
+```bash
+git add \
+  src/lib/games/ice-slide/test-fixtures.ts \
+  src/lib/games/ice-slide/game.ts \
+  src/lib/games/ice-slide/game*.test.ts \
+  src/lib/games/ice-slide/*.test.ts
+git commit -m "feat(ice-slide): track daily stage results"
+```
+
+Before committing, inspect `git diff --cached --name-only` and unstage any test file not actually changed by this task; do not use the glob to sweep unrelated edits.
+
+---
+
+### Task 4: Add fresh-vs-retry Daily lifecycle, input gating, and scoped completed submission
+
+**Files:**
+- Modify: `src/lib/games/ice-slide/init.ts`
+- Modify: `src/lib/games/ice-slide/init.test.ts`
+
+**Interfaces:**
+- Consumes: `createIceSlideDailyRunDefinition()`, `toIceSlideUtcDateKey()`, `cloneIceSlideRunDefinition()`, `IceSlidePlayableMode`, `IceSlideStageClearResult`, `ICE_SLIDE_OBJECTIVE_LABELS`, `authClient.getSession()`, existing `saveGameScore()` context option.
+- Produces:
+
+```ts
+export interface IceSlideHandle {
+  start: (mode?: IceSlidePlayableMode) => Promise<void>
+  playAgain: () => Promise<void>
+  stop: () => void
+  resetLevel: () => void
+  cleanup: () => void
+  getGame: () => IceSlideGame | null
+}
+```
+
+- [ ] **Step 1: Extend the JSDOM fixture and auth mock**
+
+Add the Daily/stage-clear element IDs that `init.ts` will own, including:
+
+```text
+#daily-meta
+#daily-date
+#daily-reset
+#daily-stage-progress
+#daily-objective-clear
+#daily-objective-efficient
+#daily-objective-bonus
+#stage-clear-overlay
+#stage-clear-title
+#stage-clear-score
+#stage-clear-clear
+#stage-clear-efficient
+#stage-clear-bonus
+#stage-clear-continue-btn
+```
+
+Mock `@/lib/auth-client` with `authClient.getSession = vi.fn()` and default it to an authenticated session for existing score tests.
+
+- [ ] **Step 2: Write failing fresh/retry/rollover tests**
+
+Use fake system time:
+
+```ts
+vi.useFakeTimers()
+vi.setSystemTime(new Date('2026-08-12T23:59:59Z'))
+await handle.start('daily')
+const firstKey = handle.getGame()!.getState().runKey
+const firstSignatures = handle.getGame()!.getState().stageSignatures
+
+vi.setSystemTime(new Date('2026-08-13T00:00:01Z'))
+await handle.playAgain()
+expect(handle.getGame()!.getState().runKey).toBe(firstKey)
+expect(handle.getGame()!.getState().stageSignatures).toEqual(firstSignatures)
+
+await handle.start('daily')
+expect(handle.getGame()!.getState().runKey).toContain('2026-08-13')
+```
+
+Also assert `start()` without a mode still starts Campaign.
+
+- [ ] **Step 3: Write failing submission-boundary tests**
+
+Add tests for:
+
+- Campaign partial stop still calls `saveGameScore()` with no context.
+- Daily partial stop never calls it.
+- completed Daily calls it exactly once with:
+
+```ts
+expect(options.context).toEqual({
+  mode: 'daily',
+  competitionKey: gameData.runKey,
+  rulesetVersion: gameData.rulesetVersion,
+})
+```
+
+- `authClient.getSession()` returning `{ data: null, error: null }` makes a completed Daily run local-only.
+- a session-check error does not silently discard an otherwise completed run; the normal score path remains authoritative.
+
+Use the production solver or the deterministic Daily run data to drive completion in the test helper; do not hard-code transform-dependent arrow sequences.
+
+- [ ] **Step 4: Write failing stage-clear/input-gate tests**
+
+Drive a Daily stage clear, then assert:
+
+- stage-clear overlay is visible;
+- objective/score text is populated from the clear result;
+- a keyboard direction while the overlay is open does not change moves/stage;
+- pointer/swipe direction is also ignored;
+- Continue hides the overlay and allows input again;
+- final-stage Continue transitions to the mission-complete overlay and only then triggers Daily submission.
+
+Add cleanup/failure assertions that no stale overlay/lock remains.
+
+- [ ] **Step 5: Run `init.test.ts` to verify failure**
+
+```bash
+bun run test:run -- src/lib/games/ice-slide/init.test.ts
+```
+
+Expected: FAIL on the old handle/submission/overlay behavior.
+
+- [ ] **Step 6: Refactor start internals around a materialized run**
+
+Create one private local `startRun(run?: IceSlideRunDefinition)` closure that contains the existing game/renderer teardown and startup sequence.
+
+Fresh start:
+
+```ts
+start: async (mode = 'campaign') => {
+  if (mode === 'daily') {
+    const dateKey = toIceSlideUtcDateKey(new Date())
+    const run = createIceSlideDailyRunDefinition(dateKey)
+    lastStartedMode = 'daily'
+    lastDailyRun = cloneIceSlideRunDefinition(run)
+    await startRun(run)
+    return
+  }
+  lastStartedMode = 'campaign'
+  lastDailyRun = null
+  await startRun()
+}
+```
+
+Retry:
+
+```ts
+playAgain: async () => {
+  if (lastStartedMode === 'daily' && lastDailyRun) {
+    await startRun(cloneIceSlideRunDefinition(lastDailyRun))
+    return
+  }
+  await startRun()
+}
+```
+
+Clear overlays/input locks at the beginning of every start.
+
+- [ ] **Step 7: Make score submission mode-aware and asynchronous**
+
+Capture the run guard before any auth/session await. For Daily:
+
+1. require `gameData.solved === true`;
+2. call `authClient.getSession()`;
+3. if the run became stale, return;
+4. if no session and no auth error, return without calling `saveGameScore()`;
+5. otherwise call existing `saveGameScore()` with game data and the exact Daily context.
+
+For Campaign, preserve the existing unscoped helper call and partial-stop behavior.
+
+Do not add server validation in this task.
+
+- [ ] **Step 8: Add one shared input gate to keyboard and swipe paths**
+
+Use one predicate such as:
+
+```ts
+const canAcceptMove = () =>
+  !!game && game.getState().status === 'playing' && !inputLocked
+```
+
+Both input handlers call it. `resetLevel()` also no-ops while the stage-clear overlay is locking interaction.
+
+- [ ] **Step 9: Implement stage-clear Continue behavior**
+
+For Daily `onLevelClear(result)`, set the lock, populate/show the page-local overlay, and focus Continue. Campaign forwards the callback without showing the Daily stage overlay.
+
+For a final Daily win, store `pendingDailyWinScore` instead of immediately replacing the stage overlay. Continue finalizes the shared result overlay, invokes external `onWin`, and starts the scoped submission.
+
+- [ ] **Step 10: Run integration tests**
+
+```bash
+bun run test:run -- \
+  src/lib/games/ice-slide/init.test.ts \
+  src/lib/games/ice-slide/game.test.ts \
+  src/lib/services/scoreService.test.ts
+```
+
+Expected: PASS.
+
+- [ ] **Step 11: Commit**
+
+```bash
+git add src/lib/games/ice-slide/init.ts src/lib/games/ice-slide/init.test.ts
+git commit -m "feat(ice-slide): integrate daily run lifecycle"
+```
+
+---
+
+### Task 5: Add the compact Daily page UX and markup contracts
+
+**Files:**
+- Modify: `src/pages/ice-slide/index.astro`
+- Modify: `src/pages/game-board-markup.test.ts`
+
+**Interfaces:**
+- Consumes: `IceSlideHandle.start(mode)`, `IceSlideHandle.playAgain()`.
+- Produces DOM IDs consumed by Task 4; page-level URL/mode selection and Change Mode behavior.
+
+- [ ] **Step 1: Add failing markup-contract assertions**
+
+Extend `game-board-markup.test.ts` to load Ice Slide markup once and assert the required surfaces:
+
+```ts
+expect(iceSlideMarkup).toContain('id="ice-slide-mode-selector"')
+expect(iceSlideMarkup).toContain('value="campaign"')
+expect(iceSlideMarkup).toContain('value="daily"')
+expect(iceSlideMarkup).not.toContain('value="expedition"')
+expect(iceSlideMarkup).toContain('id="daily-meta"')
+expect(iceSlideMarkup).toContain('id="stage-clear-overlay"')
+expect(iceSlideMarkup).toContain('id="stage-clear-continue-btn"')
+expect(iceSlideMarkup).toContain('id="change-mode-btn"')
+expect(iceSlideMarkup).toContain('Daily adds +100')
+```
+
+- [ ] **Step 2: Run the markup test and verify it fails**
+
+```bash
+bun run test:run -- src/pages/game-board-markup.test.ts
+```
+
+Expected: FAIL on missing Daily markup.
+
+- [ ] **Step 3: Add a semantic two-option selector above the board**
+
+Use a `fieldset`/radio pair rather than a custom mode component:
+
+```html
+<fieldset id="ice-slide-mode-selector">
+  <legend>Mode</legend>
+  <label><input type="radio" name="ice-slide-mode" value="campaign" checked /> Campaign</label>
+  <label><input type="radio" name="ice-slide-mode" value="daily" /> Daily</label>
+</fieldset>
+```
+
+Style locally with existing Tailwind/Cetus classes. Do not create a reusable selector component for one page.
+
+- [ ] **Step 4: Add Daily metadata/objective and stage-clear markup**
+
+The Daily HUD is hidden by default and contains the exact IDs from Task 4. Its copy includes UTC date/reset context without a countdown scheduler.
+
+Add an absolutely positioned opaque stage-clear overlay inside the board wrapper, hidden by default, with text/symbol objective states and a real button for Continue.
+
+- [ ] **Step 5: Add Change Mode to the existing final-stats slot**
+
+Use the GamePage `final-stats` slot to render a small secondary `#change-mode-btn`. It only returns the page to pre-run state; do not alter the shared `GameOverlay` API.
+
+- [ ] **Step 6: Wire URL selection and lifecycle**
+
+At page init:
+
+```ts
+const requestedMode = new URLSearchParams(window.location.search).get('mode')
+const selectedMode = requestedMode === 'daily' ? 'daily' : 'campaign'
+```
+
+Set the corresponding radio. Do not auto-start.
+
+On Start, read the checked radio and call `gameHandle.start(mode)`.
+
+On Play Again, call `gameHandle.playAgain()` rather than `start()`.
+
+Disable mode radios while a run is active. Change Mode hides the result overlay, re-enables the selector, and leaves the game idle; the next Start is fresh and therefore may capture a new UTC date.
+
+Update local callback signatures for `onLevelClear(result)`.
+
+- [ ] **Step 7: Add concise Daily instructions/scoring copy**
+
+Keep Campaign copy. Add only what a Daily player needs:
+
+- one five-stage run per UTC day;
+- three stars: Clear, Efficient, seeded bonus;
+- +100 for Efficient/bonus star;
+- 5:00 Daily completion budget;
+- Play Again retries the same Daily.
+
+Do not add leaderboard copy until HPA-488.
+
+- [ ] **Step 8: Run page and Ice Slide integration tests**
+
+```bash
+bun run test:run -- \
+  src/pages/game-board-markup.test.ts \
+  src/lib/games/ice-slide/init.test.ts
+```
+
+Expected: PASS.
+
+- [ ] **Step 9: Commit**
+
+```bash
+git add src/pages/ice-slide/index.astro src/pages/game-board-markup.test.ts
+git commit -m "feat(ice-slide): add daily mode interface"
+```
+
+---
+
+### Task 6: Lock E2E/regression behavior and run full verification
+
+**Files:**
+- Modify: `e2e/games/play-coverage.spec.ts`
+- Modify only tests required to satisfy the final coverage gate; do not add production code solely to make coverage easier.
+
+**Interfaces:**
+- Verifies all HPA-487 user-visible behavior; produces no new production API.
+
+- [ ] **Step 1: Preserve the existing Campaign smoke test**
+
+Keep `/ice-slide` as Campaign default. Extend the existing test only enough to assert the Campaign radio is selected before Start and that the existing first-level `ArrowDown` flow still reaches level 2.
+
+- [ ] **Step 2: Add a Daily query/interaction smoke test**
+
+Add a focused test:
+
+```ts
+test('preselects Daily, starts the UTC run, and can end locally', async ({ page }) => {
+  await page.goto('/ice-slide?mode=daily')
+  await expect(page.locator('input[value="daily"]')).toBeChecked()
+  await startGameWhenReady(page)
+  await expect(page.locator('#daily-meta')).toBeVisible()
+  await expect(page.locator('#daily-stage-progress')).toHaveText(/1\s*\/\s*5/)
+  await expect(page.locator('#daily-objective-clear')).toContainText('Clear')
+  await page.locator('#end-btn').click()
+  await expect(page.locator('#game-over-overlay')).not.toHaveClass(/hidden/)
+})
+```
+
+The test does not depend on the first Daily transform's solution path.
+
+- [ ] **Step 3: Add malformed/unavailable mode fallback coverage**
+
+Navigate to `/ice-slide?mode=expedition` and `/ice-slide?mode=not-a-mode`; assert Campaign is selected and no run auto-starts.
+
+- [ ] **Step 4: Run focused E2E**
+
+```bash
+bun run test:e2e -- e2e/games/play-coverage.spec.ts --grep "Ice Slide"
+```
+
+Expected: PASS.
+
+- [ ] **Step 5: Run the complete Ice Slide unit suite**
+
+```bash
+bun run test:run -- src/lib/games/ice-slide src/pages/game-board-markup.test.ts
+```
+
+Expected: PASS.
+
+- [ ] **Step 6: Run repository verification**
+
+Run, in order:
+
+```bash
+bun run format:check
+bun run lint
+bun run typecheck
+bun run test:run
+bun run test:coverage
+bun run build
+```
+
+Expected:
+
+- format: PASS;
+- lint: no new errors;
+- typecheck: no diagnostics introduced by this branch;
+- test suite: PASS;
+- coverage: satisfies the repository's current 95% Codecov gate;
+- build: PASS.
+
+If `typecheck` exposes a diagnostic already present byte-for-byte on `main`, document that baseline in the implementation PR rather than expanding HPA-487 into an unrelated fix. Any diagnostic in an HPA-487-touched file must be fixed before completion.
+
+- [ ] **Step 7: Run a final scope diff**
+
+```bash
+git diff --stat main...HEAD
+git diff --name-only main...HEAD
+```
+
+Verify there are no changes to database/leaderboard server paths, Expedition/template code, snow/cracked-ice work, shared GamePage/GameOverlay APIs, or platform Daily Challenge rotation.
+
+- [ ] **Step 8: Self-review the implementation against HPA-487**
+
+Check each acceptance condition explicitly:
+
+- same date/version exact deterministic run;
+- representative date variation;
+- five unique templates/canonical boards;
+- solver recomputed par/objective feasibility;
+- reset/hazard star facts;
+- Daily formula/300-second bonus;
+- completed-only contextual submission;
+- anonymous local result;
+- Campaign compatibility;
+- mode/query/retry/overlay/keyboard/swipe/reduced-motion/error cleanup.
+
+Fix any gap before the final commit.
+
+- [ ] **Step 9: Commit E2E/verification test changes**
+
+```bash
+git add e2e/games/play-coverage.spec.ts
+git commit -m "test(ice-slide): cover daily challenge flows"
+```
+
+---
+
+## Plan Self-Review
+
+### Spec coverage
+
+- Deterministic Daily identity, tier pools, transforms, canonical uniqueness, solver par verification, and seeded objective selection: Task 1.
+- Objective semantics and exact Daily score formula: Task 2.
+- Falls/resets/stars/stage results and game-data counters: Task 3.
+- UTC capture vs retry, completed-only submission, anonymous behavior, input/overlay lifecycle: Task 4.
+- Compact selector, URL preselection, date/reset/stage/objective UI, Continue, Change Mode, copy: Task 5.
+- Campaign regression, E2E, full gates, and final scope check: Task 6.
+
+No HPA-487 acceptance criterion is intentionally deferred.
+
+### Placeholder scan
+
+No `TBD`, `TODO`, generic “add tests”, or unspecified error-handling step remains. Each task names exact files, interfaces, commands, and expected outcomes.
+
+### Type/contract consistency
+
+- `IceSlidePlayableMode` is exactly `'campaign' | 'daily'` at the browser boundary; `IceSlideMode` remains broader for future Expedition materialized runs.
+- Daily generator version is defined once in `daily.ts` and reused by tests/fixtures.
+- Existing ruleset/schema constants remain in `run.ts`.
+- `onLevelClear` has one result-object signature everywhere after Task 2/3 migration.
+- `IceSlideGameData` keeps the existing persisted metadata shape; new per-stage facts live only in state/callback results.
+- HPA-488 remains the sole owner of server Daily semantic admission and ranked presentation.
+
+## Execution Handoff
+
+Plan complete and saved to `docs/superpowers/plans/2026-08-12-ice-slide-daily-challenge.md`.
+
+Recommended execution is **subagent-driven development** with a fresh implementation/review gate for each of the six tasks above. Inline execution is also valid if the task sequence and commit boundaries are preserved.

--- a/docs/superpowers/plans/2026-08-12-ice-slide-daily-challenge.md
+++ b/docs/superpowers/plans/2026-08-12-ice-slide-daily-challenge.md
@@ -2,71 +2,77 @@
 
 > **For agentic workers:** REQUIRED SUB-SKILL: Use superpowers:subagent-driven-development (recommended) or superpowers:executing-plans to implement this plan task-by-task. Steps use checkbox (`- [ ]`) syntax for tracking.
 
-**Goal:** Ship HPA-487 with a deterministic five-stage Ice Slide Daily mode, frozen generator-v1 outputs, objective stars/scoring, exact retry/overlay lifecycle, Daily HUD, and completed-run contextual submission while preserving Campaign behavior.
+**Goal:** Ship HPA-487 with a deterministic five-stage Ice Slide Daily mode, stage-scoped objectives/stars, Daily score configuration, exact retry identity, compact mode/HUD UX, and contextual completed-run submission while preserving Campaign behavior.
 
-**Architecture:** Materialize a complete `IceSlideRunDefinition` from an explicit UTC date before gameplay. Reuse the existing RNG, transforms, run contract, production solver, and quality validator. Keep objective/scoring policy pure; keep clock capture, exact retry identity, Daily HUD synchronization, stage-clear gating, and submission ownership in `init.ts`/the page. Do not create a second Daily engine or a generic generator framework.
+**Architecture:** Materialize a complete Daily `IceSlideRunDefinition` from an explicit UTC date before gameplay. Keep generation/objective/scoring policy pure; keep the game engine clock/RNG-free; let `init.ts` own retry identity, HUD synchronization, non-final stage-result gating, End behavior, and submission. Final Daily completion reuses the existing `onWin` result/submission path rather than adding a second final-Continue state.
 
-**Tech Stack:** Astro 5, TypeScript 6, PixiJS 8, Vitest 3, Playwright 1.54, Better Auth client, existing Cetus deterministic Ice Slide infrastructure.
+**Tech Stack:** Astro 5, TypeScript 6, PixiJS 8, Vitest 3, Playwright, existing Cetus score service and deterministic Ice Slide run/RNG/transform/solver/quality modules.
 
 ## Global Constraints
 
-- Campaign remains default and keeps existing scoring, achievements, unscoped submissions, and partial-End submission behavior.
-- Daily is the only additional playable mode; `IceSlidePlayableMode = 'campaign' | 'daily'` while the run-level `IceSlideMode` continues to include `expedition`.
-- `IceSlideGame` never reads the clock or makes random choices.
-- Daily generation never uses `Math.random()` or `crypto.getRandomValues()`.
-- Generator-v1 fork labels, stage metadata, and the literal `2026-08-12` output are compatibility contracts. A same-date materialization change requires a generator-version bump.
-- `Play Again` retries the exact materialized Daily run; a fresh Daily Start captures the current UTC date.
-- Daily has exactly five stages, unique source templates, unique final canonical boards, recomputed solver pars, and one feasible seeded bonus objective per stage.
-- Daily partial End never submits. Only final-stage Continue may initiate Daily submission.
-- HPA-488 owns server-side Daily semantic admission and leaderboard UI/query work.
-- The finite authored Daily search throws when no valid candidate exists; do not add mutation-style retry/fallback orchestration.
-- No mutation templates, Expedition UI, snow, cracked ice, abilities, persistence service, mode registry, generic generator framework, shared overlay framework, UTC countdown scheduler, or game-engine pause state.
-- Stage-clear feedback uses explicit Continue; no auto-dismiss timer or forced reduced-motion delay.
-- New/changed code must satisfy current format, lint, typecheck, unit/E2E, build, and 95% coverage gates.
+- Campaign remains default and preserves current scoring, achievements, unscoped submission, and positive-score partial-End behavior.
+- Daily is the only additional playable mode; no Expedition placeholder.
+- `IceSlideMode` remains `campaign | daily | expedition`; browser `IceSlidePlayableMode` is only `campaign | daily`.
+- `IceSlideGame` never reads the clock or random source.
+- Daily generation never calls `Math.random()` or `crypto.getRandomValues()`.
+- Fresh Daily Start captures current UTC date; Play Again retries the exact stored materialized run.
+- Daily contains five stages, unique source templates, unique materialized canonical boards, and one feasible seeded bonus objective per stage.
+- Non-final Daily stage clears use manual Continue. Final Daily stars render in the normal result overlay and submission starts immediately from `onWin`.
+- Daily End is local-only, never submits, and shows `RUN ENDED` even at score 0.
+- Anonymous completion uses the normal score endpoint; structured `UNAUTHENTICATED` is silent/local.
+- HPA-488 owns server-side semantic admission and Daily leaderboard/ranking.
+- No generic generator service, mode registry, shared overlay framework, persistence service, mutation templates, Expedition, snow, cracked ice, or abilities.
+- Existing `codecov.yml` 95% project/patch status targets remain in force; HPA-487 does not create a new coverage threshold.
 
 ---
 
 ## File Structure
 
-### New files
+### Create
 
-- `src/lib/games/ice-slide/daily.ts` — shared UTC date conversion plus deterministic Daily materialization.
-- `src/lib/games/ice-slide/daily.test.ts` — date validation, generator golden vector, year sweep, pools/transforms/quality/determinism.
-- `src/lib/games/ice-slide/objectives.ts` — pure objective completion and labels.
-- `src/lib/games/ice-slide/objectives.test.ts` — objective rules.
-- `src/lib/games/ice-slide/scoring.test.ts` — Campaign regression plus Daily scoring.
+- `src/lib/games/ice-slide/daily.ts` — deterministic UTC-keyed Daily run materialization.
+- `src/lib/games/ice-slide/daily.test.ts` — golden vector, full-year sweep, deterministic invariants.
+- `src/lib/games/ice-slide/objectives.ts` — pure stage-scoped bonus-objective rules and labels.
+- `src/lib/games/ice-slide/objectives.test.ts` — objective-rule tests.
+- `src/lib/games/ice-slide/scoring.test.ts` — default Campaign and Daily-config score tests.
 
-### Existing files to modify
+### Modify
 
-- `src/lib/games/ice-slide/types.ts` — active-stage facts, stage-clear payload, playable-mode type.
-- `src/lib/games/ice-slide/run.ts` — extract one UTC date-key validator and export Campaign difficulty mapping.
-- `src/lib/games/ice-slide/scoring.ts` — additive Daily score functions only.
-- `src/lib/games/ice-slide/test-fixtures.ts` — valid Daily test run helper.
-- `src/lib/games/ice-slide/game.ts` — reset/fall counters, Daily stars/scoring, richer clear callback while preserving callback order.
-- `src/lib/games/ice-slide/game.test.ts` / `game.hazard.test.ts` — runtime/callback/counter regressions.
-- `src/lib/games/ice-slide/init.ts` — fresh/retry lifecycle, Daily HUD, input/result gate, overlay-End semantics, scoped completed submission.
-- `src/lib/games/ice-slide/init.test.ts` — rollover, HUD, overlay/End, anonymous/submission, cleanup tests.
-- `src/pages/ice-slide/index.astro` — selector, Daily HUD markup, stage-clear markup, Play Again/Change Mode wiring.
-- `src/pages/game-board-markup.test.ts` — Ice Slide page contract.
-- `e2e/games/play-coverage.spec.ts` — Campaign smoke plus Daily query/retry/Change Mode flow.
+- `src/lib/games/ice-slide/run.ts` — shared UTC date-key validator; export Campaign difficulty mapping.
+- `src/lib/games/ice-slide/types.ts` — playable mode, active-stage facts, clear-result payload.
+- `src/lib/games/ice-slide/scoring.ts` — one configurable `levelScore()`/`timeBonus()` shape.
+- `src/lib/games/ice-slide/test-fixtures.ts` — valid five-stage Daily test run helper.
+- `src/lib/games/ice-slide/game.ts` and focused tests — counters, stars, score config, clear-result payload/order.
+- `src/lib/games/ice-slide/init.ts` and tests — fresh/retry lifecycle, HUD, non-final overlay, Daily End, scoped submit.
+- `src/lib/services/scoreService.ts` and tests — additive `UNAUTHENTICATED` structured failure propagation.
+- `src/pages/ice-slide/index.astro` — page-local selector/HUD/overlays/Play Again/Change Mode.
+- `src/pages/game-board-markup.test.ts` — stable DOM contracts only.
+- `e2e/games/play-coverage.spec.ts` — Campaign + Daily page-level lifecycle coverage.
+
+### Explicitly unchanged
+
+- database schema/query code;
+- `/api/leaderboard` and leaderboard UI;
+- server Daily admission rules;
+- shared `GamePage` / `GameOverlay` APIs;
+- platform Daily Challenge rotation;
+- Expedition/template/evolving-tile modules.
 
 ---
 
-## Task 1: Freeze and materialize deterministic five-stage Daily runs
+## Task 1: Freeze and materialize deterministic Daily generator v1
 
 **Files:**
 - Create: `src/lib/games/ice-slide/daily.ts`
 - Create: `src/lib/games/ice-slide/daily.test.ts`
 - Modify: `src/lib/games/ice-slide/run.ts`
 
-**Interfaces:**
+**Produces:**
 
 ```ts
-// run.ts
 export function assertValidIceSlideUtcDateKey(dateKey: string): void
 export const CAMPAIGN_STAGE_DIFFICULTIES: readonly IceSlideDifficulty[]
 
-// daily.ts
 export const ICE_SLIDE_DAILY_GENERATOR_VERSION = 1
 export const ICE_SLIDE_DAILY_SOLVER_MAX_STATES = 10_000
 export const ICE_SLIDE_DAILY_STAGE_POOLS: readonly (readonly number[])[]
@@ -76,238 +82,177 @@ export function createIceSlideDailyRunDefinition(
 ): IceSlideRunDefinition
 ```
 
-### Frozen generator-v1 contract
+### Step 1: Write failing shared-date tests
 
-For a selected source level, materialize exactly:
+- [ ] Extract/add tests in `run.test.ts` (or the existing run test file) for exact calendar validity:
 
 ```ts
-{
-  id: `daily:${dateKey}:${stageNumber}`,
-  name: source.name,
-  templateId: `campaign:${source.id}`,
-  difficulty: CAMPAIGN_STAGE_DIFFICULTIES[sourceIndex],
-  rows: variant.rows,
-  parMoves: quality.parMoves,
-  transform: variant.transform,
-  mutationIds: [],
-  objectiveIds: [bonusObjective],
-  scoreMultiplierBps: 10_000,
-}
+expect(() => assertValidIceSlideUtcDateKey('2026-08-12')).not.toThrow()
+expect(() => assertValidIceSlideUtcDateKey('2026-02-29')).toThrow(RangeError)
+expect(() => assertValidIceSlideUtcDateKey('2024-02-29')).not.toThrow()
+expect(() => assertValidIceSlideUtcDateKey('2026-13-01')).toThrow(RangeError)
+expect(() => assertValidIceSlideUtcDateKey('08-12-2026')).toThrow(RangeError)
 ```
 
-Pool IDs are resolved with `ICE_SLIDE_LEVELS.findIndex(level => level.id === levelId)`; never index by `levelId - 1`.
-
-The exact RNG labels are:
+- [ ] Add `daily.test.ts` red tests:
 
 ```ts
-const stageRng = rootRng.fork(`stage:${stageNumber}`)
-const templateOrder = stageRng.fork('template').shuffle(pool)
-const variantOrder = stageRng
-  .fork(`transform:${source.id}`)
-  .shuffle(getUniqueBoardTransforms(source.rows))
-const bonusObjective = stageRng.fork('objective').pick(eligibleObjectives)
+expect(toIceSlideUtcDateKey(new Date('2026-08-12T23:59:59Z'))).toBe(
+  '2026-08-12'
+)
+expect(() => toIceSlideUtcDateKey(new Date(Number.NaN))).toThrow(RangeError)
 ```
 
-Eligible-objective ordering is exactly:
+- [ ] Run:
+
+```bash
+bun run test:run -- \
+  src/lib/games/ice-slide/run.test.ts \
+  src/lib/games/ice-slide/daily.test.ts
+```
+
+Expected: FAIL on missing exports/module.
+
+### Step 2: Extract the existing date validator
+
+- [ ] Move the current Daily run-key calendar round-trip check from `assertValidIceSlideRunDefinition()` into `assertValidIceSlideUtcDateKey()`.
+- [ ] Make Daily run validation call that helper with the run-key date segment.
+- [ ] Keep run-key/seed/version behavior otherwise byte-compatible.
+
+### Step 3: Export Campaign difficulty metadata
+
+- [ ] Rename the private Campaign difficulty constant to:
 
 ```ts
-[
-  'collect_all_crystals',
-  'no_falls',
-  'no_reset',
+export const CAMPAIGN_STAGE_DIFFICULTIES: readonly IceSlideDifficulty[] = [
+  'tutorial',
+  'easy',
+  'easy',
+  'medium',
+  'medium',
+  'medium',
+  'hard',
+  'hard',
 ]
 ```
 
-- [ ] **Step 1: Write failing date-contract and generator tests**
+- [ ] Reuse it in Campaign materialization; keep the existing length assertion.
 
-Create `daily.test.ts`. Start with the single shared calendar contract:
+### Step 4: Write the full generator-v1 golden test before implementation
+
+- [ ] Lock identity:
 
 ```ts
-import { describe, expect, it } from 'vitest'
-import {
-  assertValidIceSlideRunDefinition,
-  assertValidIceSlideUtcDateKey,
-} from './run'
-import {
-  createIceSlideDailyRunDefinition,
-  toIceSlideUtcDateKey,
-} from './daily'
-
-describe('Ice Slide UTC date keys', () => {
-  it.each(['2026-01-01', '2026-02-28', '2028-02-29'])(
-    'accepts %s',
-    dateKey => expect(() => assertValidIceSlideUtcDateKey(dateKey)).not.toThrow()
-  )
-
-  it.each([
-    '2026-2-01',
-    '2026-02-30',
-    '2026-13-01',
-    'not-a-date',
-  ])('rejects %s', dateKey => {
-    expect(() => assertValidIceSlideUtcDateKey(dateKey)).toThrow(RangeError)
-  })
-
-  it('converts Date with the same shared validator', () => {
-    expect(toIceSlideUtcDateKey(new Date('2026-08-12T23:59:59Z'))).toBe(
-      '2026-08-12'
-    )
-    expect(() => toIceSlideUtcDateKey(new Date(Number.NaN))).toThrow(RangeError)
-  })
+const run = createIceSlideDailyRunDefinition('2026-08-12')
+expect(run).toMatchObject({
+  schemaVersion: 1,
+  generatorVersion: 1,
+  rulesetVersion: 1,
+  mode: 'daily',
+  seed: 'ice-slide:daily:1:1:2026-08-12',
+  runKey: 'ice-slide:daily:2026-08-12:g1:r1',
 })
 ```
 
-Then lock identity:
+- [ ] Lock the literal stage projection:
 
 ```ts
-it('builds the exact Daily identity', () => {
-  const run = createIceSlideDailyRunDefinition('2026-08-12')
-  expect(run).toMatchObject({
-    schemaVersion: 1,
-    generatorVersion: 1,
-    rulesetVersion: 1,
-    mode: 'daily',
-    seed: 'ice-slide:daily:1:1:2026-08-12',
-    runKey: 'ice-slide:daily:2026-08-12:g1:r1',
-  })
-  expect(run.stages).toHaveLength(5)
-  expect(() => assertValidIceSlideRunDefinition(run)).not.toThrow()
-})
+expect(
+  run.stages.map(stage => ({
+    id: stage.id,
+    name: stage.name,
+    templateId: stage.templateId,
+    transform: stage.transform,
+    objectiveIds: stage.objectiveIds,
+    parMoves: stage.parMoves,
+    difficulty: stage.difficulty,
+    signature: stage.signature,
+  }))
+).toEqual([
+  {
+    id: 'daily:2026-08-12:1',
+    name: 'Corner Pocket',
+    templateId: 'campaign:2',
+    transform: 'identity',
+    objectiveIds: ['no_reset'],
+    parMoves: 3,
+    difficulty: 'easy',
+    signature: 'is2-8c5387f7',
+  },
+  {
+    id: 'daily:2026-08-12:2',
+    name: 'Bank Shot',
+    templateId: 'campaign:3',
+    transform: 'rotate_180',
+    objectiveIds: ['no_reset'],
+    parMoves: 4,
+    difficulty: 'easy',
+    signature: 'is2-c8c370cb',
+  },
+  {
+    id: 'daily:2026-08-12:3',
+    name: 'Crystal Cache',
+    templateId: 'campaign:5',
+    transform: 'reflect_anti_diagonal',
+    objectiveIds: ['collect_all_crystals'],
+    parMoves: 6,
+    difficulty: 'medium',
+    signature: 'is2-2394afd9',
+  },
+  {
+    id: 'daily:2026-08-12:4',
+    name: 'Deep Freeze',
+    templateId: 'campaign:7',
+    transform: 'reflect_vertical',
+    objectiveIds: ['collect_all_crystals'],
+    parMoves: 6,
+    difficulty: 'hard',
+    signature: 'is2-07d0c27d',
+  },
+  {
+    id: 'daily:2026-08-12:5',
+    name: 'Absolute Zero',
+    templateId: 'campaign:8',
+    transform: 'reflect_main_diagonal',
+    objectiveIds: ['no_reset'],
+    parMoves: 6,
+    difficulty: 'hard',
+    signature: 'is2-c31fa49b',
+  },
+])
 ```
 
-Lock the complete generator-v1 stage projection:
+Name the test so failure says generator v1 output changed and a version-bump decision is required. Do not treat it as a snapshot to casually re-record.
+
+### Step 5: Add deterministic invariant tests
+
+- [ ] Same date returns byte-equivalent JSON.
+- [ ] Exactly five stages.
+- [ ] Each stage's `templateId` belongs to its stage pool and all five templates are unique.
+- [ ] `serializeBoardRows(stage.rows)` is unique across the five materialized stages.
+- [ ] Every stage has exactly one objective, no mutations, multiplier 10_000, and positive verified par.
+- [ ] `assertValidIceSlideRunDefinition(run)` succeeds.
+- [ ] Representative dates vary deterministically.
+
+### Step 6: Add the bounded full-year content sweep
+
+- [ ] Materialize each calendar date from `2026-01-01` through `2026-12-31` and assert no throw:
 
 ```ts
-it('locks the generator-v1 2026-08-12 stage tuples', () => {
-  const run = createIceSlideDailyRunDefinition('2026-08-12')
-  expect(
-    run.stages.map(stage => ({
-      id: stage.id,
-      name: stage.name,
-      templateId: stage.templateId,
-      transform: stage.transform,
-      objectiveIds: stage.objectiveIds,
-      parMoves: stage.parMoves,
-      difficulty: stage.difficulty,
-      signature: stage.signature,
-    }))
-  ).toEqual([
-    {
-      id: 'daily:2026-08-12:1',
-      name: 'Corner Pocket',
-      templateId: 'campaign:2',
-      transform: 'identity',
-      objectiveIds: ['no_reset'],
-      parMoves: 3,
-      difficulty: 'easy',
-      signature: 'is2-8c5387f7',
-    },
-    {
-      id: 'daily:2026-08-12:2',
-      name: 'Bank Shot',
-      templateId: 'campaign:3',
-      transform: 'rotate_180',
-      objectiveIds: ['no_reset'],
-      parMoves: 4,
-      difficulty: 'easy',
-      signature: 'is2-c8c370cb',
-    },
-    {
-      id: 'daily:2026-08-12:3',
-      name: 'Crystal Cache',
-      templateId: 'campaign:5',
-      transform: 'reflect_anti_diagonal',
-      objectiveIds: ['collect_all_crystals'],
-      parMoves: 6,
-      difficulty: 'medium',
-      signature: 'is2-2394afd9',
-    },
-    {
-      id: 'daily:2026-08-12:4',
-      name: 'Deep Freeze',
-      templateId: 'campaign:7',
-      transform: 'reflect_vertical',
-      objectiveIds: ['collect_all_crystals'],
-      parMoves: 6,
-      difficulty: 'hard',
-      signature: 'is2-07d0c27d',
-    },
-    {
-      id: 'daily:2026-08-12:5',
-      name: 'Absolute Zero',
-      templateId: 'campaign:8',
-      transform: 'reflect_main_diagonal',
-      objectiveIds: ['no_reset'],
-      parMoves: 6,
-      difficulty: 'hard',
-      signature: 'is2-c31fa49b',
-    },
-  ])
-})
-```
-
-Add invariant tests:
-
-- same date serializes byte-equivalently;
-- every stage source ID belongs to its exact pool;
-- five template IDs are unique;
-- five `serializeBoardRows(stage.rows)` values are unique;
-- every stage has one objective, no mutations, multiplier `10_000`;
-- every stage par equals `solveIceSlideBoard(stage, { maxStates: 10_000 }).minMoves`;
-- assigned objective is feasible under `validateIceSlideStageQuality()`.
-
-Add the bounded v1 content sweep:
-
-```ts
-it('materializes every UTC date in calendar year 2026', () => {
-  const start = Date.UTC(2026, 0, 1)
-  for (let offset = 0; offset < 365; offset++) {
-    const dateKey = toIceSlideUtcDateKey(
-      new Date(start + offset * 24 * 60 * 60 * 1000)
-    )
-    expect(() => createIceSlideDailyRunDefinition(dateKey)).not.toThrow()
-  }
-})
-```
-
-Keep representative-date variation as a separate assertion; the year sweep is a no-throw content gate, not a requirement that every date be unique.
-
-- [ ] **Step 2: Run the new suite to prove red**
-
-```bash
-bun run test:run -- src/lib/games/ice-slide/daily.test.ts
-```
-
-Expected: FAIL because the new exports/materializer do not exist.
-
-- [ ] **Step 3: Extract the shared date validator and Campaign difficulty mapping**
-
-In `run.ts`:
-
-1. export the current Campaign difficulty array as `CAMPAIGN_STAGE_DIFFICULTIES` and keep Campaign output unchanged;
-2. move the existing Daily run-key date round-trip into `assertValidIceSlideUtcDateKey(dateKey)`;
-3. have the Daily branch of `assertValidIceSlideRunDefinition()` call that helper instead of keeping private duplicate calendar logic.
-
-The helper performs exact regex plus calendar round-trip. Do not add a second parser in `daily.ts`.
-
-- [ ] **Step 4: Implement `toIceSlideUtcDateKey()` and strict Daily input validation**
-
-```ts
-export function toIceSlideUtcDateKey(date: Date): string {
-  if (!Number.isFinite(date.getTime())) {
-    throw new RangeError('date must be valid')
-  }
-  const dateKey = date.toISOString().slice(0, 10)
-  assertValidIceSlideUtcDateKey(dateKey)
-  return dateKey
+for (let day = new Date('2026-01-01T00:00:00Z');
+     day <= new Date('2026-12-31T00:00:00Z');
+     day = new Date(day.getTime() + 86_400_000)) {
+  expect(() =>
+    createIceSlideDailyRunDefinition(toIceSlideUtcDateKey(day))
+  ).not.toThrow()
 }
 ```
 
-`createIceSlideDailyRunDefinition(dateKey)` begins with `assertValidIceSlideUtcDateKey(dateKey)`.
+Do not add a benchmark threshold; this is content validity.
 
-- [ ] **Step 5: Implement the exact Daily materializer**
+### Step 7: Implement `daily.ts` with the frozen algorithm
 
-Use:
+- [ ] Exact pools:
 
 ```ts
 export const ICE_SLIDE_DAILY_STAGE_POOLS = [
@@ -319,22 +264,51 @@ export const ICE_SLIDE_DAILY_STAGE_POOLS = [
 ] as const
 ```
 
-For each stage:
+- [ ] Resolve each pool entry by `ICE_SLIDE_LEVELS.findIndex(level => level.id === id)`; throw if missing. Never use `id - 1`.
+- [ ] Exact forks:
 
-1. shuffle the pool with the frozen `stage:N` / `template` forks;
-2. resolve source via `.findIndex(level => level.id === levelId)` and throw if missing;
-3. skip a source whose `campaign:<id>` template ID is already used;
-4. shuffle `getUniqueBoardTransforms(source.rows)` with `transform:${source.id}`;
-5. validate candidates with empty objectives, exact source-par band, solver cap, and prior canonical keys;
-6. select the first accepted candidate;
-7. filter feasible objectives using the frozen order and pick using the `objective` fork;
-8. materialize the frozen stage fields, compute signature, and record template/canonical identity.
+```ts
+const stageRng = rootRng.fork(`stage:${stageNumber}`)
+const templateOrder = stageRng.fork('template').shuffle(pool)
+const variantOrder = stageRng
+  .fork(`transform:${source.id}`)
+  .shuffle(getUniqueBoardTransforms(source.rows))
+```
 
-Throw a descriptive error if the finite set has no valid candidate. Do not add a fallback table or a 64-attempt loop.
+- [ ] Validate each candidate using the production quality gate with empty objectives, exact source par band, 10_000 max states, and previously accepted canonical keys.
+- [ ] Current generator-v1 content is expected to accept the first eligible candidate; retain candidate iteration as defensive content validation but do not create dependency injection solely to force its failure path.
+- [ ] Eligible objectives are filtered in exact order:
 
-Validate the complete run before returning.
+```ts
+['collect_all_crystals', 'no_falls', 'no_reset']
+```
 
-- [ ] **Step 6: Run deterministic prerequisites and Daily tests**
+- [ ] Pick with `stageRng.fork('objective')`.
+- [ ] Materialize exact metadata:
+
+```ts
+const stage = {
+  id: `daily:${dateKey}:${stageNumber}`,
+  name: source.name,
+  templateId: `campaign:${source.id}`,
+  difficulty: CAMPAIGN_STAGE_DIFFICULTIES[sourceIndex],
+  rows: variant.rows,
+  parMoves: quality.parMoves,
+  transform: variant.transform,
+  mutationIds: [],
+  objectiveIds: [bonusObjective],
+  scoreMultiplierBps: 10_000,
+  signature: '',
+}
+stage.signature = createIceSlideStageSignature(stage)
+```
+
+- [ ] Throw if the finite authored set cannot produce a stage; do not add fallback/retry infrastructure.
+- [ ] Validate the complete run before returning.
+
+### Step 8: Verify Task 1
+
+- [ ] Run:
 
 ```bash
 bun run test:run -- \
@@ -346,41 +320,44 @@ bun run test:run -- \
   src/lib/games/shared/seeded-rng.test.ts
 ```
 
-Expected: PASS including the literal golden vector and full 2026 sweep.
+Expected: PASS.
 
-- [ ] **Step 7: Commit**
+- [ ] Confirm no `Math.random`, `crypto.getRandomValues`, or `new Date()` inside materialization logic.
+
+### Step 9: Commit
+
+- [ ] Commit only Task 1 files:
 
 ```bash
 git add \
+  src/lib/games/ice-slide/run.ts \
   src/lib/games/ice-slide/daily.ts \
   src/lib/games/ice-slide/daily.test.ts \
-  src/lib/games/ice-slide/run.ts
+  src/lib/games/ice-slide/run.test.ts
 git commit -m "feat(ice-slide): materialize deterministic daily runs"
 ```
 
 ---
 
-## Task 2: Add pure objective/star rules and Daily scoring
+## Task 2: Add stage-scoped objective policy and configurable scoring
 
 **Files:**
 - Create: `src/lib/games/ice-slide/objectives.ts`
 - Create: `src/lib/games/ice-slide/objectives.test.ts`
 - Create: `src/lib/games/ice-slide/scoring.test.ts`
-- Modify: `src/lib/games/ice-slide/scoring.ts`
 - Modify: `src/lib/games/ice-slide/types.ts`
+- Modify: `src/lib/games/ice-slide/scoring.ts`
 
-**Interfaces:**
+**Produces:**
 
 ```ts
 export type IceSlidePlayableMode = 'campaign' | 'daily'
 
 export interface IceSlideObjectiveFacts {
-  parMoves: number
-  movesUsed: number
   crystalsCollected: number
   totalCrystals: number
-  falls: number
-  resets: number
+  stageFalls: number
+  stageResets: number
 }
 
 export function isIceSlideObjectiveComplete(
@@ -406,7 +383,7 @@ export interface IceSlideStageClearResult {
 }
 ```
 
-Add active-stage state fields:
+Add state fields:
 
 ```ts
 parMoves: number
@@ -415,64 +392,73 @@ levelFalls: number
 levelResets: number
 ```
 
-Change local `IceSlideCallbacks.onLevelClear` to `(result: IceSlideStageClearResult) => void`.
-
-Add:
+Change Ice Slide callback only:
 
 ```ts
-export const DAILY_SCORING_CONFIG = {
-  objectiveStarBonus: 100,
-  timeBudgetSeconds: 300,
-  timeBonusPerSec: 5,
-} as const
-
-export function dailyStageScore(params: {
-  stageNumber: number
-  parMoves: number
-  movesUsed: number
-  crystalsCollected: number
-  optionalStarsEarned: number
-}): number
-
-export function dailyTimeBonus(elapsedSeconds: number): number
+onLevelClear: (result: IceSlideStageClearResult) => void
 ```
 
-- [ ] **Step 1: Write failing objective tests**
+### Step 1: Write failing objective tests
 
-Cover:
+- [ ] Test collect-all true/false and zero-crystal false.
+- [ ] Test `no_falls` against **stageFalls** only.
+- [ ] Test `no_reset` against **stageResets** only.
+
+Example:
 
 ```ts
-expect(complete('collect_all_crystals', { totalCrystals: 2, crystalsCollected: 2 })).toBe(true)
-expect(complete('collect_all_crystals', { totalCrystals: 2, crystalsCollected: 1 })).toBe(false)
-expect(complete('collect_all_crystals', { totalCrystals: 0, crystalsCollected: 0 })).toBe(false)
-expect(complete('no_falls', { falls: 0 })).toBe(true)
-expect(complete('no_falls', { falls: 1 })).toBe(false)
-expect(complete('no_reset', { resets: 0 })).toBe(true)
-expect(complete('no_reset', { resets: 1 })).toBe(false)
+expect(isIceSlideObjectiveComplete('no_falls', {
+  crystalsCollected: 0,
+  totalCrystals: 0,
+  stageFalls: 0,
+  stageResets: 4,
+})).toBe(true)
+
+expect(isIceSlideObjectiveComplete('no_reset', {
+  crystalsCollected: 0,
+  totalCrystals: 0,
+  stageFalls: 3,
+  stageResets: 0,
+})).toBe(true)
 ```
 
-The helper used by these examples fills the remaining fact fields with valid zero/default values; do not special-case tests inside production code.
+These tests make the stage-vs-run distinction explicit.
 
-- [ ] **Step 2: Write failing scoring tests**
+### Step 2: Write failing scoring tests
+
+- [ ] Preserve current Campaign defaults:
 
 ```ts
-expect(dailyStageScore({
-  stageNumber: 2,
+expect(levelScore({
+  levelNumber: 2,
+  parMoves: 4,
+  movesUsed: 4,
+  crystalsCollected: 1,
+})).toBe(400 + 25 + 50)
+expect(timeBonus(0)).toBe(1800)
+expect(timeBonus(360)).toBe(0)
+```
+
+- [ ] Lock Daily config:
+
+```ts
+expect(levelScore({
+  levelNumber: 2,
   parMoves: 4,
   movesUsed: 4,
   crystalsCollected: 1,
   optionalStarsEarned: 2,
-})).toBe(675)
+}, DAILY_SCORING_CONFIG)).toBe(400 + 25 + 50 + 200)
 
-expect(dailyTimeBonus(0)).toBe(1500)
-expect(dailyTimeBonus(299)).toBe(5)
-expect(dailyTimeBonus(300)).toBe(0)
-expect(dailyTimeBonus(301)).toBe(0)
+expect(timeBonus(0, DAILY_SCORING_CONFIG)).toBe(1500)
+expect(timeBonus(299, DAILY_SCORING_CONFIG)).toBe(5)
+expect(timeBonus(300, DAILY_SCORING_CONFIG)).toBe(0)
+expect(timeBonus(301, DAILY_SCORING_CONFIG)).toBe(0)
 ```
 
-Also copy the current Campaign expectations for `levelScore()` and `timeBonus()` into `scoring.test.ts`, including the 360-second Campaign budget.
+### Step 3: Prove red
 
-- [ ] **Step 3: Run tests to prove red**
+- [ ] Run:
 
 ```bash
 bun run test:run -- \
@@ -480,41 +466,62 @@ bun run test:run -- \
   src/lib/games/ice-slide/scoring.test.ts
 ```
 
-Expected: FAIL because the new modules/functions do not exist.
+Expected: FAIL on missing helpers/config.
 
-- [ ] **Step 4: Implement pure objective rules and labels**
+### Step 4: Implement pure objective rules
 
-`objectives.ts` stays free of DOM, Pixi, timers, and game state. The completion switch is:
+- [ ] `objectives.ts` contains no game state/DOM/Pixi imports.
+- [ ] Implement:
 
 ```ts
 case 'collect_all_crystals':
   return facts.totalCrystals > 0 &&
     facts.crystalsCollected === facts.totalCrystals
 case 'no_falls':
-  return facts.falls === 0
+  return facts.stageFalls === 0
 case 'no_reset':
-  return facts.resets === 0
+  return facts.stageResets === 0
 ```
 
-Export labels once:
+- [ ] Add concise labels: `Collect all crystals`, `No falls`, `No resets`.
+
+### Step 5: Extend scoring once, not per mode
+
+- [ ] Add `objectiveStarBonus: 0` to existing `SCORING_CONFIG`.
+- [ ] Add:
 
 ```ts
-export const ICE_SLIDE_OBJECTIVE_LABELS = {
-  collect_all_crystals: 'Collect all crystals',
-  no_falls: 'No falls',
-  no_reset: 'No resets',
-} as const satisfies Record<IceSlideObjectiveId, string>
+export interface IceSlideModeScoringConfig {
+  objectiveStarBonus: number
+  timeBudgetSeconds: number
+  timeBonusPerSec: number
+}
+
+export const DAILY_SCORING_CONFIG: IceSlideModeScoringConfig = {
+  objectiveStarBonus: 100,
+  timeBudgetSeconds: 300,
+  timeBonusPerSec: 5,
+}
 ```
 
-- [ ] **Step 5: Add Daily scoring additively**
+- [ ] Keep `levelClearPoints()`, `moveBonus()`, and `crystalBonus()` unchanged.
+- [ ] Change `timeBonus(elapsedSeconds, config = SCORING_CONFIG)` to use the supplied time fields.
+- [ ] Add optional `optionalStarsEarned?: number` and config argument to `levelScore()`, adding only:
 
-Do not modify existing Campaign constants/functions. `dailyStageScore()` reuses `levelClearPoints()`, `moveBonus()`, and `crystalBonus()` and adds `optionalStarsEarned * 100`. `dailyTimeBonus()` mirrors Campaign time-bonus shape with a 300-second budget.
+```ts
+(params.optionalStarsEarned ?? 0) * config.objectiveStarBonus
+```
 
-- [ ] **Step 6: Extend local Ice Slide types only**
+Existing Campaign call sites remain valid without changes.
 
-Add the active-stage fields, `IceSlidePlayableMode`, and `IceSlideStageClearResult`. `IceSlideMode` remains `'campaign' | 'daily' | 'expedition'` for the materialized-run contract.
+### Step 6: Extend local types
 
-- [ ] **Step 7: Run objective/scoring/Daily suites**
+- [ ] Add playable-mode, clear-result, and active-stage state fields.
+- [ ] `getState()` will later copy `objectiveIds`; do not introduce a generic cross-game result type.
+
+### Step 7: Verify Task 2
+
+- [ ] Run:
 
 ```bash
 bun run test:run -- \
@@ -525,7 +532,9 @@ bun run test:run -- \
 
 Expected: PASS.
 
-- [ ] **Step 8: Commit**
+### Step 8: Commit
+
+- [ ] Commit:
 
 ```bash
 git add \
@@ -534,25 +543,23 @@ git add \
   src/lib/games/ice-slide/objectives.test.ts \
   src/lib/games/ice-slide/scoring.ts \
   src/lib/games/ice-slide/scoring.test.ts
-git commit -m "feat(ice-slide): add daily objectives and scoring"
+git commit -m "feat(ice-slide): add daily objectives and score config"
 ```
 
 ---
 
-## Task 3: Track attempts and apply Daily stars/scoring in `IceSlideGame`
+## Task 3: Make run/stage counters live and emit Daily stage results
 
 **Files:**
 - Modify: `src/lib/games/ice-slide/test-fixtures.ts`
 - Modify: `src/lib/games/ice-slide/game.ts`
 - Modify: `src/lib/games/ice-slide/game.test.ts`
 - Modify: `src/lib/games/ice-slide/game.hazard.test.ts`
-- Update only other Ice Slide tests that compile against the changed `onLevelClear` payload.
+- Update other Ice Slide tests only where the `onLevelClear` payload type requires it.
 
-**Consumes:** `dailyStageScore()`, `dailyTimeBonus()`, `isIceSlideObjectiveComplete()`, `IceSlideStageClearResult`.
+### Step 1: Add a valid five-stage Daily test fixture
 
-- [ ] **Step 1: Add a valid Daily test-run fixture**
-
-Add:
+- [ ] Add:
 
 ```ts
 export function createTestDailyRun(
@@ -561,11 +568,11 @@ export function createTestDailyRun(
 ): IceSlideRunDefinition
 ```
 
-Use `ICE_SLIDE_DAILY_GENERATOR_VERSION`, `ICE_SLIDE_RULESET_VERSION`, valid Daily seed/key shape, and `createIceSlideStageSignature()`; do not hand-copy version numbers.
+Use `ICE_SLIDE_DAILY_GENERATOR_VERSION`, `ICE_SLIDE_RULESET_VERSION`, correct Daily key/seed, and real stage signatures. Do not hand-copy version numbers.
 
-- [ ] **Step 2: Write failing manual/hazard counter tests**
+### Step 2: Write counter red tests
 
-Manual Reset:
+- [ ] Manual Reset:
 
 ```ts
 expect(after.resets).toBe(before.resets + 1)
@@ -574,7 +581,7 @@ expect(after.levelFalls).toBe(0)
 expect(after.levelMoves).toBe(0)
 ```
 
-Hazard:
+- [ ] Hazard:
 
 ```ts
 expect(after.falls).toBe(before.falls + 1)
@@ -584,42 +591,44 @@ expect(after.levelResets).toBe(1)
 expect(after.levelMoves).toBe(1)
 ```
 
-After a normal stage advance, assert per-stage counters reset to zero while cumulative counters remain.
+- [ ] Normal stage advance resets `levelFalls` / `levelResets` while cumulative fields remain.
 
-- [ ] **Step 3: Write failing Daily clear-result/star tests**
+### Step 3: Write the cross-stage objective regression
 
-Use explicit Daily stages to cover:
+- [ ] Use a two-stage/five-stage Daily fixture where stage 1 contains a hazard and stage 2 has `no_falls`.
+- [ ] Enter the stage-1 hazard, then clear stage 1, then clear stage 2 cleanly.
+- [ ] Assert stage-2 bonus is earned despite cumulative `state.falls > 0`.
+- [ ] Add the analogous manual-reset case for `no_reset` if the fixture is cheap; at minimum one test must prove previous-stage mistakes do not poison later stage facts.
 
-- exact-par + `no_reset` => Clear/Efficient/bonus all true, `earnedCount === 3`;
-- over-par => Efficient false;
-- manual Reset before clear => `no_reset` false;
-- hazard before later clear => `no_falls` false;
-- collect-all true/false;
-- cumulative `state.starsEarned` equals Daily result earned counts.
+### Step 4: Write Daily stage-result/scoring tests
 
-Assert `scoreGained` from callback result rather than private state.
+- [ ] Exact-par + clean bonus => Clear/Efficient/bonus earned, `earnedCount = 3`.
+- [ ] Over-par => Efficient false.
+- [ ] Reset this stage => `no_reset` false.
+- [ ] Hazard this stage => `no_falls` false.
+- [ ] Collect-all true/false based on source-stage crystal count.
+- [ ] Cumulative `state.starsEarned` equals Daily earned counts.
+- [ ] `scoreGained` matches `levelScore(..., DAILY_SCORING_CONFIG)`.
 
-- [ ] **Step 4: Lock final callback order and completion bonus**
+### Step 5: Write completion/callback-order tests
 
-Add a regression test:
-
-```ts
-const events: string[] = []
-const game = new IceSlideGame({
-  onLevelClear: () => events.push('level-clear'),
-  onWin: () => events.push('win'),
-})
-```
-
-Complete the final stage and assert the final entries are:
+- [ ] Complete a five-stage Daily fixture under fake timers and verify final completion bonus uses:
 
 ```ts
-expect(events.slice(-2)).toEqual(['level-clear', 'win'])
+timeBonus(elapsedSeconds, DAILY_SCORING_CONFIG)
 ```
 
-With fake timers, complete a five-stage Daily run and assert final score includes `dailyTimeBonus(elapsedSeconds)`. Preserve existing Campaign tests and assert Campaign `starsEarned === 0`.
+- [ ] Lock final callback order:
 
-- [ ] **Step 5: Run focused tests to prove red**
+```ts
+expect(events).toEqual(['level-clear', 'win'])
+```
+
+- [ ] Campaign still gets `starsEarned === 0`, existing scoring, and existing final callback order.
+
+### Step 6: Prove red
+
+- [ ] Run:
 
 ```bash
 bun run test:run -- \
@@ -627,11 +636,11 @@ bun run test:run -- \
   src/lib/games/ice-slide/game.hazard.test.ts
 ```
 
-Expected: FAIL on missing counter/result behavior.
+Expected: FAIL on counters/results/config use.
 
-- [ ] **Step 6: Populate active-stage metadata in idle/load paths**
+### Step 7: Implement active-stage state
 
-Idle:
+- [ ] Idle fields:
 
 ```ts
 parMoves: 0,
@@ -640,59 +649,59 @@ levelFalls: 0,
 levelResets: 0,
 ```
 
-Loaded stage:
+- [ ] Loaded stage:
 
 ```ts
 parMoves: stage.parMoves,
 objectiveIds: [...stage.objectiveIds],
 ```
 
-`getState()` clones `objectiveIds`.
+- [ ] `getState()` copies `objectiveIds`.
+- [ ] Add one `preserveLevelAttemptStats` reload option. Reset/hazard same-stage reloads use it; normal stage advance does not.
+- [ ] Keep existing independent `preserveLevelMoves`: manual Reset resets moves; hazard preserves the hazard move.
 
-Add `preserveLevelAttemptStats` to `loadLevel()` options. Manual Reset and hazard reload preserve these counters; normal advance resets them. Keep `preserveLevelMoves` independent so manual Reset clears level moves and hazard keeps its committed hazard move.
+### Step 8: Increment counters exactly once
 
-- [ ] **Step 7: Increment event counters exactly once**
+- [ ] Manual Reset increments cumulative/stage reset counters before reload.
+- [ ] Hazard increments cumulative/stage fall and reset counters before reload.
+- [ ] Do not derive counter changes from callbacks/renderer state.
 
-Before manual reload:
+### Step 9: Build one clear-result object
+
+- [ ] Reuse existing physics helpers for source crystal count:
 
 ```ts
-this.state.resets += 1
-this.state.levelResets += 1
+const totalCrystals = countCrystals(parseGrid(stage))
 ```
 
-Before hazard reload:
-
-```ts
-this.state.falls += 1
-this.state.resets += 1
-this.state.levelFalls += 1
-this.state.levelResets += 1
-```
-
-Do not infer counters from callbacks/rendering.
-
-- [ ] **Step 8: Build one completed-stage result in `clearLevel()`**
-
-Count total `C` glyphs from the materialized stage rows. For Daily, calculate:
+- [ ] Compute Efficient exactly once:
 
 ```ts
 const efficient = this.state.levelMoves <= stage.parMoves
-const bonusId = stage.objectiveIds[0]
-const bonusEarned = isIceSlideObjectiveComplete(bonusId, facts)
-const optionalStarsEarned = Number(efficient) + Number(bonusEarned)
-const earnedCount = 1 + optionalStarsEarned
 ```
 
-Use `dailyStageScore()` only for Daily, otherwise existing `levelScore()`. Increment cumulative `starsEarned` only for Daily.
+Use the same boolean for existing `perfectLevels` and Daily Efficient star.
 
-Preserve current progression/callback order:
+- [ ] For Daily, evaluate the single bonus objective using:
 
-- non-final: prepare next stage, then `onLevelClear(result)`;
-- final: apply mode-specific time bonus, set won/stop timer, then `onLevelClear(result)`, then `onWin(finalScore)`.
+```ts
+{
+  crystalsCollected: this.state.levelCrystalsCollected,
+  totalCrystals,
+  stageFalls: this.state.levelFalls,
+  stageResets: this.state.levelResets,
+}
+```
 
-Do not add a paused-stage engine state.
+- [ ] `optionalStarsEarned = Number(efficient) + Number(bonusEarned)`.
+- [ ] Campaign calls default `levelScore()` and never accumulates Daily stars.
+- [ ] Daily calls `levelScore({... optionalStarsEarned}, DAILY_SCORING_CONFIG)` and accumulates all three earned stars including Clear.
+- [ ] Final Daily time bonus uses `timeBonus(..., DAILY_SCORING_CONFIG)`; Campaign uses default.
+- [ ] Preserve non-final immediate load and final callback order.
 
-- [ ] **Step 9: Run complete Ice Slide unit suite**
+### Step 10: Verify Task 3
+
+- [ ] Run:
 
 ```bash
 bun run test:run -- src/lib/games/ice-slide
@@ -700,30 +709,26 @@ bun run test:run -- src/lib/games/ice-slide
 
 Expected: PASS.
 
-- [ ] **Step 10: Commit**
+### Step 11: Commit
 
-Stage explicit changed paths only after inspecting `git diff --name-only`:
+- [ ] Stage exact changed files; inspect staged names before committing:
 
 ```bash
-git add \
-  src/lib/games/ice-slide/test-fixtures.ts \
-  src/lib/games/ice-slide/game.ts \
-  src/lib/games/ice-slide/game.test.ts \
-  src/lib/games/ice-slide/game.hazard.test.ts
+git diff --cached --name-only
 git commit -m "feat(ice-slide): track daily stage results"
 ```
 
-If another Ice Slide test required the callback signature migration, add that exact path to the commit instead of globbing every test.
-
 ---
 
-## Task 4: Integrate fresh/retry lifecycle, Daily HUD, overlay gating, and completed submission
+## Task 4: Integrate Daily lifecycle, HUD, End, and score response handling
 
 **Files:**
 - Modify: `src/lib/games/ice-slide/init.ts`
 - Modify: `src/lib/games/ice-slide/init.test.ts`
+- Modify: `src/lib/services/scoreService.ts`
+- Modify: `src/lib/services/scoreService.test.ts`
 
-**Interfaces:**
+**Produces:**
 
 ```ts
 export interface IceSlideHandle {
@@ -736,11 +741,9 @@ export interface IceSlideHandle {
 }
 ```
 
-Consumes `createIceSlideDailyRunDefinition()`, `toIceSlideUtcDateKey()`, `cloneIceSlideRunDefinition()`, `ICE_SLIDE_OBJECTIVE_LABELS`, Better Auth client, and existing contextual `saveGameScore()` options.
+### Step 1: Extend JSDOM fixture
 
-- [ ] **Step 1: Extend the JSDOM fixture and mocks**
-
-Add exact IDs:
+- [ ] Add the IDs `init.ts` will own:
 
 ```text
 #daily-meta
@@ -757,60 +760,75 @@ Add exact IDs:
 #stage-clear-efficient
 #stage-clear-bonus
 #stage-clear-continue-btn
+#daily-final-stage-result
+#daily-final-clear
+#daily-final-efficient
+#daily-final-bonus
 ```
 
-Retain `#start-btn`, `#end-btn`, shared result overlay IDs, and score/HUD IDs.
+No auth-client mock is needed.
 
-Mock `@/lib/auth-client` with `authClient.getSession = vi.fn()` and default existing score tests to an authenticated session.
+### Step 2: Write fresh/retry/rollover red tests
 
-Reuse/adapt the existing test-only BFS path helper from `init.test.ts` so it accepts a materialized `{ id, rows }` stage. Do not add a production path-returning solver API solely for tests.
-
-- [ ] **Step 2: Write failing fresh/retry/UTC rollover tests**
+- [ ] Use fake time:
 
 ```ts
 vi.useFakeTimers()
 vi.setSystemTime(new Date('2026-08-12T23:59:59Z'))
 await handle.start('daily')
-const first = handle.getGame()!.getState()
+const runKey = handle.getGame()!.getState().runKey
+const signatures = handle.getGame()!.getState().stageSignatures
 
 vi.setSystemTime(new Date('2026-08-13T00:00:01Z'))
 await handle.playAgain()
-const retry = handle.getGame()!.getState()
-expect(retry.runKey).toBe(first.runKey)
-expect(retry.stageSignatures).toEqual(first.stageSignatures)
+expect(handle.getGame()!.getState().runKey).toBe(runKey)
+expect(handle.getGame()!.getState().stageSignatures).toEqual(signatures)
 
 await handle.start('daily')
 expect(handle.getGame()!.getState().runKey).toContain('2026-08-13')
 ```
 
-Also assert `start()` without mode starts Campaign.
+- [ ] `start()` with no mode remains Campaign.
 
-- [ ] **Step 3: Write failing Daily HUD tests**
+### Step 3: Write HUD red tests
 
-With fixed time `2026-08-12T23:59:59Z`, after fresh Daily Start assert:
+- [ ] Daily Start immediately shows `#daily-meta` and sets:
+  - exact captured `#daily-date`;
+  - reset copy for next UTC day;
+  - `Stage 1 / 5`;
+  - Efficient copy containing current `parMoves`;
+  - non-empty seeded bonus label.
+- [ ] Campaign Start hides `#daily-meta`.
+- [ ] After non-final Continue, HUD reflects the next stage before another accepted move.
 
-```ts
-expect(document.querySelector('#daily-meta')).not.toHaveClass('hidden')
-expect(document.querySelector('#daily-date')).toHaveTextContent('2026-08-12')
-expect(document.querySelector('#daily-reset')).toHaveTextContent('00:00 UTC')
-expect(document.querySelector('#daily-reset')).toHaveTextContent('2026-08-13')
-expect(document.querySelector('#daily-stage-progress')).toHaveTextContent('Stage 1 / 5')
-expect(document.querySelector('#daily-objective-clear')).toHaveTextContent('Clear')
-expect(document.querySelector('#daily-objective-efficient')).toHaveTextContent('≤')
-expect(document.querySelector('#daily-objective-bonus')?.textContent).not.toBe('')
-```
+### Step 4: Write non-final overlay/input-gate tests
 
-Start Campaign and assert `#daily-meta` is hidden.
+- [ ] Clear a non-final Daily stage and assert stage overlay visible/populated.
+- [ ] Keyboard move while overlay visible does nothing.
+- [ ] Pointer/swipe while overlay visible does nothing.
+- [ ] Reset while overlay visible does nothing.
+- [ ] Continue hides overlay and unlocks movement.
+- [ ] Cleanup/fail/start clears stale overlay/lock.
 
-Clear the first Daily stage with the test-only path helper, click Continue, and assert stage progress becomes `Stage 2 / 5` and Efficient/bonus text is re-derived from the new `getState()` before further movement.
+### Step 5: Write Daily End tests
 
-- [ ] **Step 4: Write failing submission-boundary tests**
+- [ ] Immediately after a fresh zero-score Daily Start, `handle.stop()`:
+  - stops the game;
+  - shows `RUN ENDED` result overlay with score 0;
+  - restores Start/End controls;
+  - does **not** call `saveGameScore()`.
+- [ ] End while a non-final stage-clear overlay is open clears that overlay and shows `RUN ENDED`, still without submission.
+- [ ] Stored Daily retry identity survives End.
+- [ ] Campaign partial stop retains current positive-score submission semantics and remains unscoped.
 
-Cover:
+### Step 6: Write final-result/submission red tests
 
-- Campaign partial stop still calls `saveGameScore()` unscoped.
-- Daily partial stop never calls it.
-- Completed Daily calls it exactly once only after final Continue with:
+- [ ] Complete a Daily run and assert:
+  - mid-run stage-clear overlay is not left visible for the final stage;
+  - final result overlay appears immediately from `onWin`;
+  - final Daily star rows are populated;
+  - `saveGameScore()` is called exactly once without requiring a Continue click;
+  - options contain exact Daily context.
 
 ```ts
 expect(options.context).toEqual({
@@ -820,166 +838,126 @@ expect(options.context).toEqual({
 })
 ```
 
-- confirmed anonymous `{ data: null, error: null }` completion stays local;
-- auth-check error does not silently discard the completed result; the score endpoint path remains authoritative.
+### Step 7: Add structured unauthenticated score result tests
 
-Capture the run guard before the auth await and test stale completion suppression.
+- [ ] In `scoreService.test.ts`, mock a 401 response and assert:
 
-- [ ] **Step 5: Write failing overlay/input/End lifecycle tests**
+```ts
+expect(await submitScore(scoreData)).toMatchObject({
+  success: false,
+  code: 'UNAUTHENTICATED',
+  error: 'You must be logged in to save scores',
+})
+```
 
-For a non-final Daily clear:
+- [ ] Add a `saveGameScore()` test proving the structured result is forwarded as the second error-callback argument.
+- [ ] Existing one-argument error callbacks remain valid and existing `SCORE_CONTEXT_UNAVAILABLE` behavior remains covered.
 
-- stage overlay visible;
-- result text populated;
-- keyboard and swipe do not move while locked;
-- Reset no-ops while locked;
-- Continue hides overlay, re-syncs HUD, and permits movement;
-- calling `handle.stop()` while that non-final overlay is open hides it, stops locally, shows `RUN ENDED`, and never saves a Daily score.
+### Step 8: Prove Task 4 red
 
-For the final Daily clear:
-
-- `onLevelClear` overlay remains visible after the engine's immediately following `onWin` callback;
-- mission-complete overlay is still hidden;
-- `saveGameScore()` has not run;
-- End control is hidden/disabled while final Continue is pending;
-- programmatic `handle.stop()` is a no-op and leaves final stage overlay visible;
-- final Continue hides stage overlay, shows mission-complete, invokes external `onWin`, and initiates submission exactly once.
-
-Add fail/start/cleanup cases proving locks, overlays, and `pendingDailyWinScore` cannot leak into a newer run.
-
-- [ ] **Step 6: Run `init.test.ts` to prove red**
+- [ ] Run:
 
 ```bash
-bun run test:run -- src/lib/games/ice-slide/init.test.ts
+bun run test:run -- \
+  src/lib/games/ice-slide/init.test.ts \
+  src/lib/services/scoreService.test.ts
 ```
 
-Expected: FAIL on old handle/HUD/submission/overlay behavior.
+Expected: FAIL on old lifecycle/error-channel behavior.
 
-- [ ] **Step 7: Refactor startup around one `startRun()` closure**
+### Step 9: Extend `scoreService` additively
 
-Keep the existing teardown/game construction/renderer sequence in one local helper.
-
-Fresh start:
+- [ ] Change:
 
 ```ts
-start: async (mode = 'campaign') => {
-  if (mode === 'daily') {
-    const dateKey = toIceSlideUtcDateKey(new Date())
-    const run = createIceSlideDailyRunDefinition(dateKey)
-    lastStartedMode = 'daily'
-    lastDailyDateKey = dateKey
-    lastDailyRun = cloneIceSlideRunDefinition(run)
-    await startRun(run)
-    return
-  }
-
-  lastStartedMode = 'campaign'
-  lastDailyDateKey = null
-  lastDailyRun = null
-  await startRun()
-}
+export type ScoreSubmissionPublicErrorCode =
+  | 'SCORE_CONTEXT_UNAVAILABLE'
+  | 'UNAUTHENTICATED'
 ```
 
-Retry:
+- [ ] For `response.status === 401`, return `code: 'UNAUTHENTICATED'` regardless of body.
+- [ ] Change the optional callback type to:
 
 ```ts
-playAgain: async () => {
-  if (lastStartedMode === 'daily' && lastDailyRun && lastDailyDateKey) {
-    await startRun(cloneIceSlideRunDefinition(lastDailyRun))
-    return
-  }
-  await startRun()
-}
+onError?: (error: string, result?: ScoreSubmissionResult) => void
 ```
 
-`startRun()` clears input locks, stage overlay, pending win, and stale result state before starting.
-
-- [ ] **Step 8: Extend `syncHud()` with mode-specific Daily synchronization**
-
-Keep current generic score/level/moves/crystals/time/name updates.
-
-Then:
+- [ ] For a completed unsuccessful response call:
 
 ```ts
-if (state.mode !== 'daily' || !lastDailyDateKey) {
-  dailyMeta?.classList.add('hidden')
-  return
-}
-
-dailyMeta?.classList.remove('hidden')
-setText('daily-date', lastDailyDateKey)
-setText('daily-stage-progress', `Stage ${state.levelIndex + 1} / ${state.stagesTotal}`)
-setText('daily-objective-clear', 'Clear — reach the goal')
-setText('daily-objective-efficient', `Efficient — ≤ ${state.parMoves} moves`)
-setText(
-  'daily-objective-bonus',
-  state.objectiveIds[0]
-    ? ICE_SLIDE_OBJECTIVE_LABELS[state.objectiveIds[0]]
-    : 'Bonus objective unavailable'
-)
+onError?.(result.error || 'Failed to save score', result)
 ```
 
-Derive the next UTC date from the already validated captured key and format `#daily-reset` as `Resets at 00:00 UTC · Next: YYYY-MM-DD`. Do not create a live countdown.
+- [ ] Network/exception path still calls only the message; existing callers need no edits.
 
-Call `syncHud()` during initial start, normal move paths, and again on Continue after the next stage was already loaded.
+### Step 10: Refactor `init.ts` startup around materialized runs
 
-- [ ] **Step 9: Add one shared movement gate**
+- [ ] Add one internal `startRun(run?: IceSlideRunDefinition)` containing current teardown/game/renderer start logic.
+- [ ] Fresh Daily captures key, materializes run, stores defensive retry copy/key, then starts it.
+- [ ] Play Again starts cloned stored Daily or default Campaign.
+- [ ] Clear non-final overlay/lock at every start.
+
+### Step 11: Extend `syncHud()`
+
+- [ ] Preserve existing common HUD writes.
+- [ ] Campaign hides `#daily-meta`.
+- [ ] Daily shows/fills date/reset/stage/Clear/Efficient/bonus using captured date key, `state.parMoves`, and `ICE_SLIDE_OBJECTIVE_LABELS`.
+- [ ] Call after initial start, existing move/render paths, and Continue.
+
+### Step 12: Add one shared interaction predicate
+
+- [ ] Use:
 
 ```ts
 const canAcceptMove = () =>
   !!game && game.getState().status === 'playing' && !inputLocked
 ```
 
-Keyboard and pointer/swipe both use it. `resetLevel()` no-ops while `inputLocked`.
+Keyboard and swipe both call it; Reset also respects `inputLocked`.
 
-- [ ] **Step 10: Preserve engine callback order but defer Daily final side effects**
+### Step 13: Handle non-final vs final clear separately
 
-Daily `onLevelClear(result)`:
+- [ ] In Daily `onLevelClear(result)`:
+  - always forward external callback;
+  - if current state is `playing`, show/lock non-final stage overlay;
+  - if current state is `won`, populate the hidden Daily final-stage result block and do **not** show the mid-run overlay.
+- [ ] Campaign never shows Daily stage/result rows.
 
-- set lock;
-- populate/show stage overlay;
-- focus Continue;
-- if game is already `won`, hide/disable End while final Continue is pending.
+### Step 14: Keep final `onWin` immediate
 
-Daily `onWin(finalScore)`:
+- [ ] Daily final `onWin` follows the existing result path immediately:
+  - external `callbacks.onWin`;
+  - reset buttons;
+  - `MISSION COMPLETE` overlay;
+  - mode-aware score submission;
+  - HUD sync.
+- [ ] No `pendingDailyWinScore`, final Continue, or inert-End state.
+
+### Step 15: Make submission mode-aware without auth preflight
+
+- [ ] Campaign keeps the existing unscoped helper call.
+- [ ] Daily completed run passes game data + exact contextual options.
+- [ ] Daily error callback:
 
 ```ts
-pendingDailyWinScore = finalScore
-return
-```
-
-It does not show mission-complete, reset controls, invoke external `callbacks.onWin`, authenticate, or submit.
-
-Final Continue performs those actions once. Campaign `onWin` keeps existing immediate behavior.
-
-- [ ] **Step 11: Make `stop()` overlay-aware**
-
-Before ordinary stop logic:
-
-```ts
-if (pendingDailyWinScore !== null) {
-  return
+(error, result) => {
+  if (result?.code === 'UNAUTHENTICATED') {
+    return
+  }
+  callbacks.onError?.('Score not saved', error)
 }
 ```
 
-When a non-final Daily stage overlay is active:
+- [ ] Keep existing `isStale` run-guard option; do not add `authClient.getSession()` or a second staleness check.
 
-- hide it;
-- clear lock/result state;
-- stop the playing game;
-- reset controls;
-- show local `RUN ENDED` using current score;
-- do not call Daily `submitScore()`.
+### Step 16: Make `stop()` mode-aware
 
-Ordinary Campaign stop keeps its current positive-score partial submission behavior. Ordinary Daily stop never submits.
+- [ ] Daily playing run: clear non-final overlay/lock, stop, reset buttons, show local `RUN ENDED` even at score 0, never submit.
+- [ ] Campaign behavior remains current: positive-score playing stop submits and shows result; zero-score stop does not invent new Campaign behavior.
 
-- [ ] **Step 12: Make Daily submission async/auth-aware**
+### Step 17: Verify Task 4
 
-Only final Continue calls the Daily submission helper. Require `gameData.solved === true`, capture run guard before `authClient.getSession()`, re-check staleness afterward, skip confirmed anonymous, and otherwise call existing `saveGameScore()` with exact contextual options.
-
-Do not add HPA-488 server validation.
-
-- [ ] **Step 13: Run integration tests**
+- [ ] Run:
 
 ```bash
 bun run test:run -- \
@@ -990,26 +968,30 @@ bun run test:run -- \
 
 Expected: PASS.
 
-- [ ] **Step 14: Commit**
+### Step 18: Commit
+
+- [ ] Commit:
 
 ```bash
-git add src/lib/games/ice-slide/init.ts src/lib/games/ice-slide/init.test.ts
+git add \
+  src/lib/games/ice-slide/init.ts \
+  src/lib/games/ice-slide/init.test.ts \
+  src/lib/services/scoreService.ts \
+  src/lib/services/scoreService.test.ts
 git commit -m "feat(ice-slide): integrate daily run lifecycle"
 ```
 
 ---
 
-## Task 5: Add compact Daily page UX and freeze page glue
+## Task 5: Add compact Daily page UX and stable markup contracts
 
 **Files:**
 - Modify: `src/pages/ice-slide/index.astro`
 - Modify: `src/pages/game-board-markup.test.ts`
 
-**Consumes:** `IceSlideHandle.start(mode)` and `IceSlideHandle.playAgain()`.
+### Step 1: Add failing stable markup assertions
 
-- [ ] **Step 1: Add failing markup/wiring assertions**
-
-Load Ice Slide markup in `game-board-markup.test.ts` and assert:
+- [ ] Load Ice Slide source once and assert only durable element contracts:
 
 ```ts
 expect(iceSlideMarkup).toContain('id="ice-slide-mode-selector"')
@@ -1022,24 +1004,25 @@ expect(iceSlideMarkup).toContain('id="daily-reset"')
 expect(iceSlideMarkup).toContain('id="daily-stage-progress"')
 expect(iceSlideMarkup).toContain('id="stage-clear-overlay"')
 expect(iceSlideMarkup).toContain('id="stage-clear-continue-btn"')
+expect(iceSlideMarkup).toContain('id="daily-final-stage-result"')
 expect(iceSlideMarkup).toContain('id="change-mode-btn"')
-expect(iceSlideMarkup).toContain('gameHandle?.playAgain()')
-expect(iceSlideMarkup).toContain('Daily adds +100')
 ```
 
-The Playwright test in Task 6 is still authoritative for user behavior; this static check makes accidental reversion to `start()` obvious during page editing.
+Do **not** assert source-code text such as `gameHandle?.playAgain()` or exact explanatory copy. Playwright owns behavior; copy is not a contract.
 
-- [ ] **Step 2: Run markup test to prove red**
+### Step 2: Prove red
+
+- [ ] Run:
 
 ```bash
 bun run test:run -- src/pages/game-board-markup.test.ts
 ```
 
-Expected: FAIL on missing Daily markup/wiring.
+Expected: FAIL on missing Daily markup.
 
-- [ ] **Step 3: Add semantic two-option selector**
+### Step 3: Add the page-local mode selector
 
-Use a page-local fieldset/radios:
+- [ ] Add a semantic fieldset/radios above the game board:
 
 ```html
 <fieldset id="ice-slide-mode-selector">
@@ -1055,67 +1038,56 @@ Use a page-local fieldset/radios:
 </fieldset>
 ```
 
-Style with existing Tailwind/Cetus classes; do not create a reusable mode component.
+Use existing Tailwind/Cetus classes. Do not override GamePage's controls slot or create a shared mode component.
 
-- [ ] **Step 4: Add Daily HUD and stage-clear markup**
+### Step 4: Add Daily HUD and non-final overlay markup
 
-Add hidden `#daily-meta` with exact Task 4 IDs. Add an opaque page-local `#stage-clear-overlay` inside the board wrapper with result rows and a real Continue button.
+- [ ] Add hidden `#daily-meta` with the exact Task 4 IDs.
+- [ ] Add opaque page-local `#stage-clear-overlay` with completed-stage title/score/star rows and a real Continue button.
+- [ ] `init.ts` populates dynamic values; page script does not duplicate objective policy.
 
-Use text/symbol state in addition to color. `init.ts`, not page script, populates the live Daily values.
+### Step 5: Reuse `final-stats` for final Daily stars + Change Mode
 
-- [ ] **Step 5: Add Change Mode through existing `final-stats` slot**
+- [ ] Add hidden `#daily-final-stage-result` with Clear/Efficient/bonus rows.
+- [ ] Add secondary `#change-mode-btn`.
+- [ ] Do not modify shared `GameOverlay`/`GamePage` APIs.
 
-Add a secondary `#change-mode-btn`. Do not modify shared `GameOverlay` or `GamePage` APIs.
+### Step 6: Wire query preselection and Start
 
-- [ ] **Step 6: Wire URL preselection and fresh Start**
+- [ ] Parse once:
 
 ```ts
 const requestedMode = new URLSearchParams(window.location.search).get('mode')
-const selectedMode = requestedMode === 'daily' ? 'daily' : 'campaign'
+const selectedMode: IceSlidePlayableMode =
+  requestedMode === 'daily' ? 'daily' : 'campaign'
 ```
 
-Set the radio only; do not auto-start.
+- [ ] Select the corresponding radio; no auto-start.
+- [ ] Start reads checked mode and calls `gameHandle.start(mode)`.
+- [ ] Disable mode controls while active.
 
-Start reads the checked radio and calls `gameHandle.start(mode)`. Disable mode radios while active.
+### Step 7: Wire Play Again and Change Mode
 
-- [ ] **Step 7: Wire Play Again to retry and Change Mode to idle**
+- [ ] Play Again hides current result overlay and calls `gameHandle.playAgain()`.
+- [ ] Change Mode:
+  - hides result overlay;
+  - shows pre-run status prompt;
+  - restores Start visible / End hidden;
+  - re-enables mode radios;
+  - does not call `start()` or `playAgain()`.
 
-Replace the current Play Again call to `start()` with:
+### Step 8: Keep page End simple
 
-```ts
-playAgainBtn.addEventListener('click', async () => {
-  overlay.classList.add('hidden')
-  await gameHandle?.playAgain()
-})
-```
+- [ ] Existing End click still delegates to `gameHandle.stop()`; Daily-specific zero-score/result logic remains in `init.ts`.
 
-Change Mode:
+### Step 9: Add concise Daily instructions
 
-- hides result overlay;
-- shows pre-run status prompt;
-- re-enables mode radios;
-- restores Start visible / End hidden;
-- does not call `start()` or `playAgain()`.
+- [ ] Explain five UTC stages, Clear/Efficient/seeded bonus stars, +100 optional-star bonus, 5:00 completion budget, and Play Again retry identity.
+- [ ] Do not add leaderboard UI/copy before HPA-488.
 
-The next Start is fresh and can therefore capture a post-rollover Daily date.
+### Step 10: Verify Task 5
 
-- [ ] **Step 8: Keep End behavior compatible with Task 4**
-
-The normal End click still calls `gameHandle.stop()`. Final-stage Continue hides/disables End through `init.ts`, preventing a user click while completion is pending. The page does not duplicate overlay-state logic.
-
-- [ ] **Step 9: Add concise Daily instructions/scoring copy**
-
-Add only:
-
-- five stages shared per UTC date;
-- Clear/Efficient/seeded bonus stars;
-- +100 for Efficient/bonus star;
-- 5:00 Daily completion budget;
-- Play Again retries the same Daily run.
-
-No leaderboard copy before HPA-488.
-
-- [ ] **Step 10: Run page + init tests**
+- [ ] Run:
 
 ```bash
 bun run test:run -- \
@@ -1125,7 +1097,9 @@ bun run test:run -- \
 
 Expected: PASS.
 
-- [ ] **Step 11: Commit**
+### Step 11: Commit
+
+- [ ] Commit:
 
 ```bash
 git add src/pages/ice-slide/index.astro src/pages/game-board-markup.test.ts
@@ -1134,22 +1108,28 @@ git commit -m "feat(ice-slide): add daily mode interface"
 
 ---
 
-## Task 6: Lock page-level rollover/retry behavior and run full verification
+## Task 6: Lock real page retry behavior and run full verification
 
 **Files:**
 - Modify: `e2e/games/play-coverage.spec.ts`
-- Modify only tests needed for final coverage; do not add production code solely to make coverage easier.
+- Modify only tests required by final coverage/behavior; do not add production code for coverage convenience.
 
-- [ ] **Step 1: Preserve the Campaign smoke**
+### Step 1: Preserve Campaign smoke
 
-Keep `/ice-slide` as Campaign default. Assert Campaign radio selected, Start works, `ArrowDown` still clears First Frost to level 2, and End keeps current result behavior.
+- [ ] Keep `/ice-slide` as Campaign default.
+- [ ] Assert Campaign radio selected before Start.
+- [ ] Preserve the existing `ArrowDown` First Frost flow to level 2 and positive score.
+- [ ] End still shows Campaign result as today.
 
-- [ ] **Step 2: Add Daily query/HUD smoke**
+### Step 2: Add Daily query/HUD smoke
+
+- [ ] Add:
 
 ```ts
 test('preselects Daily and exposes objectives before the first move', async ({ page }) => {
   await page.clock.setFixedTime(new Date('2026-08-12T20:00:00Z'))
   await page.goto('/ice-slide?mode=daily')
+
   await expect(page.locator('input[value="daily"]')).toBeChecked()
   await startGameWhenReady(page)
   await expect(page.locator('#daily-meta')).toBeVisible()
@@ -1161,18 +1141,17 @@ test('preselects Daily and exposes objectives before the first move', async ({ p
 })
 ```
 
-- [ ] **Step 3: Add the page-glue UTC rollover / Play Again / Change Mode path**
+### Step 3: Add actual Play Again rollover + Change Mode path
 
-This test must catch the existing bug where page Play Again calls fresh `start()`:
+Because Daily End always shows local results even at zero score, no transform-specific move is needed:
 
 ```ts
-test('Play Again preserves Daily identity across UTC rollover and Change Mode stays idle', async ({ page }) => {
+test('Play Again preserves Daily identity across rollover and Change Mode stays idle', async ({ page }) => {
   await page.clock.setFixedTime(new Date('2026-08-12T23:59:59Z'))
   await page.goto('/ice-slide?mode=daily')
   await startGameWhenReady(page)
   await expect(page.locator('#daily-date')).toHaveText('2026-08-12')
 
-  // Partial Daily End is local but keeps the retry snapshot.
   await page.locator('#end-btn').click()
   await expect(page.locator('#game-over-overlay')).not.toHaveClass(/hidden/)
 
@@ -1182,7 +1161,6 @@ test('Play Again preserves Daily identity across UTC rollover and Change Mode st
   await expect(page.locator('#end-btn')).toBeVisible()
 
   await page.locator('#end-btn').click()
-  await expect(page.locator('#game-over-overlay')).not.toHaveClass(/hidden/)
   await page.locator('#change-mode-btn').click()
 
   await expect(page.locator('#ice-slide-mode-selector input')).toBeEnabled()
@@ -1192,13 +1170,16 @@ test('Play Again preserves Daily identity across UTC rollover and Change Mode st
 })
 ```
 
-`page.clock.setFixedTime()` is called before navigation and changed after the first End so browser `new Date()` crosses UTC midnight without coupling the test to real wall time.
+This is authoritative for the page glue; static markup tests do not assert the implementation expression used to call Play Again.
 
-- [ ] **Step 4: Add malformed/unavailable mode fallback coverage**
+### Step 4: Add malformed/unavailable mode fallback
 
-Navigate to both `/ice-slide?mode=expedition` and `/ice-slide?mode=not-a-mode`. Assert Campaign selected, Start visible, and no run auto-started.
+- [ ] Visit `/ice-slide?mode=expedition` and `/ice-slide?mode=not-a-mode`.
+- [ ] Assert Campaign radio selected, Start visible, status prompt visible, and no auto-start.
 
-- [ ] **Step 5: Run focused Ice Slide E2E**
+### Step 5: Run focused E2E
+
+- [ ] Run:
 
 ```bash
 bun run test:e2e -- e2e/games/play-coverage.spec.ts --grep "Ice Slide"
@@ -1206,15 +1187,22 @@ bun run test:e2e -- e2e/games/play-coverage.spec.ts --grep "Ice Slide"
 
 Expected: PASS.
 
-- [ ] **Step 6: Run complete Ice Slide/markup unit suites**
+### Step 6: Run complete Ice Slide/markup unit suites
+
+- [ ] Run:
 
 ```bash
-bun run test:run -- src/lib/games/ice-slide src/pages/game-board-markup.test.ts
+bun run test:run -- \
+  src/lib/games/ice-slide \
+  src/pages/game-board-markup.test.ts \
+  src/lib/services/scoreService.test.ts
 ```
 
 Expected: PASS.
 
-- [ ] **Step 7: Run repository verification**
+### Step 7: Run repository verification
+
+- [ ] Run in order:
 
 ```bash
 bun run format:check
@@ -1230,45 +1218,45 @@ Expected:
 - format: PASS;
 - lint: no new errors;
 - typecheck: no branch-introduced diagnostics;
-- tests: PASS;
-- coverage: current 95% gate satisfied;
+- unit tests: PASS;
+- coverage report generated successfully and PR satisfies the existing `codecov.yml` **95% project / 95% patch** status targets;
 - build: PASS.
 
-If typecheck shows a byte-identical `main` baseline diagnostic outside touched scope, document it rather than expanding HPA-487. Any diagnostic in a touched file must be fixed.
+If typecheck output contains a diagnostic already present byte-for-byte on `main`, document the baseline rather than widening HPA-487. Any diagnostic in a touched file must be fixed.
 
-- [ ] **Step 8: Verify final diff scope**
+### Step 8: Final scope diff
+
+- [ ] Run:
 
 ```bash
 git diff --stat main...HEAD
 git diff --name-only main...HEAD
 ```
 
-Confirm no database/leaderboard-server paths, Expedition/template code, snow/cracked-ice work, shared GamePage/GameOverlay APIs, or platform Daily rotation changes.
+- [ ] Confirm no DB/leaderboard server paths, HPA-488 admission logic, shared GamePage/GameOverlay APIs, Expedition/templates, snow/cracked ice, or platform Daily Challenge rotation changed.
 
-- [ ] **Step 9: Self-review every HPA-487 contract**
+### Step 9: Acceptance self-review
 
-Explicitly check:
+- [ ] Check each item explicitly:
+  - golden 2026-08-12 output;
+  - 365-date sweep;
+  - pool/template/canonical uniqueness;
+  - production quality/solver verification;
+  - source-content generator-version rule;
+  - stage-scoped fall/reset objective facts;
+  - Campaign default scoring vs Daily config;
+  - non-final Continue/input gate;
+  - final stars in result overlay + immediate submit;
+  - zero-score Daily End local overlay/no submit;
+  - structured unauthenticated silence;
+  - fresh vs retry UTC identity through actual page buttons;
+  - HUD before each stage's first accepted move;
+  - Campaign compatibility;
+  - HPA-488/Expedition scope exclusion.
 
-- literal `2026-08-12` generator-v1 tuple;
-- 2026 full-date no-throw sweep;
-- same-date byte equivalence and representative variation;
-- exact fork labels/source-by-ID/stage metadata;
-- five unique templates/canonical boards;
-- solver par/objective feasibility;
-- manual/hazard star facts;
-- Daily formula/300-second completion bonus;
-- engine final callback order `level-clear` then `win`;
-- non-final overlay End local/no-submit;
-- final overlay End inert and final Continue is the only submission transition;
-- HUD populated before each stage's first accepted move;
-- handle-level rollover retry plus page-level Play Again rollover E2E;
-- Change Mode idle/no-auto-start;
-- completed-only contextual submission and anonymous local result;
-- Campaign compatibility and HPA-488 boundary.
+### Step 10: Commit E2E changes
 
-Fix any gap before the final commit.
-
-- [ ] **Step 10: Commit E2E changes**
+- [ ] Commit:
 
 ```bash
 git add e2e/games/play-coverage.spec.ts
@@ -1281,32 +1269,26 @@ git commit -m "test(ice-slide): cover daily challenge flows"
 
 ### Spec coverage
 
-- **Task 1:** shared UTC calendar contract, exact RNG labels, source-by-ID mapping, frozen stage metadata, literal generator-v1 output, year sweep, solver/quality validation.
-- **Task 2:** objective semantics and additive Daily scoring.
-- **Task 3:** reset/fall counters, stars, score application, final engine callback order.
-- **Task 4:** fresh/retry UTC identity, Daily HUD, overlay/End semantics, final-Continue submission, auth/stale handling, input parity.
-- **Task 5:** selector/HUD/result markup, page `playAgain()` wiring, Change Mode, no shared overlay changes.
-- **Task 6:** browser-level UTC rollover retry, Change Mode no-auto-start, malformed-mode fallback, full regression/coverage gates.
+- Task 1: deterministic identity, shared UTC day validation, source metadata, golden contract, full-year validity, solver/quality verification.
+- Task 2: stage-scoped objective facts and one configurable scoring shape.
+- Task 3: live counters, star results, cross-stage isolation, callback order.
+- Task 4: retry identity, HUD, non-final gating, zero-score Daily End, immediate final submission, anonymous structured result.
+- Task 5: page-local selector/HUD/final stats/Change Mode and real Play Again wiring.
+- Task 6: browser rollover proof, regressions, existing Codecov gate, full verification.
 
-No HPA-487 acceptance criterion is intentionally deferred.
+### YAGNI check
 
-### Placeholder scan
+No generator framework, fallback engine, auth preflight, final pending-win state, final Continue state, mode registry, UTC countdown scheduler, shared overlay abstraction, or per-mode duplicate score function is planned.
 
-No `TBD`, `TODO`, generic “add tests”, or unspecified lifecycle branch remains. Exact interfaces, fork labels, generator tuple, DOM IDs, test paths, commands, and expected outcomes are named.
+### Deterministic contract check
+
+A change to eligible Campaign level identity/name/rows/par, difficulty mapping, pools, fork labels, transform/objective selection, or other materialized output under the same date requires a generator-version decision. The golden test is a tripwire.
 
 ### Type/contract consistency
 
-- `IceSlidePlayableMode` is exactly `'campaign' | 'daily'`; `IceSlideMode` remains broader.
-- UTC date calendar validation has one source in `run.ts`; `daily.ts` reuses it.
-- Daily generator version is defined once in `daily.ts` and reused by fixtures/tests.
-- Existing ruleset/schema constants remain in `run.ts`.
-- `onLevelClear` has one result-object signature and engine callback order stays unchanged.
-- Daily final browser/network side effects move to Continue without changing engine sequencing.
-- `IceSlideGameData` keeps existing run/counter metadata; active-stage HUD facts remain state/callback data.
-- HPA-488 remains the sole owner of server Daily admission and ranked presentation.
-
-## Execution Handoff
-
-Plan saved to `docs/superpowers/plans/2026-08-12-ice-slide-daily-challenge.md`.
-
-Recommended execution is **subagent-driven development**, one fresh implementation/review gate per task. Inline execution is also valid if the six task and commit boundaries are preserved.
+- `IceSlidePlayableMode` remains narrower than run-level `IceSlideMode`.
+- Objective facts use `stageFalls`/`stageResets`; cumulative state stays `falls`/`resets`.
+- `onLevelClear` has one result-object shape.
+- Default `levelScore()` / `timeBonus()` keep Campaign behavior; Daily passes `DAILY_SCORING_CONFIG`.
+- `saveGameScore` retains existing callers while optionally forwarding structured failure as a second callback argument.
+- HPA-488 remains the sole owner of server admission/ranked presentation.

--- a/docs/superpowers/plans/2026-08-12-ice-slide-daily-challenge.md
+++ b/docs/superpowers/plans/2026-08-12-ice-slide-daily-challenge.md
@@ -2,26 +2,27 @@
 
 > **For agentic workers:** REQUIRED SUB-SKILL: Use superpowers:subagent-driven-development (recommended) or superpowers:executing-plans to implement this plan task-by-task. Steps use checkbox (`- [ ]`) syntax for tracking.
 
-**Goal:** Ship HPA-487 by adding a deterministic five-stage Ice Slide Daily mode with seeded objectives/stars, Daily scoring, mode/retry UX, and completed-run contextual submission while preserving Campaign behavior.
+**Goal:** Ship HPA-487 with a deterministic five-stage Ice Slide Daily mode, frozen generator-v1 outputs, objective stars/scoring, exact retry/overlay lifecycle, Daily HUD, and completed-run contextual submission while preserving Campaign behavior.
 
-**Architecture:** Materialize a complete Daily `IceSlideRunDefinition` from an explicit UTC date before gameplay starts. Keep generation, objectives, and scoring pure; extend `IceSlideGame` only with active-stage attempt facts and Daily score/star application; keep clock capture, exact retry identity, overlays, input gating, and submission ownership in `init.ts`/the page.
+**Architecture:** Materialize a complete `IceSlideRunDefinition` from an explicit UTC date before gameplay. Reuse the existing RNG, transforms, run contract, production solver, and quality validator. Keep objective/scoring policy pure; keep clock capture, exact retry identity, Daily HUD synchronization, stage-clear gating, and submission ownership in `init.ts`/the page. Do not create a second Daily engine or a generic generator framework.
 
-**Tech Stack:** Astro 5, TypeScript 6, PixiJS 8, Vitest 3, Playwright, Better Auth client, existing Cetus seeded RNG/run/solver/quality infrastructure.
+**Tech Stack:** Astro 5, TypeScript 6, PixiJS 8, Vitest 3, Playwright 1.54, Better Auth client, existing Cetus deterministic Ice Slide infrastructure.
 
 ## Global Constraints
 
-- Campaign remains the default mode and keeps existing scoring, achievements, unscoped submissions, and partial-End submission behavior.
-- Daily is the only additional selectable mode; do not expose Expedition.
-- Daily run identity is UTC-based and versioned exactly as specified by the parent replayability design.
-- `IceSlideGame` must not read the clock or make random choices.
-- Daily generation must not use `Math.random()` or `crypto.getRandomValues()`.
-- `Play Again` retries the exact previously materialized Daily run; a fresh Daily Start captures the current UTC date.
-- Daily has exactly five stages, unique source templates, unique final canonical boards, and one feasible seeded bonus objective per stage.
-- Daily partial End never submits. Only a fully completed Daily run may attempt contextual submission.
-- HPA-488 owns server-side Daily semantic admission and leaderboard UI/query work; do not implement it here.
-- No mutation templates, Expedition, snow, cracked ice, abilities, new persistence layer, mode registry, generic generator framework, or shared overlay abstraction.
-- Stage-clear feedback uses an explicit Continue button; no auto-dismiss timer or forced reduced-motion delay.
-- New/changed code must satisfy the repository's current lint, format, test, build, and 95% coverage gates.
+- Campaign remains default and keeps existing scoring, achievements, unscoped submissions, and partial-End submission behavior.
+- Daily is the only additional playable mode; `IceSlidePlayableMode = 'campaign' | 'daily'` while the run-level `IceSlideMode` continues to include `expedition`.
+- `IceSlideGame` never reads the clock or makes random choices.
+- Daily generation never uses `Math.random()` or `crypto.getRandomValues()`.
+- Generator-v1 fork labels, stage metadata, and the literal `2026-08-12` output are compatibility contracts. A same-date materialization change requires a generator-version bump.
+- `Play Again` retries the exact materialized Daily run; a fresh Daily Start captures the current UTC date.
+- Daily has exactly five stages, unique source templates, unique final canonical boards, recomputed solver pars, and one feasible seeded bonus objective per stage.
+- Daily partial End never submits. Only final-stage Continue may initiate Daily submission.
+- HPA-488 owns server-side Daily semantic admission and leaderboard UI/query work.
+- The finite authored Daily search throws when no valid candidate exists; do not add mutation-style retry/fallback orchestration.
+- No mutation templates, Expedition UI, snow, cracked ice, abilities, persistence service, mode registry, generic generator framework, shared overlay framework, UTC countdown scheduler, or game-engine pause state.
+- Stage-clear feedback uses explicit Continue; no auto-dismiss timer or forced reduced-motion delay.
+- New/changed code must satisfy current format, lint, typecheck, unit/E2E, build, and 95% coverage gates.
 
 ---
 
@@ -29,30 +30,29 @@
 
 ### New files
 
-- `src/lib/games/ice-slide/daily.ts` — UTC-keyed deterministic Daily run materialization.
-- `src/lib/games/ice-slide/daily.test.ts` — Daily identity, selection, transforms, quality, determinism tests.
-- `src/lib/games/ice-slide/objectives.ts` — pure objective completion rules and labels.
-- `src/lib/games/ice-slide/objectives.test.ts` — objective-rule tests.
-- `src/lib/games/ice-slide/scoring.test.ts` — Campaign regression plus Daily scoring tests.
+- `src/lib/games/ice-slide/daily.ts` — shared UTC date conversion plus deterministic Daily materialization.
+- `src/lib/games/ice-slide/daily.test.ts` — date validation, generator golden vector, year sweep, pools/transforms/quality/determinism.
+- `src/lib/games/ice-slide/objectives.ts` — pure objective completion and labels.
+- `src/lib/games/ice-slide/objectives.test.ts` — objective rules.
+- `src/lib/games/ice-slide/scoring.test.ts` — Campaign regression plus Daily scoring.
 
 ### Existing files to modify
 
 - `src/lib/games/ice-slide/types.ts` — active-stage facts, stage-clear payload, playable-mode type.
-- `src/lib/games/ice-slide/run.ts` — export the existing Campaign difficulty mapping for Daily reuse.
-- `src/lib/games/ice-slide/scoring.ts` — additive Daily score functions; Campaign functions unchanged.
-- `src/lib/games/ice-slide/test-fixtures.ts` — valid Daily test-run helper.
-- `src/lib/games/ice-slide/game.ts` — reset/fall counters, Daily stars/scoring, richer clear callback.
-- `src/lib/games/ice-slide/game.test.ts` — Daily runtime/star/scoring tests and callback migration.
-- `src/lib/games/ice-slide/game.hazard.test.ts` — exact hazard counter regression.
-- `src/lib/games/ice-slide/init.ts` — mode-specific fresh/retry lifecycle, input gate, stage-result UI, scoped Daily submission.
-- `src/lib/games/ice-slide/init.test.ts` — lifecycle/rollover/submission/overlay/anonymous tests.
-- `src/pages/ice-slide/index.astro` — selector, Daily HUD, stage-clear markup, Change Mode flow.
-- `src/pages/game-board-markup.test.ts` — Ice Slide markup contract.
-- `e2e/games/play-coverage.spec.ts` — preserve Campaign smoke and add focused Daily/query smoke.
+- `src/lib/games/ice-slide/run.ts` — extract one UTC date-key validator and export Campaign difficulty mapping.
+- `src/lib/games/ice-slide/scoring.ts` — additive Daily score functions only.
+- `src/lib/games/ice-slide/test-fixtures.ts` — valid Daily test run helper.
+- `src/lib/games/ice-slide/game.ts` — reset/fall counters, Daily stars/scoring, richer clear callback while preserving callback order.
+- `src/lib/games/ice-slide/game.test.ts` / `game.hazard.test.ts` — runtime/callback/counter regressions.
+- `src/lib/games/ice-slide/init.ts` — fresh/retry lifecycle, Daily HUD, input/result gate, overlay-End semantics, scoped completed submission.
+- `src/lib/games/ice-slide/init.test.ts` — rollover, HUD, overlay/End, anonymous/submission, cleanup tests.
+- `src/pages/ice-slide/index.astro` — selector, Daily HUD markup, stage-clear markup, Play Again/Change Mode wiring.
+- `src/pages/game-board-markup.test.ts` — Ice Slide page contract.
+- `e2e/games/play-coverage.spec.ts` — Campaign smoke plus Daily query/retry/Change Mode flow.
 
 ---
 
-### Task 1: Materialize deterministic five-stage Daily runs
+## Task 1: Freeze and materialize deterministic five-stage Daily runs
 
 **Files:**
 - Create: `src/lib/games/ice-slide/daily.ts`
@@ -60,128 +60,254 @@
 - Modify: `src/lib/games/ice-slide/run.ts`
 
 **Interfaces:**
-- Consumes: `ICE_SLIDE_LEVELS`, `ICE_SLIDE_RULESET_VERSION`, `createIceSlideStageSignature()`, `assertValidIceSlideRunDefinition()`, `createSeededRng()`, `getUniqueBoardTransforms()`, `validateIceSlideStageQuality()`.
-- Produces:
 
 ```ts
+// run.ts
+export function assertValidIceSlideUtcDateKey(dateKey: string): void
+export const CAMPAIGN_STAGE_DIFFICULTIES: readonly IceSlideDifficulty[]
+
+// daily.ts
 export const ICE_SLIDE_DAILY_GENERATOR_VERSION = 1
 export const ICE_SLIDE_DAILY_SOLVER_MAX_STATES = 10_000
 export const ICE_SLIDE_DAILY_STAGE_POOLS: readonly (readonly number[])[]
-
 export function toIceSlideUtcDateKey(date: Date): string
 export function createIceSlideDailyRunDefinition(
   dateKey: string
 ): IceSlideRunDefinition
 ```
 
-- Also export the already-existing Campaign level difficulty mapping from `run.ts` as:
+### Frozen generator-v1 contract
+
+For a selected source level, materialize exactly:
 
 ```ts
-export const CAMPAIGN_STAGE_DIFFICULTIES: readonly IceSlideDifficulty[]
+{
+  id: `daily:${dateKey}:${stageNumber}`,
+  name: source.name,
+  templateId: `campaign:${source.id}`,
+  difficulty: CAMPAIGN_STAGE_DIFFICULTIES[sourceIndex],
+  rows: variant.rows,
+  parMoves: quality.parMoves,
+  transform: variant.transform,
+  mutationIds: [],
+  objectiveIds: [bonusObjective],
+  scoreMultiplierBps: 10_000,
+}
 ```
 
-- [ ] **Step 1: Write failing deterministic-run tests**
+Pool IDs are resolved with `ICE_SLIDE_LEVELS.findIndex(level => level.id === levelId)`; never index by `levelId - 1`.
 
-Create `daily.test.ts` with tests that lock identity and invariants without hard-coding random internal call counts:
+The exact RNG labels are:
+
+```ts
+const stageRng = rootRng.fork(`stage:${stageNumber}`)
+const templateOrder = stageRng.fork('template').shuffle(pool)
+const variantOrder = stageRng
+  .fork(`transform:${source.id}`)
+  .shuffle(getUniqueBoardTransforms(source.rows))
+const bonusObjective = stageRng.fork('objective').pick(eligibleObjectives)
+```
+
+Eligible-objective ordering is exactly:
+
+```ts
+[
+  'collect_all_crystals',
+  'no_falls',
+  'no_reset',
+]
+```
+
+- [ ] **Step 1: Write failing date-contract and generator tests**
+
+Create `daily.test.ts`. Start with the single shared calendar contract:
 
 ```ts
 import { describe, expect, it } from 'vitest'
-import { serializeBoardRows } from './transforms'
-import { assertValidIceSlideRunDefinition } from './run'
+import {
+  assertValidIceSlideRunDefinition,
+  assertValidIceSlideUtcDateKey,
+} from './run'
 import {
   createIceSlideDailyRunDefinition,
   toIceSlideUtcDateKey,
 } from './daily'
 
-describe('Ice Slide Daily materialization', () => {
-  it('formats UTC date keys and rejects invalid dates', () => {
+describe('Ice Slide UTC date keys', () => {
+  it.each(['2026-01-01', '2026-02-28', '2028-02-29'])(
+    'accepts %s',
+    dateKey => expect(() => assertValidIceSlideUtcDateKey(dateKey)).not.toThrow()
+  )
+
+  it.each([
+    '2026-2-01',
+    '2026-02-30',
+    '2026-13-01',
+    'not-a-date',
+  ])('rejects %s', dateKey => {
+    expect(() => assertValidIceSlideUtcDateKey(dateKey)).toThrow(RangeError)
+  })
+
+  it('converts Date with the same shared validator', () => {
     expect(toIceSlideUtcDateKey(new Date('2026-08-12T23:59:59Z'))).toBe(
       '2026-08-12'
     )
     expect(() => toIceSlideUtcDateKey(new Date(Number.NaN))).toThrow(RangeError)
   })
-
-  it('builds the exact versioned Daily identity', () => {
-    const run = createIceSlideDailyRunDefinition('2026-08-12')
-    expect(run).toMatchObject({
-      schemaVersion: 1,
-      generatorVersion: 1,
-      rulesetVersion: 1,
-      mode: 'daily',
-      seed: 'ice-slide:daily:1:1:2026-08-12',
-      runKey: 'ice-slide:daily:2026-08-12:g1:r1',
-    })
-    expect(run.stages).toHaveLength(5)
-    expect(() => assertValidIceSlideRunDefinition(run)).not.toThrow()
-  })
-
-  it('is byte-equivalent for the same date and versions', () => {
-    const first = createIceSlideDailyRunDefinition('2026-08-12')
-    const second = createIceSlideDailyRunDefinition('2026-08-12')
-    expect(JSON.stringify(second)).toBe(JSON.stringify(first))
-  })
-
-  it('never repeats a source template or final canonical board', () => {
-    const run = createIceSlideDailyRunDefinition('2026-08-12')
-    expect(new Set(run.stages.map(stage => stage.templateId)).size).toBe(5)
-    expect(
-      new Set(run.stages.map(stage => serializeBoardRows(stage.rows))).size
-    ).toBe(5)
-  })
-
-  it('assigns exactly one feasible bonus objective and recomputed par', () => {
-    const run = createIceSlideDailyRunDefinition('2026-08-12')
-    for (const stage of run.stages) {
-      expect(stage.objectiveIds).toHaveLength(1)
-      expect(stage.scoreMultiplierBps).toBe(10_000)
-      expect(stage.mutationIds).toEqual([])
-      expect(stage.parMoves).toBeGreaterThan(0)
-    }
-  })
-
-  it('varies deterministically across representative dates', () => {
-    const signatures = ['2026-08-12', '2026-08-13', '2026-09-01'].map(date =>
-      createIceSlideDailyRunDefinition(date).stages.map(stage => stage.signature)
-    )
-    expect(new Set(signatures.map(value => value.join(','))).size).toBeGreaterThan(1)
-  })
 })
 ```
 
-Add a table test proving each stage's template ID is inside its exact required pool and all five source template IDs are unique.
+Then lock identity:
 
-- [ ] **Step 2: Run the new test and verify it fails**
+```ts
+it('builds the exact Daily identity', () => {
+  const run = createIceSlideDailyRunDefinition('2026-08-12')
+  expect(run).toMatchObject({
+    schemaVersion: 1,
+    generatorVersion: 1,
+    rulesetVersion: 1,
+    mode: 'daily',
+    seed: 'ice-slide:daily:1:1:2026-08-12',
+    runKey: 'ice-slide:daily:2026-08-12:g1:r1',
+  })
+  expect(run.stages).toHaveLength(5)
+  expect(() => assertValidIceSlideRunDefinition(run)).not.toThrow()
+})
+```
 
-Run:
+Lock the complete generator-v1 stage projection:
+
+```ts
+it('locks the generator-v1 2026-08-12 stage tuples', () => {
+  const run = createIceSlideDailyRunDefinition('2026-08-12')
+  expect(
+    run.stages.map(stage => ({
+      id: stage.id,
+      name: stage.name,
+      templateId: stage.templateId,
+      transform: stage.transform,
+      objectiveIds: stage.objectiveIds,
+      parMoves: stage.parMoves,
+      difficulty: stage.difficulty,
+      signature: stage.signature,
+    }))
+  ).toEqual([
+    {
+      id: 'daily:2026-08-12:1',
+      name: 'Corner Pocket',
+      templateId: 'campaign:2',
+      transform: 'identity',
+      objectiveIds: ['no_reset'],
+      parMoves: 3,
+      difficulty: 'easy',
+      signature: 'is2-8c5387f7',
+    },
+    {
+      id: 'daily:2026-08-12:2',
+      name: 'Bank Shot',
+      templateId: 'campaign:3',
+      transform: 'rotate_180',
+      objectiveIds: ['no_reset'],
+      parMoves: 4,
+      difficulty: 'easy',
+      signature: 'is2-c8c370cb',
+    },
+    {
+      id: 'daily:2026-08-12:3',
+      name: 'Crystal Cache',
+      templateId: 'campaign:5',
+      transform: 'reflect_anti_diagonal',
+      objectiveIds: ['collect_all_crystals'],
+      parMoves: 6,
+      difficulty: 'medium',
+      signature: 'is2-2394afd9',
+    },
+    {
+      id: 'daily:2026-08-12:4',
+      name: 'Deep Freeze',
+      templateId: 'campaign:7',
+      transform: 'reflect_vertical',
+      objectiveIds: ['collect_all_crystals'],
+      parMoves: 6,
+      difficulty: 'hard',
+      signature: 'is2-07d0c27d',
+    },
+    {
+      id: 'daily:2026-08-12:5',
+      name: 'Absolute Zero',
+      templateId: 'campaign:8',
+      transform: 'reflect_main_diagonal',
+      objectiveIds: ['no_reset'],
+      parMoves: 6,
+      difficulty: 'hard',
+      signature: 'is2-c31fa49b',
+    },
+  ])
+})
+```
+
+Add invariant tests:
+
+- same date serializes byte-equivalently;
+- every stage source ID belongs to its exact pool;
+- five template IDs are unique;
+- five `serializeBoardRows(stage.rows)` values are unique;
+- every stage has one objective, no mutations, multiplier `10_000`;
+- every stage par equals `solveIceSlideBoard(stage, { maxStates: 10_000 }).minMoves`;
+- assigned objective is feasible under `validateIceSlideStageQuality()`.
+
+Add the bounded v1 content sweep:
+
+```ts
+it('materializes every UTC date in calendar year 2026', () => {
+  const start = Date.UTC(2026, 0, 1)
+  for (let offset = 0; offset < 365; offset++) {
+    const dateKey = toIceSlideUtcDateKey(
+      new Date(start + offset * 24 * 60 * 60 * 1000)
+    )
+    expect(() => createIceSlideDailyRunDefinition(dateKey)).not.toThrow()
+  }
+})
+```
+
+Keep representative-date variation as a separate assertion; the year sweep is a no-throw content gate, not a requirement that every date be unique.
+
+- [ ] **Step 2: Run the new suite to prove red**
 
 ```bash
 bun run test:run -- src/lib/games/ice-slide/daily.test.ts
 ```
 
-Expected: FAIL because `daily.ts`/exports do not exist yet.
+Expected: FAIL because the new exports/materializer do not exist.
 
-- [ ] **Step 3: Export Campaign difficulty metadata instead of duplicating it**
+- [ ] **Step 3: Extract the shared date validator and Campaign difficulty mapping**
 
-In `run.ts`, rename the private constant and reuse the exported name inside `createCampaignRunDefinition()`:
+In `run.ts`:
+
+1. export the current Campaign difficulty array as `CAMPAIGN_STAGE_DIFFICULTIES` and keep Campaign output unchanged;
+2. move the existing Daily run-key date round-trip into `assertValidIceSlideUtcDateKey(dateKey)`;
+3. have the Daily branch of `assertValidIceSlideRunDefinition()` call that helper instead of keeping private duplicate calendar logic.
+
+The helper performs exact regex plus calendar round-trip. Do not add a second parser in `daily.ts`.
+
+- [ ] **Step 4: Implement `toIceSlideUtcDateKey()` and strict Daily input validation**
 
 ```ts
-export const CAMPAIGN_STAGE_DIFFICULTIES: readonly IceSlideDifficulty[] = [
-  'tutorial',
-  'easy',
-  'easy',
-  'medium',
-  'medium',
-  'medium',
-  'hard',
-  'hard',
-]
+export function toIceSlideUtcDateKey(date: Date): string {
+  if (!Number.isFinite(date.getTime())) {
+    throw new RangeError('date must be valid')
+  }
+  const dateKey = date.toISOString().slice(0, 10)
+  assertValidIceSlideUtcDateKey(dateKey)
+  return dateKey
+}
 ```
 
-Keep the existing length assertion and Campaign stage output unchanged.
+`createIceSlideDailyRunDefinition(dateKey)` begins with `assertValidIceSlideUtcDateKey(dateKey)`.
 
-- [ ] **Step 4: Implement the minimal pure Daily materializer**
+- [ ] **Step 5: Implement the exact Daily materializer**
 
-Use the exact pools:
+Use:
 
 ```ts
 export const ICE_SLIDE_DAILY_STAGE_POOLS = [
@@ -193,47 +319,22 @@ export const ICE_SLIDE_DAILY_STAGE_POOLS = [
 ] as const
 ```
 
-Implement strict date parsing by requiring `YYYY-MM-DD`, constructing UTC midnight, and round-tripping year/month/day. Do not rely on permissive `Date.parse()` alone.
+For each stage:
 
-The stage loop must use these exact labeled streams:
+1. shuffle the pool with the frozen `stage:N` / `template` forks;
+2. resolve source via `.findIndex(level => level.id === levelId)` and throw if missing;
+3. skip a source whose `campaign:<id>` template ID is already used;
+4. shuffle `getUniqueBoardTransforms(source.rows)` with `transform:${source.id}`;
+5. validate candidates with empty objectives, exact source-par band, solver cap, and prior canonical keys;
+6. select the first accepted candidate;
+7. filter feasible objectives using the frozen order and pick using the `objective` fork;
+8. materialize the frozen stage fields, compute signature, and record template/canonical identity.
 
-```ts
-const stageRng = rootRng.fork(`stage:${stageNumber}`)
-const templateOrder = stageRng.fork('template').shuffle(pool)
-const variantOrder = stageRng
-  .fork(`transform:${source.id}`)
-  .shuffle(getUniqueBoardTransforms(source.rows))
-```
+Throw a descriptive error if the finite set has no valid candidate. Do not add a fallback table or a 64-attempt loop.
 
-For each candidate variant, validate it with:
+Validate the complete run before returning.
 
-```ts
-const quality = validateIceSlideStageQuality(
-  { id: `daily:${dateKey}:${stageNumber}`, rows: variant.rows, objectiveIds: [] },
-  {
-    parBand: { minMoves: source.parMoves, maxMoves: source.parMoves },
-    maxStates: ICE_SLIDE_DAILY_SOLVER_MAX_STATES,
-    existingCanonicalKeys: usedCanonicalKeys,
-  }
-)
-```
-
-On the first accepted candidate:
-
-```ts
-const eligibleObjectives = DAILY_BONUS_OBJECTIVE_ORDER.filter(
-  objectiveId => quality.objectiveFeasibility[objectiveId]
-)
-const bonusObjective = stageRng.fork('objective').pick(eligibleObjectives)
-```
-
-Create the final stage, compute its signature, add template/canonical identities to their used sets, and break. Throw a descriptive `Error` if the finite authored candidate set produces no accepted candidate.
-
-Finish by validating the full run with `assertValidIceSlideRunDefinition(run)` before returning it.
-
-- [ ] **Step 5: Run Daily + prerequisite deterministic tests**
-
-Run:
+- [ ] **Step 6: Run deterministic prerequisites and Daily tests**
 
 ```bash
 bun run test:run -- \
@@ -245,9 +346,9 @@ bun run test:run -- \
   src/lib/games/shared/seeded-rng.test.ts
 ```
 
-Expected: PASS.
+Expected: PASS including the literal golden vector and full 2026 sweep.
 
-- [ ] **Step 6: Commit**
+- [ ] **Step 7: Commit**
 
 ```bash
 git add \
@@ -259,7 +360,7 @@ git commit -m "feat(ice-slide): materialize deterministic daily runs"
 
 ---
 
-### Task 2: Add pure objective/star rules and Daily scoring
+## Task 2: Add pure objective/star rules and Daily scoring
 
 **Files:**
 - Create: `src/lib/games/ice-slide/objectives.ts`
@@ -269,7 +370,6 @@ git commit -m "feat(ice-slide): materialize deterministic daily runs"
 - Modify: `src/lib/games/ice-slide/types.ts`
 
 **Interfaces:**
-- Produces:
 
 ```ts
 export type IceSlidePlayableMode = 'campaign' | 'daily'
@@ -306,7 +406,7 @@ export interface IceSlideStageClearResult {
 }
 ```
 
-- Add active-stage state fields:
+Add active-stage state fields:
 
 ```ts
 parMoves: number
@@ -315,10 +415,17 @@ levelFalls: number
 levelResets: number
 ```
 
-- Change `IceSlideCallbacks.onLevelClear` to `(result: IceSlideStageClearResult) => void`.
-- Produces scoring helpers:
+Change local `IceSlideCallbacks.onLevelClear` to `(result: IceSlideStageClearResult) => void`.
+
+Add:
 
 ```ts
+export const DAILY_SCORING_CONFIG = {
+  objectiveStarBonus: 100,
+  timeBudgetSeconds: 300,
+  timeBonusPerSec: 5,
+} as const
+
 export function dailyStageScore(params: {
   stageNumber: number
   parMoves: number
@@ -332,45 +439,21 @@ export function dailyTimeBonus(elapsedSeconds: number): number
 
 - [ ] **Step 1: Write failing objective tests**
 
-Cover every rule directly:
+Cover:
 
 ```ts
-it('requires all crystals for collect_all_crystals', () => {
-  expect(isIceSlideObjectiveComplete('collect_all_crystals', {
-    parMoves: 4,
-    movesUsed: 4,
-    crystalsCollected: 2,
-    totalCrystals: 2,
-    falls: 0,
-    resets: 0,
-  })).toBe(true)
-
-  expect(isIceSlideObjectiveComplete('collect_all_crystals', {
-    parMoves: 4,
-    movesUsed: 4,
-    crystalsCollected: 1,
-    totalCrystals: 2,
-    falls: 0,
-    resets: 0,
-  })).toBe(false)
-})
-
-it('requires no falls for no_falls', () => {
-  expect(base({ falls: 0 }, 'no_falls')).toBe(true)
-  expect(base({ falls: 1 }, 'no_falls')).toBe(false)
-})
-
-it('requires no manual or hazard reset for no_reset', () => {
-  expect(base({ resets: 0 }, 'no_reset')).toBe(true)
-  expect(base({ resets: 1 }, 'no_reset')).toBe(false)
-})
+expect(complete('collect_all_crystals', { totalCrystals: 2, crystalsCollected: 2 })).toBe(true)
+expect(complete('collect_all_crystals', { totalCrystals: 2, crystalsCollected: 1 })).toBe(false)
+expect(complete('collect_all_crystals', { totalCrystals: 0, crystalsCollected: 0 })).toBe(false)
+expect(complete('no_falls', { falls: 0 })).toBe(true)
+expect(complete('no_falls', { falls: 1 })).toBe(false)
+expect(complete('no_reset', { resets: 0 })).toBe(true)
+expect(complete('no_reset', { resets: 1 })).toBe(false)
 ```
 
-Also assert `collect_all_crystals` is false when `totalCrystals === 0`; the generator should not assign it in that case, but runtime policy remains explicit.
+The helper used by these examples fills the remaining fact fields with valid zero/default values; do not special-case tests inside production code.
 
-- [ ] **Step 2: Write failing Daily scoring tests**
-
-Lock exact boundaries:
+- [ ] **Step 2: Write failing scoring tests**
 
 ```ts
 expect(dailyStageScore({
@@ -379,7 +462,7 @@ expect(dailyStageScore({
   movesUsed: 4,
   crystalsCollected: 1,
   optionalStarsEarned: 2,
-})).toBe(400 + 25 + 50 + 200)
+})).toBe(675)
 
 expect(dailyTimeBonus(0)).toBe(1500)
 expect(dailyTimeBonus(299)).toBe(5)
@@ -387,9 +470,9 @@ expect(dailyTimeBonus(300)).toBe(0)
 expect(dailyTimeBonus(301)).toBe(0)
 ```
 
-Copy the current Campaign expectations into this test file for `levelScore()`/`timeBonus()` so additive Daily work cannot silently alter the 360-second Campaign contract.
+Also copy the current Campaign expectations for `levelScore()` and `timeBonus()` into `scoring.test.ts`, including the 360-second Campaign budget.
 
-- [ ] **Step 3: Run tests to verify failure**
+- [ ] **Step 3: Run tests to prove red**
 
 ```bash
 bun run test:run -- \
@@ -397,11 +480,11 @@ bun run test:run -- \
   src/lib/games/ice-slide/scoring.test.ts
 ```
 
-Expected: FAIL because the new interfaces/functions do not exist.
+Expected: FAIL because the new modules/functions do not exist.
 
-- [ ] **Step 4: Implement objective rules and labels**
+- [ ] **Step 4: Implement pure objective rules and labels**
 
-Keep `objectives.ts` free of DOM/Pixi/game state. Implement with a switch over the existing objective union:
+`objectives.ts` stays free of DOM, Pixi, timers, and game state. The completion switch is:
 
 ```ts
 case 'collect_all_crystals':
@@ -413,38 +496,25 @@ case 'no_reset':
   return facts.resets === 0
 ```
 
-Use concise display labels such as `Collect all crystals`, `No falls`, and `No resets` from the exported record instead of duplicating copy in `init.ts`/Astro.
-
-- [ ] **Step 5: Add Daily scoring without changing Campaign functions**
-
-Add:
+Export labels once:
 
 ```ts
-export const DAILY_SCORING_CONFIG = {
-  objectiveStarBonus: 100,
-  timeBudgetSeconds: 300,
-  timeBonusPerSec: 5,
-} as const
+export const ICE_SLIDE_OBJECTIVE_LABELS = {
+  collect_all_crystals: 'Collect all crystals',
+  no_falls: 'No falls',
+  no_reset: 'No resets',
+} as const satisfies Record<IceSlideObjectiveId, string>
 ```
 
-Validate `optionalStarsEarned` as a simple numeric input from game policy and compute:
+- [ ] **Step 5: Add Daily scoring additively**
 
-```ts
-return (
-  levelClearPoints(params.stageNumber) +
-  moveBonus(params.parMoves, params.movesUsed) +
-  crystalBonus(params.crystalsCollected) +
-  params.optionalStarsEarned * DAILY_SCORING_CONFIG.objectiveStarBonus
-)
-```
+Do not modify existing Campaign constants/functions. `dailyStageScore()` reuses `levelClearPoints()`, `moveBonus()`, and `crystalBonus()` and adds `optionalStarsEarned * 100`. `dailyTimeBonus()` mirrors Campaign time-bonus shape with a 300-second budget.
 
-`dailyTimeBonus()` mirrors the existing `timeBonus()` shape with the 300-second budget.
+- [ ] **Step 6: Extend local Ice Slide types only**
 
-- [ ] **Step 6: Extend local Ice Slide types**
+Add the active-stage fields, `IceSlidePlayableMode`, and `IceSlideStageClearResult`. `IceSlideMode` remains `'campaign' | 'daily' | 'expedition'` for the materialized-run contract.
 
-Add the four active-stage fields and clear-result/playable-mode types. Change only Ice Slide's local callback payload. Do not modify shared platform game types or introduce a generic stage-result abstraction.
-
-- [ ] **Step 7: Run tests and type-focused suite**
+- [ ] **Step 7: Run objective/scoring/Daily suites**
 
 ```bash
 bun run test:run -- \
@@ -469,22 +539,20 @@ git commit -m "feat(ice-slide): add daily objectives and scoring"
 
 ---
 
-### Task 3: Track stage attempts and apply Daily stars/scoring in `IceSlideGame`
+## Task 3: Track attempts and apply Daily stars/scoring in `IceSlideGame`
 
 **Files:**
 - Modify: `src/lib/games/ice-slide/test-fixtures.ts`
 - Modify: `src/lib/games/ice-slide/game.ts`
 - Modify: `src/lib/games/ice-slide/game.test.ts`
 - Modify: `src/lib/games/ice-slide/game.hazard.test.ts`
-- Update any Ice Slide tests that compile against the old numeric `onLevelClear` callback.
+- Update only other Ice Slide tests that compile against the changed `onLevelClear` payload.
 
-**Interfaces:**
-- Consumes: `dailyStageScore()`, `dailyTimeBonus()`, `isIceSlideObjectiveComplete()`, `IceSlideStageClearResult`.
-- Produces: exact run/stage counters and clear-result payload for `init.ts`.
+**Consumes:** `dailyStageScore()`, `dailyTimeBonus()`, `isIceSlideObjectiveComplete()`, `IceSlideStageClearResult`.
 
 - [ ] **Step 1: Add a valid Daily test-run fixture**
 
-In `test-fixtures.ts`, add a helper that derives valid key/seed/version metadata from `dateKey` and calls `createIceSlideStageSignature()` for every override stage. Default it to five one-move stages so Daily completion tests remain short.
+Add:
 
 ```ts
 export function createTestDailyRun(
@@ -493,20 +561,22 @@ export function createTestDailyRun(
 ): IceSlideRunDefinition
 ```
 
-Use `ICE_SLIDE_DAILY_GENERATOR_VERSION` and `ICE_SLIDE_RULESET_VERSION`; do not hand-copy version numbers.
+Use `ICE_SLIDE_DAILY_GENERATOR_VERSION`, `ICE_SLIDE_RULESET_VERSION`, valid Daily seed/key shape, and `createIceSlideStageSignature()`; do not hand-copy version numbers.
 
-- [ ] **Step 2: Write failing counter tests**
+- [ ] **Step 2: Write failing manual/hazard counter tests**
 
-Add tests proving:
+Manual Reset:
 
 ```ts
-// manual Reset
 expect(after.resets).toBe(before.resets + 1)
 expect(after.levelResets).toBe(1)
 expect(after.levelFalls).toBe(0)
 expect(after.levelMoves).toBe(0)
+```
 
-// hazard entry
+Hazard:
+
+```ts
 expect(after.falls).toBe(before.falls + 1)
 expect(after.resets).toBe(before.resets + 1)
 expect(after.levelFalls).toBe(1)
@@ -514,32 +584,42 @@ expect(after.levelResets).toBe(1)
 expect(after.levelMoves).toBe(1)
 ```
 
-Then clear/advance a test stage and assert `levelFalls`/`levelResets` reset to zero on the next stage while cumulative `falls`/`resets` remain.
+After a normal stage advance, assert per-stage counters reset to zero while cumulative counters remain.
 
 - [ ] **Step 3: Write failing Daily clear-result/star tests**
 
-Use small explicit Daily stages to exercise each outcome:
+Use explicit Daily stages to cover:
 
-- exact-par + no reset => Clear/Efficient/bonus all earned, `earnedCount === 3`;
+- exact-par + `no_reset` => Clear/Efficient/bonus all true, `earnedCount === 3`;
 - over-par => Efficient false;
-- manual reset before clear => `no_reset` false;
-- hazard before a later clear => `no_falls` false;
-- collect all vs not all crystals;
-- cumulative `state.starsEarned` equals the sum of Daily stage results.
+- manual Reset before clear => `no_reset` false;
+- hazard before later clear => `no_falls` false;
+- collect-all true/false;
+- cumulative `state.starsEarned` equals Daily result earned counts.
 
-Assert the callback payload shape, including `scoreGained`, rather than reading private state.
+Assert `scoreGained` from callback result rather than private state.
 
-- [ ] **Step 4: Write failing Daily completion-bonus and Campaign regression tests**
+- [ ] **Step 4: Lock final callback order and completion bonus**
 
-With fake timers, complete a five-stage Daily test run and verify the final score adds `dailyTimeBonus(elapsedSeconds)`. Separately retain existing Campaign assertions and add:
+Add a regression test:
 
 ```ts
-expect(game.getState().starsEarned).toBe(0)
+const events: string[] = []
+const game = new IceSlideGame({
+  onLevelClear: () => events.push('level-clear'),
+  onWin: () => events.push('win'),
+})
 ```
 
-for Campaign clears.
+Complete the final stage and assert the final entries are:
 
-- [ ] **Step 5: Run focused tests to verify failure**
+```ts
+expect(events.slice(-2)).toEqual(['level-clear', 'win'])
+```
+
+With fake timers, complete a five-stage Daily run and assert final score includes `dailyTimeBonus(elapsedSeconds)`. Preserve existing Campaign tests and assert Campaign `starsEarned === 0`.
+
+- [ ] **Step 5: Run focused tests to prove red**
 
 ```bash
 bun run test:run -- \
@@ -547,11 +627,11 @@ bun run test:run -- \
   src/lib/games/ice-slide/game.hazard.test.ts
 ```
 
-Expected: FAIL on missing counters/result behavior.
+Expected: FAIL on missing counter/result behavior.
 
-- [ ] **Step 6: Populate active-stage metadata in `createIdleState()`/`loadLevel()`**
+- [ ] **Step 6: Populate active-stage metadata in idle/load paths**
 
-Idle values:
+Idle:
 
 ```ts
 parMoves: 0,
@@ -560,51 +640,59 @@ levelFalls: 0,
 levelResets: 0,
 ```
 
-Loaded values come from the materialized stage:
+Loaded stage:
 
 ```ts
 parMoves: stage.parMoves,
 objectiveIds: [...stage.objectiveIds],
 ```
 
-`getState()` must clone `objectiveIds`.
+`getState()` clones `objectiveIds`.
 
-Add one `preserveLevelAttemptStats` load option. Manual Reset and hazard reload pass it; normal stage advance does not. Keep the current independent `preserveLevelMoves` behavior so manual Reset still clears `levelMoves` while hazard keeps the hazard move.
+Add `preserveLevelAttemptStats` to `loadLevel()` options. Manual Reset and hazard reload preserve these counters; normal advance resets them. Keep `preserveLevelMoves` independent so manual Reset clears level moves and hazard keeps its committed hazard move.
 
-- [ ] **Step 7: Increment reset/fall counters exactly once at their event sites**
+- [ ] **Step 7: Increment event counters exactly once**
 
-Before same-stage reload:
+Before manual reload:
 
 ```ts
-// manual Reset
 this.state.resets += 1
 this.state.levelResets += 1
+```
 
-// hazard
+Before hazard reload:
+
+```ts
 this.state.falls += 1
 this.state.resets += 1
 this.state.levelFalls += 1
 this.state.levelResets += 1
 ```
 
-Do not derive these values from callbacks or renderer events.
+Do not infer counters from callbacks/rendering.
 
-- [ ] **Step 8: Build one clear-result object inside `clearLevel()`**
+- [ ] **Step 8: Build one completed-stage result in `clearLevel()`**
 
-Count `C` glyphs from `stage.rows` at clear time. For Daily, evaluate exactly one bonus objective and Efficient, then derive:
+Count total `C` glyphs from the materialized stage rows. For Daily, calculate:
 
 ```ts
+const efficient = this.state.levelMoves <= stage.parMoves
+const bonusId = stage.objectiveIds[0]
+const bonusEarned = isIceSlideObjectiveComplete(bonusId, facts)
 const optionalStarsEarned = Number(efficient) + Number(bonusEarned)
 const earnedCount = 1 + optionalStarsEarned
 ```
 
-Use `dailyStageScore()` only when `this.state.mode === 'daily'`; otherwise use the existing `levelScore()` path. Add cumulative stars only for Daily.
+Use `dailyStageScore()` only for Daily, otherwise existing `levelScore()`. Increment cumulative `starsEarned` only for Daily.
 
-Fire `onLevelClear(result)` with the completed stage's facts before the next-stage interaction can occur.
+Preserve current progression/callback order:
 
-For the final stage, use `dailyTimeBonus()` only for Daily; keep `timeBonus()` for Campaign/non-Daily explicit runs.
+- non-final: prepare next stage, then `onLevelClear(result)`;
+- final: apply mode-specific time bonus, set won/stop timer, then `onLevelClear(result)`, then `onWin(finalScore)`.
 
-- [ ] **Step 9: Run all Ice Slide unit tests**
+Do not add a paused-stage engine state.
+
+- [ ] **Step 9: Run complete Ice Slide unit suite**
 
 ```bash
 bun run test:run -- src/lib/games/ice-slide
@@ -614,28 +702,28 @@ Expected: PASS.
 
 - [ ] **Step 10: Commit**
 
+Stage explicit changed paths only after inspecting `git diff --name-only`:
+
 ```bash
 git add \
   src/lib/games/ice-slide/test-fixtures.ts \
   src/lib/games/ice-slide/game.ts \
-  src/lib/games/ice-slide/game*.test.ts \
-  src/lib/games/ice-slide/*.test.ts
+  src/lib/games/ice-slide/game.test.ts \
+  src/lib/games/ice-slide/game.hazard.test.ts
 git commit -m "feat(ice-slide): track daily stage results"
 ```
 
-Before committing, inspect `git diff --cached --name-only` and unstage any test file not actually changed by this task; do not use the glob to sweep unrelated edits.
+If another Ice Slide test required the callback signature migration, add that exact path to the commit instead of globbing every test.
 
 ---
 
-### Task 4: Add fresh-vs-retry Daily lifecycle, input gating, and scoped completed submission
+## Task 4: Integrate fresh/retry lifecycle, Daily HUD, overlay gating, and completed submission
 
 **Files:**
 - Modify: `src/lib/games/ice-slide/init.ts`
 - Modify: `src/lib/games/ice-slide/init.test.ts`
 
 **Interfaces:**
-- Consumes: `createIceSlideDailyRunDefinition()`, `toIceSlideUtcDateKey()`, `cloneIceSlideRunDefinition()`, `IceSlidePlayableMode`, `IceSlideStageClearResult`, `ICE_SLIDE_OBJECTIVE_LABELS`, `authClient.getSession()`, existing `saveGameScore()` context option.
-- Produces:
 
 ```ts
 export interface IceSlideHandle {
@@ -648,9 +736,11 @@ export interface IceSlideHandle {
 }
 ```
 
-- [ ] **Step 1: Extend the JSDOM fixture and auth mock**
+Consumes `createIceSlideDailyRunDefinition()`, `toIceSlideUtcDateKey()`, `cloneIceSlideRunDefinition()`, `ICE_SLIDE_OBJECTIVE_LABELS`, Better Auth client, and existing contextual `saveGameScore()` options.
 
-Add the Daily/stage-clear element IDs that `init.ts` will own, including:
+- [ ] **Step 1: Extend the JSDOM fixture and mocks**
+
+Add exact IDs:
 
 ```text
 #daily-meta
@@ -669,37 +759,58 @@ Add the Daily/stage-clear element IDs that `init.ts` will own, including:
 #stage-clear-continue-btn
 ```
 
-Mock `@/lib/auth-client` with `authClient.getSession = vi.fn()` and default it to an authenticated session for existing score tests.
+Retain `#start-btn`, `#end-btn`, shared result overlay IDs, and score/HUD IDs.
 
-- [ ] **Step 2: Write failing fresh/retry/rollover tests**
+Mock `@/lib/auth-client` with `authClient.getSession = vi.fn()` and default existing score tests to an authenticated session.
 
-Use fake system time:
+Reuse/adapt the existing test-only BFS path helper from `init.test.ts` so it accepts a materialized `{ id, rows }` stage. Do not add a production path-returning solver API solely for tests.
+
+- [ ] **Step 2: Write failing fresh/retry/UTC rollover tests**
 
 ```ts
 vi.useFakeTimers()
 vi.setSystemTime(new Date('2026-08-12T23:59:59Z'))
 await handle.start('daily')
-const firstKey = handle.getGame()!.getState().runKey
-const firstSignatures = handle.getGame()!.getState().stageSignatures
+const first = handle.getGame()!.getState()
 
 vi.setSystemTime(new Date('2026-08-13T00:00:01Z'))
 await handle.playAgain()
-expect(handle.getGame()!.getState().runKey).toBe(firstKey)
-expect(handle.getGame()!.getState().stageSignatures).toEqual(firstSignatures)
+const retry = handle.getGame()!.getState()
+expect(retry.runKey).toBe(first.runKey)
+expect(retry.stageSignatures).toEqual(first.stageSignatures)
 
 await handle.start('daily')
 expect(handle.getGame()!.getState().runKey).toContain('2026-08-13')
 ```
 
-Also assert `start()` without a mode still starts Campaign.
+Also assert `start()` without mode starts Campaign.
 
-- [ ] **Step 3: Write failing submission-boundary tests**
+- [ ] **Step 3: Write failing Daily HUD tests**
 
-Add tests for:
+With fixed time `2026-08-12T23:59:59Z`, after fresh Daily Start assert:
 
-- Campaign partial stop still calls `saveGameScore()` with no context.
+```ts
+expect(document.querySelector('#daily-meta')).not.toHaveClass('hidden')
+expect(document.querySelector('#daily-date')).toHaveTextContent('2026-08-12')
+expect(document.querySelector('#daily-reset')).toHaveTextContent('00:00 UTC')
+expect(document.querySelector('#daily-reset')).toHaveTextContent('2026-08-13')
+expect(document.querySelector('#daily-stage-progress')).toHaveTextContent('Stage 1 / 5')
+expect(document.querySelector('#daily-objective-clear')).toHaveTextContent('Clear')
+expect(document.querySelector('#daily-objective-efficient')).toHaveTextContent('≤')
+expect(document.querySelector('#daily-objective-bonus')?.textContent).not.toBe('')
+```
+
+Start Campaign and assert `#daily-meta` is hidden.
+
+Clear the first Daily stage with the test-only path helper, click Continue, and assert stage progress becomes `Stage 2 / 5` and Efficient/bonus text is re-derived from the new `getState()` before further movement.
+
+- [ ] **Step 4: Write failing submission-boundary tests**
+
+Cover:
+
+- Campaign partial stop still calls `saveGameScore()` unscoped.
 - Daily partial stop never calls it.
-- completed Daily calls it exactly once with:
+- Completed Daily calls it exactly once only after final Continue with:
 
 ```ts
 expect(options.context).toEqual({
@@ -709,35 +820,44 @@ expect(options.context).toEqual({
 })
 ```
 
-- `authClient.getSession()` returning `{ data: null, error: null }` makes a completed Daily run local-only.
-- a session-check error does not silently discard an otherwise completed run; the normal score path remains authoritative.
+- confirmed anonymous `{ data: null, error: null }` completion stays local;
+- auth-check error does not silently discard the completed result; the score endpoint path remains authoritative.
 
-Use the production solver or the deterministic Daily run data to drive completion in the test helper; do not hard-code transform-dependent arrow sequences.
+Capture the run guard before the auth await and test stale completion suppression.
 
-- [ ] **Step 4: Write failing stage-clear/input-gate tests**
+- [ ] **Step 5: Write failing overlay/input/End lifecycle tests**
 
-Drive a Daily stage clear, then assert:
+For a non-final Daily clear:
 
-- stage-clear overlay is visible;
-- objective/score text is populated from the clear result;
-- a keyboard direction while the overlay is open does not change moves/stage;
-- pointer/swipe direction is also ignored;
-- Continue hides the overlay and allows input again;
-- final-stage Continue transitions to the mission-complete overlay and only then triggers Daily submission.
+- stage overlay visible;
+- result text populated;
+- keyboard and swipe do not move while locked;
+- Reset no-ops while locked;
+- Continue hides overlay, re-syncs HUD, and permits movement;
+- calling `handle.stop()` while that non-final overlay is open hides it, stops locally, shows `RUN ENDED`, and never saves a Daily score.
 
-Add cleanup/failure assertions that no stale overlay/lock remains.
+For the final Daily clear:
 
-- [ ] **Step 5: Run `init.test.ts` to verify failure**
+- `onLevelClear` overlay remains visible after the engine's immediately following `onWin` callback;
+- mission-complete overlay is still hidden;
+- `saveGameScore()` has not run;
+- End control is hidden/disabled while final Continue is pending;
+- programmatic `handle.stop()` is a no-op and leaves final stage overlay visible;
+- final Continue hides stage overlay, shows mission-complete, invokes external `onWin`, and initiates submission exactly once.
+
+Add fail/start/cleanup cases proving locks, overlays, and `pendingDailyWinScore` cannot leak into a newer run.
+
+- [ ] **Step 6: Run `init.test.ts` to prove red**
 
 ```bash
 bun run test:run -- src/lib/games/ice-slide/init.test.ts
 ```
 
-Expected: FAIL on the old handle/submission/overlay behavior.
+Expected: FAIL on old handle/HUD/submission/overlay behavior.
 
-- [ ] **Step 6: Refactor start internals around a materialized run**
+- [ ] **Step 7: Refactor startup around one `startRun()` closure**
 
-Create one private local `startRun(run?: IceSlideRunDefinition)` closure that contains the existing game/renderer teardown and startup sequence.
+Keep the existing teardown/game construction/renderer sequence in one local helper.
 
 Fresh start:
 
@@ -747,11 +867,14 @@ start: async (mode = 'campaign') => {
     const dateKey = toIceSlideUtcDateKey(new Date())
     const run = createIceSlideDailyRunDefinition(dateKey)
     lastStartedMode = 'daily'
+    lastDailyDateKey = dateKey
     lastDailyRun = cloneIceSlideRunDefinition(run)
     await startRun(run)
     return
   }
+
   lastStartedMode = 'campaign'
+  lastDailyDateKey = null
   lastDailyRun = null
   await startRun()
 }
@@ -761,7 +884,7 @@ Retry:
 
 ```ts
 playAgain: async () => {
-  if (lastStartedMode === 'daily' && lastDailyRun) {
+  if (lastStartedMode === 'daily' && lastDailyRun && lastDailyDateKey) {
     await startRun(cloneIceSlideRunDefinition(lastDailyRun))
     return
   }
@@ -769,40 +892,94 @@ playAgain: async () => {
 }
 ```
 
-Clear overlays/input locks at the beginning of every start.
+`startRun()` clears input locks, stage overlay, pending win, and stale result state before starting.
 
-- [ ] **Step 7: Make score submission mode-aware and asynchronous**
+- [ ] **Step 8: Extend `syncHud()` with mode-specific Daily synchronization**
 
-Capture the run guard before any auth/session await. For Daily:
+Keep current generic score/level/moves/crystals/time/name updates.
 
-1. require `gameData.solved === true`;
-2. call `authClient.getSession()`;
-3. if the run became stale, return;
-4. if no session and no auth error, return without calling `saveGameScore()`;
-5. otherwise call existing `saveGameScore()` with game data and the exact Daily context.
+Then:
 
-For Campaign, preserve the existing unscoped helper call and partial-stop behavior.
+```ts
+if (state.mode !== 'daily' || !lastDailyDateKey) {
+  dailyMeta?.classList.add('hidden')
+  return
+}
 
-Do not add server validation in this task.
+dailyMeta?.classList.remove('hidden')
+setText('daily-date', lastDailyDateKey)
+setText('daily-stage-progress', `Stage ${state.levelIndex + 1} / ${state.stagesTotal}`)
+setText('daily-objective-clear', 'Clear — reach the goal')
+setText('daily-objective-efficient', `Efficient — ≤ ${state.parMoves} moves`)
+setText(
+  'daily-objective-bonus',
+  state.objectiveIds[0]
+    ? ICE_SLIDE_OBJECTIVE_LABELS[state.objectiveIds[0]]
+    : 'Bonus objective unavailable'
+)
+```
 
-- [ ] **Step 8: Add one shared input gate to keyboard and swipe paths**
+Derive the next UTC date from the already validated captured key and format `#daily-reset` as `Resets at 00:00 UTC · Next: YYYY-MM-DD`. Do not create a live countdown.
 
-Use one predicate such as:
+Call `syncHud()` during initial start, normal move paths, and again on Continue after the next stage was already loaded.
+
+- [ ] **Step 9: Add one shared movement gate**
 
 ```ts
 const canAcceptMove = () =>
   !!game && game.getState().status === 'playing' && !inputLocked
 ```
 
-Both input handlers call it. `resetLevel()` also no-ops while the stage-clear overlay is locking interaction.
+Keyboard and pointer/swipe both use it. `resetLevel()` no-ops while `inputLocked`.
 
-- [ ] **Step 9: Implement stage-clear Continue behavior**
+- [ ] **Step 10: Preserve engine callback order but defer Daily final side effects**
 
-For Daily `onLevelClear(result)`, set the lock, populate/show the page-local overlay, and focus Continue. Campaign forwards the callback without showing the Daily stage overlay.
+Daily `onLevelClear(result)`:
 
-For a final Daily win, store `pendingDailyWinScore` instead of immediately replacing the stage overlay. Continue finalizes the shared result overlay, invokes external `onWin`, and starts the scoped submission.
+- set lock;
+- populate/show stage overlay;
+- focus Continue;
+- if game is already `won`, hide/disable End while final Continue is pending.
 
-- [ ] **Step 10: Run integration tests**
+Daily `onWin(finalScore)`:
+
+```ts
+pendingDailyWinScore = finalScore
+return
+```
+
+It does not show mission-complete, reset controls, invoke external `callbacks.onWin`, authenticate, or submit.
+
+Final Continue performs those actions once. Campaign `onWin` keeps existing immediate behavior.
+
+- [ ] **Step 11: Make `stop()` overlay-aware**
+
+Before ordinary stop logic:
+
+```ts
+if (pendingDailyWinScore !== null) {
+  return
+}
+```
+
+When a non-final Daily stage overlay is active:
+
+- hide it;
+- clear lock/result state;
+- stop the playing game;
+- reset controls;
+- show local `RUN ENDED` using current score;
+- do not call Daily `submitScore()`.
+
+Ordinary Campaign stop keeps its current positive-score partial submission behavior. Ordinary Daily stop never submits.
+
+- [ ] **Step 12: Make Daily submission async/auth-aware**
+
+Only final Continue calls the Daily submission helper. Require `gameData.solved === true`, capture run guard before `authClient.getSession()`, re-check staleness afterward, skip confirmed anonymous, and otherwise call existing `saveGameScore()` with exact contextual options.
+
+Do not add HPA-488 server validation.
+
+- [ ] **Step 13: Run integration tests**
 
 ```bash
 bun run test:run -- \
@@ -813,7 +990,7 @@ bun run test:run -- \
 
 Expected: PASS.
 
-- [ ] **Step 11: Commit**
+- [ ] **Step 14: Commit**
 
 ```bash
 git add src/lib/games/ice-slide/init.ts src/lib/games/ice-slide/init.test.ts
@@ -822,19 +999,17 @@ git commit -m "feat(ice-slide): integrate daily run lifecycle"
 
 ---
 
-### Task 5: Add the compact Daily page UX and markup contracts
+## Task 5: Add compact Daily page UX and freeze page glue
 
 **Files:**
 - Modify: `src/pages/ice-slide/index.astro`
 - Modify: `src/pages/game-board-markup.test.ts`
 
-**Interfaces:**
-- Consumes: `IceSlideHandle.start(mode)`, `IceSlideHandle.playAgain()`.
-- Produces DOM IDs consumed by Task 4; page-level URL/mode selection and Change Mode behavior.
+**Consumes:** `IceSlideHandle.start(mode)` and `IceSlideHandle.playAgain()`.
 
-- [ ] **Step 1: Add failing markup-contract assertions**
+- [ ] **Step 1: Add failing markup/wiring assertions**
 
-Extend `game-board-markup.test.ts` to load Ice Slide markup once and assert the required surfaces:
+Load Ice Slide markup in `game-board-markup.test.ts` and assert:
 
 ```ts
 expect(iceSlideMarkup).toContain('id="ice-slide-mode-selector"')
@@ -842,76 +1017,105 @@ expect(iceSlideMarkup).toContain('value="campaign"')
 expect(iceSlideMarkup).toContain('value="daily"')
 expect(iceSlideMarkup).not.toContain('value="expedition"')
 expect(iceSlideMarkup).toContain('id="daily-meta"')
+expect(iceSlideMarkup).toContain('id="daily-date"')
+expect(iceSlideMarkup).toContain('id="daily-reset"')
+expect(iceSlideMarkup).toContain('id="daily-stage-progress"')
 expect(iceSlideMarkup).toContain('id="stage-clear-overlay"')
 expect(iceSlideMarkup).toContain('id="stage-clear-continue-btn"')
 expect(iceSlideMarkup).toContain('id="change-mode-btn"')
+expect(iceSlideMarkup).toContain('gameHandle?.playAgain()')
 expect(iceSlideMarkup).toContain('Daily adds +100')
 ```
 
-- [ ] **Step 2: Run the markup test and verify it fails**
+The Playwright test in Task 6 is still authoritative for user behavior; this static check makes accidental reversion to `start()` obvious during page editing.
+
+- [ ] **Step 2: Run markup test to prove red**
 
 ```bash
 bun run test:run -- src/pages/game-board-markup.test.ts
 ```
 
-Expected: FAIL on missing Daily markup.
+Expected: FAIL on missing Daily markup/wiring.
 
-- [ ] **Step 3: Add a semantic two-option selector above the board**
+- [ ] **Step 3: Add semantic two-option selector**
 
-Use a `fieldset`/radio pair rather than a custom mode component:
+Use a page-local fieldset/radios:
 
 ```html
 <fieldset id="ice-slide-mode-selector">
   <legend>Mode</legend>
-  <label><input type="radio" name="ice-slide-mode" value="campaign" checked /> Campaign</label>
-  <label><input type="radio" name="ice-slide-mode" value="daily" /> Daily</label>
+  <label>
+    <input type="radio" name="ice-slide-mode" value="campaign" checked />
+    Campaign
+  </label>
+  <label>
+    <input type="radio" name="ice-slide-mode" value="daily" />
+    Daily
+  </label>
 </fieldset>
 ```
 
-Style locally with existing Tailwind/Cetus classes. Do not create a reusable selector component for one page.
+Style with existing Tailwind/Cetus classes; do not create a reusable mode component.
 
-- [ ] **Step 4: Add Daily metadata/objective and stage-clear markup**
+- [ ] **Step 4: Add Daily HUD and stage-clear markup**
 
-The Daily HUD is hidden by default and contains the exact IDs from Task 4. Its copy includes UTC date/reset context without a countdown scheduler.
+Add hidden `#daily-meta` with exact Task 4 IDs. Add an opaque page-local `#stage-clear-overlay` inside the board wrapper with result rows and a real Continue button.
 
-Add an absolutely positioned opaque stage-clear overlay inside the board wrapper, hidden by default, with text/symbol objective states and a real button for Continue.
+Use text/symbol state in addition to color. `init.ts`, not page script, populates the live Daily values.
 
-- [ ] **Step 5: Add Change Mode to the existing final-stats slot**
+- [ ] **Step 5: Add Change Mode through existing `final-stats` slot**
 
-Use the GamePage `final-stats` slot to render a small secondary `#change-mode-btn`. It only returns the page to pre-run state; do not alter the shared `GameOverlay` API.
+Add a secondary `#change-mode-btn`. Do not modify shared `GameOverlay` or `GamePage` APIs.
 
-- [ ] **Step 6: Wire URL selection and lifecycle**
-
-At page init:
+- [ ] **Step 6: Wire URL preselection and fresh Start**
 
 ```ts
 const requestedMode = new URLSearchParams(window.location.search).get('mode')
 const selectedMode = requestedMode === 'daily' ? 'daily' : 'campaign'
 ```
 
-Set the corresponding radio. Do not auto-start.
+Set the radio only; do not auto-start.
 
-On Start, read the checked radio and call `gameHandle.start(mode)`.
+Start reads the checked radio and calls `gameHandle.start(mode)`. Disable mode radios while active.
 
-On Play Again, call `gameHandle.playAgain()` rather than `start()`.
+- [ ] **Step 7: Wire Play Again to retry and Change Mode to idle**
 
-Disable mode radios while a run is active. Change Mode hides the result overlay, re-enables the selector, and leaves the game idle; the next Start is fresh and therefore may capture a new UTC date.
+Replace the current Play Again call to `start()` with:
 
-Update local callback signatures for `onLevelClear(result)`.
+```ts
+playAgainBtn.addEventListener('click', async () => {
+  overlay.classList.add('hidden')
+  await gameHandle?.playAgain()
+})
+```
 
-- [ ] **Step 7: Add concise Daily instructions/scoring copy**
+Change Mode:
 
-Keep Campaign copy. Add only what a Daily player needs:
+- hides result overlay;
+- shows pre-run status prompt;
+- re-enables mode radios;
+- restores Start visible / End hidden;
+- does not call `start()` or `playAgain()`.
 
-- one five-stage run per UTC day;
-- three stars: Clear, Efficient, seeded bonus;
+The next Start is fresh and can therefore capture a post-rollover Daily date.
+
+- [ ] **Step 8: Keep End behavior compatible with Task 4**
+
+The normal End click still calls `gameHandle.stop()`. Final-stage Continue hides/disables End through `init.ts`, preventing a user click while completion is pending. The page does not duplicate overlay-state logic.
+
+- [ ] **Step 9: Add concise Daily instructions/scoring copy**
+
+Add only:
+
+- five stages shared per UTC date;
+- Clear/Efficient/seeded bonus stars;
 - +100 for Efficient/bonus star;
 - 5:00 Daily completion budget;
-- Play Again retries the same Daily.
+- Play Again retries the same Daily run.
 
-Do not add leaderboard copy until HPA-488.
+No leaderboard copy before HPA-488.
 
-- [ ] **Step 8: Run page and Ice Slide integration tests**
+- [ ] **Step 10: Run page + init tests**
 
 ```bash
 bun run test:run -- \
@@ -921,7 +1125,7 @@ bun run test:run -- \
 
 Expected: PASS.
 
-- [ ] **Step 9: Commit**
+- [ ] **Step 11: Commit**
 
 ```bash
 git add src/pages/ice-slide/index.astro src/pages/game-board-markup.test.ts
@@ -930,43 +1134,71 @@ git commit -m "feat(ice-slide): add daily mode interface"
 
 ---
 
-### Task 6: Lock E2E/regression behavior and run full verification
+## Task 6: Lock page-level rollover/retry behavior and run full verification
 
 **Files:**
 - Modify: `e2e/games/play-coverage.spec.ts`
-- Modify only tests required to satisfy the final coverage gate; do not add production code solely to make coverage easier.
+- Modify only tests needed for final coverage; do not add production code solely to make coverage easier.
 
-**Interfaces:**
-- Verifies all HPA-487 user-visible behavior; produces no new production API.
+- [ ] **Step 1: Preserve the Campaign smoke**
 
-- [ ] **Step 1: Preserve the existing Campaign smoke test**
+Keep `/ice-slide` as Campaign default. Assert Campaign radio selected, Start works, `ArrowDown` still clears First Frost to level 2, and End keeps current result behavior.
 
-Keep `/ice-slide` as Campaign default. Extend the existing test only enough to assert the Campaign radio is selected before Start and that the existing first-level `ArrowDown` flow still reaches level 2.
-
-- [ ] **Step 2: Add a Daily query/interaction smoke test**
-
-Add a focused test:
+- [ ] **Step 2: Add Daily query/HUD smoke**
 
 ```ts
-test('preselects Daily, starts the UTC run, and can end locally', async ({ page }) => {
+test('preselects Daily and exposes objectives before the first move', async ({ page }) => {
+  await page.clock.setFixedTime(new Date('2026-08-12T20:00:00Z'))
   await page.goto('/ice-slide?mode=daily')
   await expect(page.locator('input[value="daily"]')).toBeChecked()
   await startGameWhenReady(page)
   await expect(page.locator('#daily-meta')).toBeVisible()
+  await expect(page.locator('#daily-date')).toHaveText('2026-08-12')
   await expect(page.locator('#daily-stage-progress')).toHaveText(/1\s*\/\s*5/)
   await expect(page.locator('#daily-objective-clear')).toContainText('Clear')
-  await page.locator('#end-btn').click()
-  await expect(page.locator('#game-over-overlay')).not.toHaveClass(/hidden/)
+  await expect(page.locator('#daily-objective-efficient')).toContainText('Efficient')
+  await expect(page.locator('#daily-objective-bonus')).not.toHaveText('')
 })
 ```
 
-The test does not depend on the first Daily transform's solution path.
+- [ ] **Step 3: Add the page-glue UTC rollover / Play Again / Change Mode path**
 
-- [ ] **Step 3: Add malformed/unavailable mode fallback coverage**
+This test must catch the existing bug where page Play Again calls fresh `start()`:
 
-Navigate to `/ice-slide?mode=expedition` and `/ice-slide?mode=not-a-mode`; assert Campaign is selected and no run auto-starts.
+```ts
+test('Play Again preserves Daily identity across UTC rollover and Change Mode stays idle', async ({ page }) => {
+  await page.clock.setFixedTime(new Date('2026-08-12T23:59:59Z'))
+  await page.goto('/ice-slide?mode=daily')
+  await startGameWhenReady(page)
+  await expect(page.locator('#daily-date')).toHaveText('2026-08-12')
 
-- [ ] **Step 4: Run focused E2E**
+  // Partial Daily End is local but keeps the retry snapshot.
+  await page.locator('#end-btn').click()
+  await expect(page.locator('#game-over-overlay')).not.toHaveClass(/hidden/)
+
+  await page.clock.setFixedTime(new Date('2026-08-13T00:00:01Z'))
+  await page.locator('#play-again-btn').click()
+  await expect(page.locator('#daily-date')).toHaveText('2026-08-12')
+  await expect(page.locator('#end-btn')).toBeVisible()
+
+  await page.locator('#end-btn').click()
+  await expect(page.locator('#game-over-overlay')).not.toHaveClass(/hidden/)
+  await page.locator('#change-mode-btn').click()
+
+  await expect(page.locator('#ice-slide-mode-selector input')).toBeEnabled()
+  await expect(page.locator('#start-btn')).toBeVisible()
+  await expect(page.locator('#end-btn')).toHaveCSS('display', 'none')
+  await expect(page.locator('#game-status')).toBeVisible()
+})
+```
+
+`page.clock.setFixedTime()` is called before navigation and changed after the first End so browser `new Date()` crosses UTC midnight without coupling the test to real wall time.
+
+- [ ] **Step 4: Add malformed/unavailable mode fallback coverage**
+
+Navigate to both `/ice-slide?mode=expedition` and `/ice-slide?mode=not-a-mode`. Assert Campaign selected, Start visible, and no run auto-started.
+
+- [ ] **Step 5: Run focused Ice Slide E2E**
 
 ```bash
 bun run test:e2e -- e2e/games/play-coverage.spec.ts --grep "Ice Slide"
@@ -974,7 +1206,7 @@ bun run test:e2e -- e2e/games/play-coverage.spec.ts --grep "Ice Slide"
 
 Expected: PASS.
 
-- [ ] **Step 5: Run the complete Ice Slide unit suite**
+- [ ] **Step 6: Run complete Ice Slide/markup unit suites**
 
 ```bash
 bun run test:run -- src/lib/games/ice-slide src/pages/game-board-markup.test.ts
@@ -982,9 +1214,7 @@ bun run test:run -- src/lib/games/ice-slide src/pages/game-board-markup.test.ts
 
 Expected: PASS.
 
-- [ ] **Step 6: Run repository verification**
-
-Run, in order:
+- [ ] **Step 7: Run repository verification**
 
 ```bash
 bun run format:check
@@ -999,40 +1229,46 @@ Expected:
 
 - format: PASS;
 - lint: no new errors;
-- typecheck: no diagnostics introduced by this branch;
-- test suite: PASS;
-- coverage: satisfies the repository's current 95% Codecov gate;
+- typecheck: no branch-introduced diagnostics;
+- tests: PASS;
+- coverage: current 95% gate satisfied;
 - build: PASS.
 
-If `typecheck` exposes a diagnostic already present byte-for-byte on `main`, document that baseline in the implementation PR rather than expanding HPA-487 into an unrelated fix. Any diagnostic in an HPA-487-touched file must be fixed before completion.
+If typecheck shows a byte-identical `main` baseline diagnostic outside touched scope, document it rather than expanding HPA-487. Any diagnostic in a touched file must be fixed.
 
-- [ ] **Step 7: Run a final scope diff**
+- [ ] **Step 8: Verify final diff scope**
 
 ```bash
 git diff --stat main...HEAD
 git diff --name-only main...HEAD
 ```
 
-Verify there are no changes to database/leaderboard server paths, Expedition/template code, snow/cracked-ice work, shared GamePage/GameOverlay APIs, or platform Daily Challenge rotation.
+Confirm no database/leaderboard-server paths, Expedition/template code, snow/cracked-ice work, shared GamePage/GameOverlay APIs, or platform Daily rotation changes.
 
-- [ ] **Step 8: Self-review the implementation against HPA-487**
+- [ ] **Step 9: Self-review every HPA-487 contract**
 
-Check each acceptance condition explicitly:
+Explicitly check:
 
-- same date/version exact deterministic run;
-- representative date variation;
+- literal `2026-08-12` generator-v1 tuple;
+- 2026 full-date no-throw sweep;
+- same-date byte equivalence and representative variation;
+- exact fork labels/source-by-ID/stage metadata;
 - five unique templates/canonical boards;
-- solver recomputed par/objective feasibility;
-- reset/hazard star facts;
-- Daily formula/300-second bonus;
-- completed-only contextual submission;
-- anonymous local result;
-- Campaign compatibility;
-- mode/query/retry/overlay/keyboard/swipe/reduced-motion/error cleanup.
+- solver par/objective feasibility;
+- manual/hazard star facts;
+- Daily formula/300-second completion bonus;
+- engine final callback order `level-clear` then `win`;
+- non-final overlay End local/no-submit;
+- final overlay End inert and final Continue is the only submission transition;
+- HUD populated before each stage's first accepted move;
+- handle-level rollover retry plus page-level Play Again rollover E2E;
+- Change Mode idle/no-auto-start;
+- completed-only contextual submission and anonymous local result;
+- Campaign compatibility and HPA-488 boundary.
 
 Fix any gap before the final commit.
 
-- [ ] **Step 9: Commit E2E/verification test changes**
+- [ ] **Step 10: Commit E2E changes**
 
 ```bash
 git add e2e/games/play-coverage.spec.ts
@@ -1045,30 +1281,32 @@ git commit -m "test(ice-slide): cover daily challenge flows"
 
 ### Spec coverage
 
-- Deterministic Daily identity, tier pools, transforms, canonical uniqueness, solver par verification, and seeded objective selection: Task 1.
-- Objective semantics and exact Daily score formula: Task 2.
-- Falls/resets/stars/stage results and game-data counters: Task 3.
-- UTC capture vs retry, completed-only submission, anonymous behavior, input/overlay lifecycle: Task 4.
-- Compact selector, URL preselection, date/reset/stage/objective UI, Continue, Change Mode, copy: Task 5.
-- Campaign regression, E2E, full gates, and final scope check: Task 6.
+- **Task 1:** shared UTC calendar contract, exact RNG labels, source-by-ID mapping, frozen stage metadata, literal generator-v1 output, year sweep, solver/quality validation.
+- **Task 2:** objective semantics and additive Daily scoring.
+- **Task 3:** reset/fall counters, stars, score application, final engine callback order.
+- **Task 4:** fresh/retry UTC identity, Daily HUD, overlay/End semantics, final-Continue submission, auth/stale handling, input parity.
+- **Task 5:** selector/HUD/result markup, page `playAgain()` wiring, Change Mode, no shared overlay changes.
+- **Task 6:** browser-level UTC rollover retry, Change Mode no-auto-start, malformed-mode fallback, full regression/coverage gates.
 
 No HPA-487 acceptance criterion is intentionally deferred.
 
 ### Placeholder scan
 
-No `TBD`, `TODO`, generic “add tests”, or unspecified error-handling step remains. Each task names exact files, interfaces, commands, and expected outcomes.
+No `TBD`, `TODO`, generic “add tests”, or unspecified lifecycle branch remains. Exact interfaces, fork labels, generator tuple, DOM IDs, test paths, commands, and expected outcomes are named.
 
 ### Type/contract consistency
 
-- `IceSlidePlayableMode` is exactly `'campaign' | 'daily'` at the browser boundary; `IceSlideMode` remains broader for future Expedition materialized runs.
-- Daily generator version is defined once in `daily.ts` and reused by tests/fixtures.
+- `IceSlidePlayableMode` is exactly `'campaign' | 'daily'`; `IceSlideMode` remains broader.
+- UTC date calendar validation has one source in `run.ts`; `daily.ts` reuses it.
+- Daily generator version is defined once in `daily.ts` and reused by fixtures/tests.
 - Existing ruleset/schema constants remain in `run.ts`.
-- `onLevelClear` has one result-object signature everywhere after Task 2/3 migration.
-- `IceSlideGameData` keeps the existing persisted metadata shape; new per-stage facts live only in state/callback results.
-- HPA-488 remains the sole owner of server Daily semantic admission and ranked presentation.
+- `onLevelClear` has one result-object signature and engine callback order stays unchanged.
+- Daily final browser/network side effects move to Continue without changing engine sequencing.
+- `IceSlideGameData` keeps existing run/counter metadata; active-stage HUD facts remain state/callback data.
+- HPA-488 remains the sole owner of server Daily admission and ranked presentation.
 
 ## Execution Handoff
 
-Plan complete and saved to `docs/superpowers/plans/2026-08-12-ice-slide-daily-challenge.md`.
+Plan saved to `docs/superpowers/plans/2026-08-12-ice-slide-daily-challenge.md`.
 
-Recommended execution is **subagent-driven development** with a fresh implementation/review gate for each of the six tasks above. Inline execution is also valid if the task sequence and commit boundaries are preserved.
+Recommended execution is **subagent-driven development**, one fresh implementation/review gate per task. Inline execution is also valid if the six task and commit boundaries are preserved.

--- a/docs/superpowers/specs/2026-08-12-ice-slide-daily-challenge-design.md
+++ b/docs/superpowers/specs/2026-08-12-ice-slide-daily-challenge-design.md
@@ -1,0 +1,527 @@
+# Ice Slide Daily Challenge MVP — Design
+
+- **Date:** 2026-08-12
+- **Status:** Proposed for HPA-487 implementation
+- **Repository:** `cwchanap/cetus`
+- **Linear issue:** HPA-487 — Ship Ice Slide Daily Challenge MVP with mode selection and three-star objectives
+- **Parent design:** `docs/superpowers/specs/2026-07-30-ice-slide-replayability-design.md`
+
+## 1. Summary
+
+HPA-487 is the next unblocked Ice Slide replayability task. Its prerequisites are already merged: HPA-484 added optional score context, HPA-485 added deterministic run definitions/RNG/transforms, and HPA-486 added the production solver and stage-quality validator.
+
+This change should therefore be an integration feature, not a new game framework. Daily generation materializes an `IceSlideRunDefinition` before play starts; `IceSlideGame` continues to consume materialized runs. Pure helpers own Daily generation, objective evaluation, and scoring. `init.ts` owns the clock boundary, retry identity, local UI gating, and submission choice.
+
+The MVP ships only two selectable modes:
+
+- **Campaign** — unchanged default behavior.
+- **Daily** — one deterministic five-stage run per UTC date and version pair.
+
+HPA-488 remains responsible for server-side semantic admission and the Daily leaderboard UI/query flow.
+
+## 2. Why HPA-487 Is Next
+
+Linear currently models HPA-487 as blocked by HPA-484, HPA-485, and HPA-486. All three are Done. HPA-487 in turn blocks HPA-488, HPA-489, and HPA-490, so completing it unlocks both the Daily ranking finish work and Expedition generation work.
+
+No HPA-487 branch or PR currently exists in GitHub.
+
+## 3. Existing Boundaries to Reuse
+
+The current code already provides the important foundations:
+
+- `run.ts` owns run schema/version checks, exact Daily run-key/seed validation, stage signatures, Campaign materialization, and defensive cloning.
+- `seeded-rng.ts` owns stable FNV-1a/Mulberry32 RNG and labeled forks.
+- `transforms.ts` owns all eight transforms and canonical deduplication through `getUniqueBoardTransforms()`.
+- `quality.ts` owns solver-backed board, par, duplicate, and objective-feasibility validation.
+- `game.ts` already accepts `start(run?: IceSlideRunDefinition)` and reports run/version metadata in state/game data.
+- `scoreService.ts` already accepts contextual submissions through `SaveScoreOptions.context`.
+- `index.astro` already owns the page-level Start/End/Reset/Play Again wiring.
+
+HPA-487 should extend these seams rather than introduce a generic generator framework, mode registry, overlay framework, or new persistence service.
+
+## 4. Approaches Considered
+
+### 4.1 Recommended: thin Daily materializer + pure policy helpers
+
+Add a focused `daily.ts` that turns an explicit UTC date key into a complete five-stage run, plus `objectives.ts` for objective evaluation. Extend existing scoring/game/init/page surfaces only where Daily behavior differs.
+
+**Why this fits now**
+
+- Reuses every HPA-484/485/486 primitive directly.
+- Keeps date/random selection out of `IceSlideGame`.
+- Keeps Expedition-specific template/retry orchestration out of HPA-487.
+- Produces deterministic, independently testable contracts.
+- Is small enough to replace later only if Expedition proves a shared abstraction is actually useful.
+
+### 4.2 Generic generated-run service
+
+Create a reusable generator pipeline with policies for pools, retries, objectives, fallbacks, and modes.
+
+**Rejected for HPA-487:** only Daily uses generated content today. HPA-489 has materially different authored mutation templates and bounded candidate generation. Generalizing before that code exists would encode guesses and increase the implementation surface.
+
+### 4.3 Put Daily generation inside `IceSlideGame`
+
+Have the game inspect the current date and construct Daily stages internally.
+
+**Rejected:** this breaks the already-established materialized-run boundary, makes rollover/retry testing harder, and couples gameplay state to clock/RNG policy.
+
+## 5. Fixed Product Decisions
+
+1. Campaign remains the default and keeps its existing score/submission semantics.
+2. Daily is the only additional selectable mode. Do not show Expedition placeholders.
+3. `/ice-slide?mode=daily` preselects Daily. Any other/malformed value selects Campaign. Query selection never auto-starts a run.
+4. A fresh Daily Start captures the current UTC date once and materializes a run from that date.
+5. `Play Again` reuses the exact previously materialized Daily run, even after UTC rollover.
+6. A player can choose **Change Mode** from the result overlay to return to the idle selector; starting Daily from there captures the then-current UTC date.
+7. Daily has exactly five stages and one seeded bonus objective per stage.
+8. Stage-clear feedback uses an explicit **Continue** button. There is no auto-advance timer or forced animation delay.
+9. Daily partial End is local only and never sends a score.
+10. Daily completed authenticated runs send contextual scores. A positively confirmed anonymous session stays local without producing a score-save error.
+11. HPA-488 owns server-side Daily admission rules and leaderboard presentation; HPA-487 does not duplicate them.
+12. Expedition, mutation templates, snow, cracked ice, abilities, and the platform-wide Daily Challenge rotation remain out of scope.
+
+## 6. Daily Run Materialization
+
+### 6.1 Version and identity
+
+Add:
+
+```ts
+export const ICE_SLIDE_DAILY_GENERATOR_VERSION = 1
+export const ICE_SLIDE_DAILY_SOLVER_MAX_STATES = 10_000
+```
+
+For an explicit `dateKey: YYYY-MM-DD`:
+
+```text
+seed = ice-slide:daily:<generatorVersion>:<rulesetVersion>:YYYY-MM-DD
+runKey = ice-slide:daily:YYYY-MM-DD:g<generatorVersion>:r<rulesetVersion>
+```
+
+The generator uses the existing `ICE_SLIDE_RULESET_VERSION`. `init.ts`, not the generator or game engine, converts `new Date()` to a UTC date key.
+
+### 6.2 Tier pools
+
+Daily stage pools are fixed to the parent design:
+
+```ts
+[
+  [1, 2],
+  [2, 3],
+  [3, 4, 5],
+  [5, 6, 7],
+  [7, 8],
+]
+```
+
+The values are authored Campaign level IDs, not array offsets.
+
+`run.ts` should expose the existing Campaign difficulty mapping under a stable exported name so `daily.ts` does not duplicate level-to-difficulty knowledge.
+
+### 6.3 Exact deterministic selection algorithm
+
+The algorithm is deliberately finite and bounded by the small authored pools:
+
+1. Create `rootRng = createSeededRng(seed)`.
+2. For stage number `N` (1-based), create `stageRng = rootRng.fork('stage:N')`.
+3. Shuffle that stage's level pool with `stageRng.fork('template').shuffle(pool)`.
+4. Iterate the shuffled level IDs and skip any template ID already used by this run.
+5. For each remaining source level, call `getUniqueBoardTransforms(level.rows)`. This removes symmetric duplicate transforms before random choice.
+6. Shuffle those unique variants with `stageRng.fork('transform:<levelId>').shuffle(variants)`.
+7. Iterate variants and call `validateIceSlideStageQuality()` with:
+   - `objectiveIds: []`;
+   - `parBand.minMoves = source.parMoves`;
+   - `parBand.maxMoves = source.parMoves`;
+   - `maxStates = 10_000`;
+   - the canonical keys already accepted for earlier stages.
+8. The first accepted candidate wins. Its returned `parMoves` becomes the materialized par.
+9. Build the eligible bonus-objective list from the validator's `objectiveFeasibility` in this fixed order:
+   `collect_all_crystals`, `no_falls`, `no_reset`.
+10. Pick exactly one with `stageRng.fork('objective').pick(eligibleObjectives)`.
+11. Materialize the stage with the selected transform, no mutation IDs, `scoreMultiplierBps = 10000`, and a signature from `createIceSlideStageSignature()`.
+12. Record the source template ID and canonical key, then continue to the next stage.
+13. After five stages, call `assertValidIceSlideRunDefinition(run)` before returning it.
+
+`no_reset` is feasible for every solvable board, so the eligible-objective list is non-empty after quality acceptance.
+
+The complete search space is at most three authored templates × eight unique transforms for any one Daily stage, so it stays below the parent design's 64-candidate cap without introducing a retry service. If the checked-in authored content cannot produce a valid unique candidate, `createIceSlideDailyRunDefinition()` throws. The existing `failRun` path owns cleanup and player-safe error display.
+
+### 6.4 No hidden nondeterminism
+
+`daily.ts` must not call `Math.random()`, `crypto.getRandomValues()`, or read the current clock. All entropy comes from the explicit seed and labeled RNG forks.
+
+## 7. Objective and Star Model
+
+Add a pure `objectives.ts` helper rather than embedding policy in the renderer or page.
+
+```ts
+export interface IceSlideObjectiveFacts {
+  parMoves: number
+  movesUsed: number
+  crystalsCollected: number
+  totalCrystals: number
+  falls: number
+  resets: number
+}
+
+export function isIceSlideObjectiveComplete(
+  objectiveId: IceSlideObjectiveId,
+  facts: IceSlideObjectiveFacts
+): boolean
+```
+
+Completion rules:
+
+- `collect_all_crystals`: `totalCrystals > 0` and all stage crystals were collected.
+- `no_falls`: no hazard was entered during the stage.
+- `no_reset`: neither manual Reset nor hazard reset occurred during the stage.
+
+Daily stars are computed at clear time:
+
+- Clear: always earned when the result is produced.
+- Efficient: `movesUsed <= parMoves`.
+- Bonus: evaluate the stage's single `objectiveIds[0]` with the facts above.
+
+The game records the cumulative Daily star count in the existing `starsEarned` field. Campaign continues to report `starsEarned = 0`.
+
+## 8. Runtime State and Stage Results
+
+Extend `IceSlideState` only with data needed to render/evaluate the active stage:
+
+```ts
+parMoves: number
+objectiveIds: IceSlideObjectiveId[]
+levelFalls: number
+levelResets: number
+```
+
+`getState()` must defensively copy `objectiveIds`.
+
+Counter rules:
+
+- A normal committed move keeps the existing move behavior.
+- Manual Reset increments `resets` and `levelResets`; it does not increment falls.
+- Hazard entry increments `falls`, `resets`, `levelFalls`, and `levelResets` exactly once.
+- Existing hazard behavior continues to preserve the hazard move in `levelMoves`.
+- Starting a new stage resets `levelFalls`/`levelResets` to zero.
+- Reloading the same stage because of Reset/hazard preserves those stage counters.
+
+Replace the numeric `onLevelClear(level)` payload with a focused result object because the callback is local to Ice Slide and the new UI needs the facts anyway:
+
+```ts
+export interface IceSlideStageClearResult {
+  stageNumber: number
+  stageName: string
+  parMoves: number
+  movesUsed: number
+  crystalsCollected: number
+  scoreGained: number
+  stars: {
+    clear: boolean
+    efficient: boolean
+    bonus: { id: IceSlideObjectiveId; earned: boolean } | null
+    earnedCount: number
+  }
+}
+```
+
+For Campaign, `bonus` is `null` and cumulative `starsEarned` remains unchanged. The `efficient` fact may still be reported for consistency, but Campaign UI does not show star feedback.
+
+The game can prepare the next stage immediately after producing this result. The browser integration places an opaque stage-clear overlay above the canvas before `afterMove()` renders again, so the player sees the completed-stage result before interacting with the next board without adding a new game-engine pause/advance state.
+
+## 9. Scoring
+
+Existing Campaign functions and constants remain unchanged.
+
+Add pure Daily functions in `scoring.ts`:
+
+```ts
+export const DAILY_SCORING_CONFIG = {
+  objectiveStarBonus: 100,
+  timeBudgetSeconds: 300,
+  timeBonusPerSec: 5,
+} as const
+
+export function dailyStageScore(params: {
+  stageNumber: number
+  parMoves: number
+  movesUsed: number
+  crystalsCollected: number
+  optionalStarsEarned: number
+}): number
+
+export function dailyTimeBonus(elapsedSeconds: number): number
+```
+
+`dailyStageScore` reuses the current Campaign primitives for base clear, move efficiency, and crystals:
+
+```text
+200 × stageNumber
++ moveBonus(parMoves, movesUsed)
++ 50 × crystalsCollected
++ 100 × optionalStarsEarned
+```
+
+`optionalStarsEarned` is the number of earned Efficient/bonus stars (`0..2`); the Clear star is represented by the base clear points.
+
+The Daily completion bonus is:
+
+```text
+max(0, (300 - elapsedSeconds) × 5)
+```
+
+Only `mode === 'daily'` uses these new functions. Campaign keeps the existing 360-second completion bonus. Expedition scoring is not implemented or changed by HPA-487.
+
+## 10. Browser Lifecycle and Retry Semantics
+
+Change the handle to expose the two shipped choices without inventing a mode registry:
+
+```ts
+export type IceSlidePlayableMode = 'campaign' | 'daily'
+
+export interface IceSlideHandle {
+  start: (mode?: IceSlidePlayableMode) => Promise<void>
+  playAgain: () => Promise<void>
+  stop: () => void
+  resetLevel: () => void
+  cleanup: () => void
+  getGame: () => IceSlideGame | null
+}
+```
+
+`start(mode)` means a **fresh** run:
+
+- Campaign creates the normal Campaign run.
+- Daily captures `new Date().toISOString().slice(0, 10)`, materializes the Daily run, and stores a defensive copy as the retry run.
+
+`playAgain()` means **retry the last started run**:
+
+- Campaign starts Campaign again.
+- Daily starts a clone of the exact stored run. It never re-reads the date.
+
+This distinction directly handles UTC rollover without adding clock state to `IceSlideGame`.
+
+## 11. Stage-Clear and Input Gating
+
+`init.ts` owns a small `inputLocked` flag.
+
+Input is accepted only while:
+
+```text
+game.status === 'playing' && inputLocked === false
+```
+
+Both keyboard and pointer/swipe paths use the same condition.
+
+For Daily stage clear:
+
+1. Receive `IceSlideStageClearResult`.
+2. Set `inputLocked = true`.
+3. Fill the stage-clear overlay with Clear/Efficient/bonus states and score gained.
+4. Show the overlay and focus its Continue button.
+5. On Continue, hide the overlay, clear the lock, render/sync the next stage.
+
+There is no auto-dismiss timer. This makes keyboard behavior deterministic and inherently satisfies reduced-motion requirements.
+
+On the fifth Daily stage, `onWin` records the pending final score while the stage-clear overlay remains visible. Continue then transitions to the existing mission-complete overlay, invokes the external win callback, and submits the completed result.
+
+All failure/cleanup/start paths clear pending overlay state and input locks.
+
+## 12. Page UI
+
+Keep the UI local to `src/pages/ice-slide/index.astro`.
+
+### 12.1 Pre-run mode selector
+
+Add a compact semantic selector above the canvas:
+
+- Campaign
+- Daily
+
+Campaign starts selected. The page reads `URLSearchParams` once during initialization; only the exact string `daily` preselects Daily. `campaign`, missing values, `expedition`, and malformed values all select Campaign.
+
+The selector is disabled while a run is active.
+
+### 12.2 Daily HUD
+
+Show only in Daily mode:
+
+- UTC competition date.
+- `Resets at 00:00 UTC` plus the next UTC date.
+- `Stage N / 5`.
+- active objective rows for Clear, Efficient (`≤ par`), and the seeded bonus objective.
+
+Do not add a countdown timer; the existing elapsed-time ticker should not be overloaded with UTC boundary scheduling.
+
+### 12.3 Stage-clear overlay
+
+Add a page-local overlay inside the board area with:
+
+- stage name/number;
+- three objective rows with earned/missed states;
+- stage score gained;
+- Continue button.
+
+Use text/symbol state in addition to color.
+
+### 12.4 Result overlay escape path
+
+Keep the shared GameOverlay's primary **Play Again** button. Add a small **Change Mode** button through the existing `final-stats` slot. It hides the result overlay, returns to the idle selector, and does not start a run.
+
+This preserves the required Daily retry behavior while still letting a player switch mode or start a new post-rollover Daily run.
+
+### 12.5 Scoring copy
+
+Keep existing Campaign scoring copy and add one concise Daily note: Daily gives +100 for each Efficient/bonus star and uses a 5:00 completion budget.
+
+No new shared UI component is needed for one page.
+
+## 13. Score Submission and Anonymous Play
+
+Campaign submission remains byte-for-behavior compatible:
+
+- completed Campaign submits unscoped;
+- manually ended Campaign with positive score still submits its partial score.
+
+Daily behavior:
+
+- manual End never submits;
+- only the final completed five-stage run submits;
+- submission uses current game data and:
+
+```ts
+{
+  context: {
+    mode: 'daily',
+    competitionKey: gameData.runKey,
+    rulesetVersion: gameData.rulesetVersion,
+  },
+  isStale,
+}
+```
+
+Before a Daily submission, call the existing `authClient.getSession()`:
+
+- if it positively returns no session and no error, keep the result local and skip `saveGameScore()`;
+- if a session exists, submit normally;
+- if the session check itself fails, allow the existing score endpoint to remain authoritative rather than silently discarding a potentially authenticated result.
+
+A score-save failure never invalidates the completed local run.
+
+HPA-487 performs only this client lifecycle guard. HPA-488 will add server-side checks for solved state, matching Daily key/version identity, and leaderboard admission.
+
+## 14. Error Handling
+
+- Invalid/malformed mode query values fall back to Campaign without auto-start.
+- Daily materialization failures flow through the existing `failRun()` cleanup path.
+- Failed renderer setup retains the existing cleanup behavior.
+- `start()` clears stale stage/result overlay state before creating a new game.
+- Run guard semantics continue to suppress stale achievement callbacks.
+- Daily score failures use the existing `Score not saved` reporting but do not remove local completion UI.
+- A confirmed anonymous Daily completion is not an error.
+- No path falls back to nondeterministic generation.
+
+## 15. File Boundaries
+
+### Create
+
+- `src/lib/games/ice-slide/daily.ts` — deterministic Daily identity/stage materialization.
+- `src/lib/games/ice-slide/daily.test.ts` — deterministic pools/transforms/quality/version tests.
+- `src/lib/games/ice-slide/objectives.ts` — pure objective completion and display labels.
+- `src/lib/games/ice-slide/objectives.test.ts` — objective rules.
+
+### Modify
+
+- `src/lib/games/ice-slide/types.ts` — active-stage facts, stage-clear result, playable mode type.
+- `src/lib/games/ice-slide/run.ts` — expose Campaign difficulty mapping for reuse.
+- `src/lib/games/ice-slide/scoring.ts` and tests — Daily pure score functions.
+- `src/lib/games/ice-slide/game.ts` and tests — counters, Daily stars/scoring/result payload.
+- `src/lib/games/ice-slide/init.ts` and tests — fresh-vs-retry runs, input gate, overlays, scoped completed submission, anonymous guard.
+- `src/pages/ice-slide/index.astro` — selector, Daily HUD, stage/result controls and URL preselection.
+- `e2e/games/play-coverage.spec.ts` — preserve Campaign smoke and add focused Daily selector/query/lifecycle coverage.
+
+### Do not modify for HPA-487
+
+- database schema/query code;
+- `/api/leaderboard` or leaderboard pages;
+- server-side score admission logic;
+- Expedition templates/generation;
+- shared `GamePage`/`GameOverlay` APIs unless implementation discovers an actual blocker;
+- platform Daily Challenge rotation.
+
+## 16. Testing Strategy
+
+### Pure generation
+
+- exact seed/run-key format for a fixed UTC date;
+- exactly five stages;
+- stage templates follow pools and never repeat;
+- all final canonical boards are unique;
+- same date/version produces deeply equal run definitions;
+- multiple representative dates produce deterministic variation;
+- every materialized par equals the production solver result;
+- every assigned objective is feasible;
+- generated signatures pass `assertValidIceSlideRunDefinition()`.
+
+### Objectives/scoring
+
+- collect-all success/failure;
+- no-falls success/failure;
+- no-reset distinguishes manual/hazard reset history;
+- Efficient uses `<= par`;
+- Daily optional-star bonus and 300-second completion bonus exact boundaries;
+- existing Campaign scoring tests stay unchanged.
+
+### Game runtime
+
+- manual Reset increments reset counters once;
+- hazard increments fall/reset counters once and preserves move semantics;
+- per-stage attempt counters survive reload then reset on next stage;
+- Daily clear result reports exact star outcome/score gained;
+- cumulative Daily stars carry across stages;
+- Campaign score, stars, progression, reset/hazard behavior remain compatible.
+
+### Browser integration
+
+- fresh Daily captures current UTC date;
+- `playAgain()` reproduces exact run/signatures after simulated UTC rollover;
+- a new Daily `start('daily')` after rollover uses the new date;
+- partial Daily End does not call `saveGameScore()`;
+- completed Daily uses exact score context;
+- confirmed anonymous completion skips submission;
+- stage-clear overlay gates keyboard and swipe until Continue;
+- cleanup/failure clears locks/overlays;
+- Campaign partial/full submission remains unscoped.
+
+### Page/E2E
+
+- `/ice-slide` defaults to Campaign;
+- `/ice-slide?mode=daily` preselects Daily;
+- malformed/unavailable `mode` falls back to Campaign;
+- Daily Start shows date/stage/objectives;
+- Campaign happy path remains covered;
+- stage-clear Continue path is keyboard accessible;
+- Change Mode returns to the selector;
+- reduced-motion mode has no mandatory wait because the overlay is manual.
+
+## 17. Acceptance Criteria
+
+HPA-487 is complete when:
+
+1. same UTC date + versions produces byte-equivalent five-stage Daily run data across retries/clients;
+2. representative dates deterministically vary while templates/final boards do not repeat within a run;
+3. every Daily stage is solver-validated, has recomputed par, and has one feasible seeded bonus objective;
+4. stars correctly reflect par, crystals, hazards, manual Reset, and hazard reset;
+5. Daily scoring uses the documented stage formula and 300-second time budget;
+6. only completed Daily runs attempt contextual submission and confirmed anonymous runs remain local;
+7. Campaign behavior, scoring, achievements, partial End semantics, and unscoped submission remain unchanged;
+8. mode selection, URL preselection, stage metadata, objective feedback, retry identity, input gating, keyboard/swipe parity, cleanup, and reduced-motion behavior are covered by tests;
+9. no HPA-488 leaderboard/server-admission work or Expedition/evolving-tile work is pulled into this implementation.
+
+## 18. Spec Self-Review
+
+- **Placeholder scan:** no TBD/TODO or deferred decision exists inside HPA-487 scope.
+- **Consistency:** Daily generation remains outside `IceSlideGame`; the game consumes only materialized runs.
+- **Scope:** HPA-488 server admission/leaderboard work and HPA-489+ Expedition work remain explicitly separate.
+- **YAGNI:** no mode registry, generic generator pipeline, new persistence service, shared overlay abstraction, UTC countdown scheduler, or automatic stage-delay state machine is introduced.
+- **Ambiguity:** fresh Start vs Play Again has explicit rollover semantics; objective RNG order and selection labels are fixed; partial Daily End submission behavior is explicit.

--- a/docs/superpowers/specs/2026-08-12-ice-slide-daily-challenge-design.md
+++ b/docs/superpowers/specs/2026-08-12-ice-slide-daily-challenge-design.md
@@ -4,104 +4,105 @@
 - **Status:** Proposed for HPA-487 implementation
 - **Repository:** `cwchanap/cetus`
 - **Linear issue:** HPA-487 — Ship Ice Slide Daily Challenge MVP with mode selection and three-star objectives
-- **Planning PR:** #60
 - **Parent design:** `docs/superpowers/specs/2026-07-30-ice-slide-replayability-design.md`
 
 ## 1. Summary
 
-HPA-487 is the next unblocked Ice Slide replayability task. HPA-484 already added optional score context, HPA-485 added deterministic run definitions/RNG/transforms, and HPA-486 added the production solver and stage-quality validator.
+HPA-487 is the next unblocked Ice Slide replayability task. HPA-484 already added optional score context, HPA-485 added deterministic materialized runs/RNG/transforms, and HPA-486 added the production solver and stage-quality validator.
 
-This is an integration feature, not a new game framework. Daily generation materializes an `IceSlideRunDefinition` before play starts; `IceSlideGame` continues to consume materialized runs. Pure helpers own Daily generation, objective evaluation, and scoring. `init.ts` owns the clock boundary, exact retry identity, Daily HUD synchronization, stage-result gating, and submission choice.
+Daily therefore remains an integration feature, not a second game engine or a generic generation framework:
 
-The MVP ships only two selectable modes:
+- `daily.ts` materializes a complete `IceSlideRunDefinition` from an explicit UTC date key.
+- `IceSlideGame` consumes the materialized run and never reads the clock or random source.
+- objective completion and score policy stay pure.
+- `init.ts` owns fresh-vs-retry identity, HUD synchronization, mid-run stage-result gating, and score submission.
+- `index.astro` owns the page-local Campaign/Daily selector and overlays.
 
-- **Campaign** — unchanged default behavior.
-- **Daily** — one deterministic five-stage run per UTC date and version pair.
-
-HPA-488 remains responsible for server-side Daily semantic admission and the Daily leaderboard UI/query flow.
+Only **Campaign** and **Daily** are selectable. HPA-488 remains responsible for server-side Daily semantic admission and per-day leaderboard presentation.
 
 ## 2. Why HPA-487 Is Next
 
-Linear models HPA-487 as blocked by HPA-484, HPA-485, and HPA-486. All three are Done. HPA-487 then unlocks HPA-488, HPA-489, and HPA-490.
+Linear models HPA-487 as blocked by HPA-484, HPA-485, and HPA-486; all three are Done. HPA-487 then unblocks HPA-488, HPA-489, and HPA-490.
 
-The planning work lives in draft PR #60. HPA-487 remains a planning-only Backlog item until implementation begins.
+The current shipping seams already cover almost everything this feature needs:
 
-## 3. Existing Boundaries to Reuse
+- `run.ts`: run schema/version validation, Daily run-key/seed validation, signatures, Campaign materialization, defensive cloning.
+- `seeded-rng.ts`: stable FNV-1a/Mulberry32 and labeled forks.
+- `transforms.ts`: all eight transforms and canonical transform deduplication.
+- `quality.ts` / `solver.ts`: pure solver-backed stage validation.
+- `physics.ts`: parsing, sliding, and crystal counting.
+- `game.ts`: explicit `start(run?)` plus run metadata/state.
+- `scoreService.ts`: score submission plus optional contextual metadata.
+- `GamePage.astro` / `GameOverlay.astro`: existing final result overlay and `final-stats` slot.
 
-The current code already provides the important foundations:
+Do not introduce `generator.ts`, a mode registry, shared overlay framework, or new persistence service.
 
-- `run.ts` owns run schema/version checks, Daily run-key/seed validation, stage signatures, Campaign materialization, and defensive cloning.
-- `seeded-rng.ts` owns stable FNV-1a/Mulberry32 RNG and labeled forks.
-- `transforms.ts` owns all eight transforms and canonical deduplication through `getUniqueBoardTransforms()`.
-- `solver.ts` and `quality.ts` own bounded solve facts and stage admission.
-- `game.ts` already accepts `start(run?: IceSlideRunDefinition)` and reports run/version metadata.
-- `scoreService.ts` already accepts contextual submissions through `SaveScoreOptions.context`.
-- `index.astro` already owns page-level Start/End/Reset/Play Again wiring.
+## 3. Approaches Considered
 
-HPA-487 extends these seams. It does not introduce `generator.ts`, a generic generated-run service, a mode registry, a new persistence service, or a shared overlay framework.
+### 3.1 Recommended: thin Daily materializer + local integration
 
-## 4. Approaches Considered
+Create one focused `daily.ts`, one pure objective helper, and additive score configuration. Extend only the existing Ice Slide game/init/page seams.
 
-### 4.1 Recommended: thin Daily materializer + pure policy helpers
+This is the smallest implementation that preserves deterministic contracts and leaves HPA-489 free to design mutation templates without inheriting a guessed abstraction.
 
-Add a focused `daily.ts` that turns an explicit UTC date key into a complete five-stage run, plus `objectives.ts` for objective evaluation. Extend existing scoring/game/init/page surfaces only where Daily differs.
+### 3.2 Generic generated-run service
 
-This reuses every HPA-484/485/486 primitive directly and keeps the clock/RNG out of `IceSlideGame`.
+Rejected. Daily v1 only selects/transforms authored Campaign levels. Expedition has different authored mutation/fallback requirements and should not be forced into an abstraction written before it exists.
 
-### 4.2 Generic generated-run service
+### 3.3 Generate inside `IceSlideGame`
 
-Rejected. Only Daily uses generated content today, while HPA-489 has materially different authored mutation templates and bounded candidate generation. Generalizing now would encode guesses.
+Rejected. Clock/RNG ownership would break the materialized-run boundary and make retry/UTC-rollover behavior harder to reason about and test.
 
-### 4.3 Put Daily generation inside `IceSlideGame`
+## 4. Fixed Product Decisions
 
-Rejected. It breaks the materialized-run boundary and couples gameplay state to the current clock and random-selection policy.
+1. Campaign remains the default and keeps current scoring, achievements, unscoped submission, and positive-score partial-End behavior.
+2. Daily is the only additional selectable mode; no Expedition placeholder is shown.
+3. `/ice-slide?mode=daily` preselects Daily. Missing, malformed, `campaign`, or unavailable values select Campaign. Query selection never auto-starts.
+4. A fresh `start('daily')` captures the current UTC date once and materializes that run.
+5. `playAgain()` retries the exact previously materialized Daily run even after UTC rollover.
+6. Change Mode returns to the idle selector without auto-start; the next Start is fresh.
+7. Daily contains exactly five stages and one seeded feasible bonus objective per stage.
+8. Non-final Daily stage clears use an explicit Continue overlay; there is no auto-advance timer.
+9. The final Daily stage does **not** require Continue. Its three-star result is rendered in the existing final result overlay and `onWin` follows the existing immediate submission path.
+10. Daily End is always local-only and never submits. Ending an active Daily run shows `RUN ENDED` even when score is zero so Play Again/Change Mode remain available.
+11. Anonymous Daily completion may hit the normal score endpoint; a structured unauthenticated result is treated as local-only rather than as a visible save error.
+12. HPA-488 owns server admission/ranking. Expedition, mutation templates, snow, cracked ice, abilities, and platform Daily Challenge rotation are out of scope.
 
-## 5. Fixed Product Decisions
+## 5. Shared UTC Day Contract
 
-1. Campaign remains the default and keeps existing score/submission semantics.
-2. Daily is the only additional selectable mode. Do not show an Expedition placeholder.
-3. `/ice-slide?mode=daily` preselects Daily. Any other/malformed value selects Campaign. Query selection never auto-starts.
-4. A fresh Daily Start captures the current UTC date once and materializes a run for that date.
-5. `Play Again` reuses the exact previously materialized Daily run, even after UTC rollover.
-6. **Change Mode** from the result overlay returns to the idle selector without starting a run; a later Daily Start captures the then-current UTC date.
-7. Daily has exactly five stages and exactly one seeded feasible bonus objective per stage.
-8. Stage-clear feedback uses an explicit **Continue** button. There is no auto-advance timer or forced animation delay.
-9. A partial Daily End is local only and never sends a score.
-10. A completed authenticated Daily sends contextual score data. A positively confirmed anonymous session stays local without a score-save error.
-11. HPA-488 owns server-side Daily admission and ranked presentation.
-12. The finite authored Daily candidate set throws if it cannot materialize a valid stage; HPA-487 does not add the parent roadmap's mutation-generation fallback/retry service.
-13. Expedition, mutation templates, snow, cracked ice, abilities, and the platform-wide Daily Challenge rotation remain out of scope.
+### 5.1 One calendar validator
 
-## 6. Daily Run Materialization
-
-### 6.1 Shared UTC date-key validation
-
-The existing calendar-valid `YYYY-MM-DD` check inside `assertValidIceSlideRunDefinition()` must become one exported `run.ts` helper instead of being copied into `daily.ts`:
+`run.ts` already contains the calendar-valid `YYYY-MM-DD` logic inside `assertValidIceSlideRunDefinition()`. Extract it once:
 
 ```ts
 export function assertValidIceSlideUtcDateKey(dateKey: string): void
 ```
 
-The helper requires the exact `YYYY-MM-DD` shape, constructs a UTC calendar date, round-trips year/month/day, and throws `RangeError` for malformed or impossible dates.
+The function:
 
-`assertValidIceSlideRunDefinition()` calls this helper for the date segment captured by the Daily run-key regex.
+- requires exact `YYYY-MM-DD` syntax;
+- parses year/month/day numerically;
+- constructs UTC midnight;
+- round-trips UTC year/month/day;
+- throws `RangeError` for malformed or impossible dates.
+
+Daily run validation calls this helper instead of maintaining its current inline copy.
+
+### 5.2 Explicit-Date formatter
 
 `daily.ts` exposes:
 
 ```ts
-export function toIceSlideUtcDateKey(date: Date): string {
-  if (!Number.isFinite(date.getTime())) {
-    throw new RangeError('date must be valid')
-  }
-  const dateKey = date.toISOString().slice(0, 10)
-  assertValidIceSlideUtcDateKey(dateKey)
-  return dateKey
-}
+export function toIceSlideUtcDateKey(date: Date): string
 ```
 
-`createIceSlideDailyRunDefinition(dateKey)` also calls `assertValidIceSlideUtcDateKey(dateKey)` before constructing any seed or run key. There is one calendar-validation contract, not a second Daily parser.
+It rejects an invalid `Date`, derives the UTC `YYYY-MM-DD` value, calls `assertValidIceSlideUtcDateKey()`, and returns the key.
 
-### 6.2 Version and identity
+This intentionally overlaps the **same UTC-midnight boundary** used by platform `getTodayUTC()` / `getSecondsUntilMidnightUTC()` in `src/lib/challenges.ts`, but keeps an explicit `Date` input so Ice Slide rollover tests do not depend on the wall clock. Do not create a second platform date system.
+
+## 6. Daily Run Materialization
+
+### 6.1 Version and identity
 
 Add:
 
@@ -110,18 +111,18 @@ export const ICE_SLIDE_DAILY_GENERATOR_VERSION = 1
 export const ICE_SLIDE_DAILY_SOLVER_MAX_STATES = 10_000
 ```
 
-For an explicit `dateKey`:
+For `dateKey`:
 
 ```text
-seed = ice-slide:daily:<generatorVersion>:<rulesetVersion>:YYYY-MM-DD
+seed   = ice-slide:daily:<generatorVersion>:<rulesetVersion>:YYYY-MM-DD
 runKey = ice-slide:daily:YYYY-MM-DD:g<generatorVersion>:r<rulesetVersion>
 ```
 
-The generator uses the existing `ICE_SLIDE_RULESET_VERSION`. It never reads the current clock itself.
+The ruleset version is the existing `ICE_SLIDE_RULESET_VERSION`.
 
-### 6.3 Tier pools and source resolution
+### 6.2 Tier pools
 
-Daily stage pools are fixed:
+Pools contain authored `IceSlideLevel.id` values, never array offsets:
 
 ```ts
 export const ICE_SLIDE_DAILY_STAGE_POOLS = [
@@ -133,19 +134,19 @@ export const ICE_SLIDE_DAILY_STAGE_POOLS = [
 ] as const
 ```
 
-Pool values are authored `IceSlideLevel.id` values, never array offsets. Resolve a source by searching `ICE_SLIDE_LEVELS` for matching `level.id`; do not use `ICE_SLIDE_LEVELS[id - 1]`.
+Resolve a source by finding the level whose `level.id` matches the selected ID. Never use `ICE_SLIDE_LEVELS[id - 1]`.
 
-`run.ts` exports its existing difficulty mapping as:
+`run.ts` exports the existing Campaign mapping:
 
 ```ts
 export const CAMPAIGN_STAGE_DIFFICULTIES: readonly IceSlideDifficulty[]
 ```
 
-After resolving the level, use that level's actual array index to read its Campaign difficulty.
+After resolving the source, use its real Campaign array index to obtain difficulty.
 
-### 6.4 Frozen stage metadata
+### 6.3 Frozen stage metadata
 
-Every selected Daily stage materializes these exact identity fields:
+Every Daily stage materializes:
 
 ```ts
 {
@@ -162,55 +163,53 @@ Every selected Daily stage materializes these exact identity fields:
 }
 ```
 
-Compute `signature` from that complete object with `createIceSlideStageSignature()`.
+Then compute `signature` with `createIceSlideStageSignature()`.
 
-These fields are part of the deterministic generator contract. A change that alters them for an existing date requires a Daily generator-version bump.
+`id`, name, template identity, difficulty, rows, par, transform, objective, multiplier, and signature are all generator-v1 output. Do not casually re-record changed golden output under generator version 1.
 
-### 6.5 Exact deterministic selection algorithm
+### 6.4 Frozen selection algorithm
 
-The selection algorithm is frozen as follows:
+For each 1-based stage `N`:
 
-1. Create `rootRng = createSeededRng(seed)`.
-2. For 1-based stage `N`, create `stageRng = rootRng.fork(`stage:${N}`)`.
-3. Shuffle that stage's level-ID pool with `stageRng.fork('template').shuffle(pool)`.
-4. Iterate the shuffled IDs and skip any `campaign:<id>` template already used by the run.
-5. Resolve the source by `level.id` and call `getUniqueBoardTransforms(source.rows)`.
-6. Shuffle those canonical-deduplicated variants with:
-
-   ```ts
-   stageRng
-     .fork(`transform:${source.id}`)
-     .shuffle(getUniqueBoardTransforms(source.rows))
-   ```
-
-7. Iterate variants and call `validateIceSlideStageQuality()` with:
+1. `rootRng = createSeededRng(seed)`.
+2. `stageRng = rootRng.fork(`stage:${N}`)`.
+3. `templateOrder = stageRng.fork('template').shuffle(pool)`.
+4. Iterate template IDs, skipping `campaign:<id>` values already used in this run.
+5. Resolve source by `level.id`.
+6. `variants = getUniqueBoardTransforms(source.rows)`.
+7. `variantOrder = stageRng.fork(`transform:${source.id}`).shuffle(variants)`.
+8. Iterate variants and call `validateIceSlideStageQuality()` with:
    - `objectiveIds: []`;
-   - par band exactly equal to `source.parMoves`;
+   - exact par band `[source.parMoves, source.parMoves]`;
    - `maxStates = 10_000`;
-   - canonical keys already accepted for earlier stages.
-8. The first accepted candidate wins; use `quality.parMoves` as the materialized par.
-9. Build eligible bonus objectives from `quality.objectiveFeasibility` in this fixed order:
+   - canonical keys already accepted earlier in the run.
+9. Use the first accepted candidate and its returned `quality.parMoves`.
+10. Build eligible objective IDs in this fixed order:
 
    ```ts
-   [
-     'collect_all_crystals',
-     'no_falls',
-     'no_reset',
-   ]
+   ['collect_all_crystals', 'no_falls', 'no_reset']
    ```
 
-10. Pick exactly one with `stageRng.fork('objective').pick(eligibleObjectives)`.
-11. Materialize the frozen metadata from §6.4 and compute the signature.
-12. Record its template ID and canonical key, then continue.
-13. After five stages, call `assertValidIceSlideRunDefinition(run)` before returning it.
+11. `bonusObjective = stageRng.fork('objective').pick(eligibleObjectives)`.
+12. Materialize the frozen stage metadata and signature.
+13. Record template/canonical identities and continue.
+14. Validate the finished run with `assertValidIceSlideRunDefinition()`.
 
-`no_reset` is feasible for every accepted solvable board, so the eligible-objective list cannot be empty.
+`no_reset` is feasible on every accepted solvable board, so the objective list is non-empty.
 
-The largest stage pool has three sources and each source has at most eight unique transforms. The finite authored search is therefore below the parent design's 64-candidate bound without adding a retry/fallback subsystem. If no source/variant satisfies the frozen contract, `createIceSlideDailyRunDefinition()` throws and the existing `failRun()` lifecycle owns cleanup/error display.
+### 6.5 Quality gate behavior in generator v1
+
+With the current checked-in Campaign content, transforms are board isometries, the par band is exactly the authored par, and the 2026 content sweep observes no rejected candidate: the first eligible candidate passes the quality gate.
+
+Keep the quality call anyway because HPA-487 explicitly requires production-solver verification and because it catches future content drift (bad par, solver truncation, invalid content, accidental duplicate). Do **not** add dependency injection or synthetic Daily pools only to force the Daily throw branch. Rejection behavior is already covered by `quality.test.ts`.
+
+If the finite authored candidate set cannot satisfy the contract, `createIceSlideDailyRunDefinition()` throws and the existing `failRun()` lifecycle owns cleanup/error display. There is no Daily retry/fallback subsystem.
+
+“Recomputed par” in HPA-487 means the production solver independently verifies the transformed board and returns the materialized par; in v1 that value equals the authored source par by transform isometry. Canonical uniqueness is still asserted on the materialized run even though current source/template constraints make duplicates absent by construction.
 
 ### 6.6 Generator-v1 golden output
 
-Generator version 1 is not defined only by invariants. The full deterministic tuple for `2026-08-12` is frozen:
+The literal projection for `2026-08-12` is frozen:
 
 ```ts
 [
@@ -267,28 +266,39 @@ Generator version 1 is not defined only by invariants. The full deterministic tu
 ]
 ```
 
-`daily.test.ts` asserts this literal projection in addition to run-key/seed and structural invariants.
+`daily.test.ts` asserts this literal tuple. The test name/documentation must state that a red golden test requires a generator-version decision; do not “fix” it by blindly re-recording the vector.
 
-Before generator v1 is considered frozen, the test suite also materializes every UTC date from `2026-01-01` through `2026-12-31` and asserts that none throws. This is a bounded content-validity sweep, not a statistical quality guarantee.
+Also materialize every date from `2026-01-01` through `2026-12-31` and assert none throws. This is a cheap bounded content-validity sweep, not a statistical quality benchmark.
 
-Any future change to pool contents/order, fork labels, transform candidate order, objective ordering, source metadata mapping, stage-signature inputs, or another generator choice that changes the same date's materialized run increments `ICE_SLIDE_DAILY_GENERATOR_VERSION`. Competitive physics/objective/scoring meaning continues to use `ICE_SLIDE_RULESET_VERSION`.
+### 6.7 Version-bump rules
 
-### 6.7 No hidden nondeterminism
+Increment `ICE_SLIDE_DAILY_GENERATOR_VERSION` whenever the same date could materialize different run data. This explicitly includes:
 
-`daily.ts` does not call `Math.random()`, `crypto.getRandomValues()`, or read the current clock. All entropy comes from the explicit seed and the frozen labeled RNG forks.
+- pool contents/order;
+- fork labels or RNG selection order;
+- transform candidate behavior/order;
+- objective eligibility ordering/selection;
+- stage metadata mapping;
+- stage-signature inputs;
+- `CAMPAIGN_STAGE_DIFFICULTIES` changes affecting eligible Daily levels;
+- **any edit to eligible `ICE_SLIDE_LEVELS` identity/name/rows/parMoves that changes Daily output**.
 
-## 7. Objective and Star Model
+Competitive physics/objective/scoring interpretation changes use `ICE_SLIDE_RULESET_VERSION` as already designed.
 
-Add a pure `objectives.ts` helper:
+No Daily path calls `Math.random()`, `crypto.getRandomValues()`, or reads the clock.
+
+## 7. Objective and Star Policy
+
+### 7.1 Stage-scoped facts
+
+Add a pure helper with names that cannot be confused with cumulative run counters:
 
 ```ts
 export interface IceSlideObjectiveFacts {
-  parMoves: number
-  movesUsed: number
   crystalsCollected: number
   totalCrystals: number
-  falls: number
-  resets: number
+  stageFalls: number
+  stageResets: number
 }
 
 export function isIceSlideObjectiveComplete(
@@ -297,23 +307,27 @@ export function isIceSlideObjectiveComplete(
 ): boolean
 ```
 
-Completion rules:
+Rules:
 
-- `collect_all_crystals`: `totalCrystals > 0` and all stage crystals were collected.
-- `no_falls`: no hazard was entered during the stage.
-- `no_reset`: neither manual Reset nor hazard reset occurred during the stage.
+- `collect_all_crystals`: `totalCrystals > 0` and `crystalsCollected === totalCrystals`.
+- `no_falls`: `stageFalls === 0`.
+- `no_reset`: `stageResets === 0`.
 
-Daily stars at clear time:
+Add `ICE_SLIDE_OBJECTIVE_LABELS` for the three bonus-objective labels.
 
-- Clear: always earned.
-- Efficient: `movesUsed <= parMoves`.
-- Bonus: evaluate the stage's single `objectiveIds[0]`.
+### 7.2 Efficient uses one expression
 
-The game records cumulative Daily stars in the existing `starsEarned` field. Campaign continues to report zero Daily stars.
+Efficient is not a second objective helper. In `clearLevel()` compute once:
 
-## 8. Runtime State and Stage Results
+```ts
+const efficient = this.state.levelMoves <= stage.parMoves
+```
 
-Extend `IceSlideState` only with active-stage facts needed by policy/UI:
+Use that same boolean both for existing `perfectLevels` behavior and for the Daily Efficient star.
+
+### 7.3 Counters
+
+`IceSlideState` already has cumulative `falls`, `resets`, and `starsEarned`. Make them live and add only:
 
 ```ts
 parMoves: number
@@ -322,16 +336,19 @@ levelFalls: number
 levelResets: number
 ```
 
-`getState()` defensively copies `objectiveIds`.
+Rules:
 
-Counter rules:
+- manual Reset: cumulative `resets += 1`, stage `levelResets += 1`, no fall increment;
+- hazard: cumulative `falls += 1`, `resets += 1`, stage `levelFalls += 1`, `levelResets += 1` exactly once;
+- hazard move remains counted in `levelMoves`;
+- same-stage reload preserves stage attempt counters;
+- normal stage advance resets stage attempt counters to zero.
 
-- A normal committed move keeps existing move behavior.
-- Manual Reset increments `resets` and `levelResets`; it does not increment falls.
-- Hazard entry increments `falls`, `resets`, `levelFalls`, and `levelResets` exactly once.
-- Hazard reload preserves the hazard move in `levelMoves`.
-- A new stage resets `levelFalls`/`levelResets` to zero.
-- Same-stage Reset/hazard reload preserves those stage attempt counters.
+At clear time, obtain the source-stage crystal total using existing physics parsing/counting (`countCrystals(parseGrid(stage))`) rather than exporting the private quality-module glyph counter.
+
+A regression test must prove stage scope: make a mistake on stage 1, then cleanly clear stage 2 and still earn stage 2 `no_falls`/`no_reset` as appropriate.
+
+## 8. Stage-Clear Result Contract
 
 Replace numeric `onLevelClear(level)` with:
 
@@ -352,65 +369,75 @@ export interface IceSlideStageClearResult {
 }
 ```
 
-Campaign may report Efficient as a fact but shows no star UI and does not increment `starsEarned`.
+Campaign may expose `efficient` in the result object, but does not show Daily star UI and does not increment `starsEarned`.
 
-### 8.1 Preserve the current callback order
+Preserve engine callback ordering:
 
-Do not redesign `IceSlideGame` into a paused-stage state machine.
+- non-final clear: compute result, load next stage through the existing immediate flow, then invoke `onLevelClear(result)`;
+- final clear: apply completion bonus, set `status = 'won'`, stop timer, invoke `onLevelClear(result)`, then invoke `onWin(finalScore)` synchronously.
 
-- On a non-final clear, the game computes the completed-stage result, prepares the next stage using the existing immediate-load flow, and invokes `onLevelClear(result)`.
-- On a final clear, it applies the correct completion bonus, sets `status = 'won'`, stops the timer, invokes `onLevelClear(result)`, then invokes `onWin(finalScore)` synchronously.
+Tests lock final order as `level-clear` then `win`.
 
-Tests lock final callback order as `level-clear` then `win`.
+## 9. Scoring Without Per-Mode Function Copies
 
-The browser overlay, not the game engine, prevents interaction with the already-prepared next stage.
-
-## 9. Scoring
-
-Existing Campaign functions/constants remain unchanged.
-
-Add:
+Keep the existing shared scoring primitives. Add only the data needed to vary Daily behavior.
 
 ```ts
-export const DAILY_SCORING_CONFIG = {
-  objectiveStarBonus: 100,
-  timeBudgetSeconds: 300,
+export interface IceSlideModeScoringConfig {
+  objectiveStarBonus: number
+  timeBudgetSeconds: number
+  timeBonusPerSec: number
+}
+
+export const SCORING_CONFIG = {
+  levelClearBase: 200,
+  moveBonusPerUnderPar: 25,
+  crystalBonus: 50,
+  timeBudgetSeconds: 360,
   timeBonusPerSec: 5,
+  objectiveStarBonus: 0,
 } as const
 
-export function dailyStageScore(params: {
-  stageNumber: number
-  parMoves: number
-  movesUsed: number
-  crystalsCollected: number
-  optionalStarsEarned: number
-}): number
-
-export function dailyTimeBonus(elapsedSeconds: number): number
+export const DAILY_SCORING_CONFIG: IceSlideModeScoringConfig = {
+  timeBudgetSeconds: 300,
+  timeBonusPerSec: 5,
+  objectiveStarBonus: 100,
+}
 ```
 
-Daily stage score:
+Keep `levelClearPoints()`, `moveBonus()`, and `crystalBonus()` behavior unchanged.
+
+Extend existing functions additively:
+
+```ts
+export function timeBonus(
+  elapsedSeconds: number,
+  config: IceSlideModeScoringConfig = SCORING_CONFIG
+): number
+
+export function levelScore(
+  params: {
+    levelNumber: number
+    parMoves: number
+    movesUsed: number
+    crystalsCollected: number
+    optionalStarsEarned?: number
+  },
+  config: IceSlideModeScoringConfig = SCORING_CONFIG
+): number
+```
+
+`levelScore()` adds:
 
 ```text
-200 × stageNumber
-+ moveBonus(parMoves, movesUsed)
-+ 50 × crystalsCollected
-+ 100 × optionalStarsEarned
+(optionalStarsEarned ?? 0) × config.objectiveStarBonus
 ```
 
-`optionalStarsEarned` counts Efficient and bonus stars only (`0..2`). Clear is represented by the base clear points.
-
-Daily completion bonus:
-
-```text
-max(0, (300 - elapsedSeconds) × 5)
-```
-
-Campaign keeps the existing 360-second completion bonus. Expedition scoring is untouched.
+Campaign callers remain unchanged and therefore get zero star bonus plus the existing 360-second time budget. Daily passes `DAILY_SCORING_CONFIG` and a `0..2` Efficient/bonus star count. This same closed shape can serve Expedition later without another pair of mode-named scoring functions.
 
 ## 10. Browser Lifecycle and Retry Semantics
 
-Use the two shipped choices only:
+Use the narrow playable boundary:
 
 ```ts
 export type IceSlidePlayableMode = 'campaign' | 'daily'
@@ -425,118 +452,147 @@ export interface IceSlideHandle {
 }
 ```
 
-`start(mode)` means a fresh run:
+`IceSlideMode` remains broader (`campaign | daily | expedition`) on materialized run contracts.
 
-- Campaign starts the normal Campaign.
-- Daily calls `toIceSlideUtcDateKey(new Date())`, materializes the Daily, and stores a defensive copy plus the captured date key for retry/HUD use.
+Fresh Start:
 
-`playAgain()` retries the last started run:
+- Campaign starts the existing Campaign run.
+- Daily calls `toIceSlideUtcDateKey(new Date())`, materializes the run, and stores a defensive retry copy plus captured date key.
+
+Play Again:
 
 - Campaign starts Campaign again.
-- Daily starts a clone of the exact stored run and reuses its captured date key. It does not read the clock.
+- Daily starts a clone of the stored Daily run and reuses its captured date key; it never reads the clock.
 
-This is the only fresh-vs-retry distinction needed for UTC rollover.
+Start/fail/cleanup clear any non-final stage overlay/input lock state.
 
-## 11. Stage-Clear, Final-Win, and End Semantics
+## 11. Non-Final Stage Overlay and Final Result
 
-`init.ts` owns `inputLocked`, the stage-clear DOM state, and `pendingDailyWinScore`.
+### 11.1 Input gate
 
-Movement is accepted only when:
+`init.ts` owns one `inputLocked` flag. Keyboard, pointer/swipe, and Reset accept input only when the game is playing and the lock is clear.
 
-```text
-game.status === 'playing' && inputLocked === false
-```
+### 11.2 Non-final Daily clear
 
-Keyboard and pointer/swipe use the same predicate. Reset also no-ops while the stage-clear overlay is active.
+When Daily `onLevelClear(result)` runs and the current game status is still `playing`:
 
-### 11.1 Daily non-final clear
+1. set `inputLocked = true`;
+2. populate/show the page-local stage-clear overlay;
+3. focus Continue;
+4. the already-loaded next board may render underneath the opaque overlay;
+5. Continue hides the overlay, clears the lock, and re-renders/re-syncs HUD before the next move.
 
-1. `onLevelClear(result)` sets `inputLocked = true`.
-2. Fill/show the stage-clear overlay and focus Continue.
-3. `afterMove()` may render/synchronize the already-prepared next stage underneath the opaque overlay.
-4. Continue hides the overlay, clears the lock, and calls render/HUD sync again before the player can move.
+There is no timer.
 
-### 11.2 Daily final clear
+### 11.3 Final Daily clear
 
-Keep the engine callback order from §8.1.
+When Daily `onLevelClear(result)` observes current status `won`:
 
-1. Final `onLevelClear(result)` shows/locks the stage-clear overlay.
-2. The immediately following Daily `onWin(finalScore)` **only** stores `pendingDailyWinScore = finalScore`; it does not show `MISSION COMPLETE`, call the external `callbacks.onWin`, reset buttons, authenticate, or submit.
-3. Continue on that final overlay clears the stage overlay, shows `MISSION COMPLETE`, invokes the external win callback, resets controls, and starts the completed Daily submission flow exactly once.
+- do **not** show the mid-run stage-clear overlay;
+- populate the Daily final-stage star/result rows already rendered through `GamePage`'s `final-stats` slot.
 
-This guarantees that the final stage result is visible before the result overlay or network work.
+The immediately following `onWin(finalScore)` keeps the existing result path:
 
-### 11.3 End while a stage-clear overlay is visible
+- invoke external `callbacks.onWin`;
+- reset controls;
+- show `MISSION COMPLETE`;
+- submit the completed Daily score immediately;
+- keep the completed local result visible regardless of submission outcome.
 
-The behavior is explicit because the engine has already advanced/finished underneath the overlay:
+This removes `pendingDailyWinScore`, inert-End special cases, and the risk of losing a completed run because the player closes the tab before pressing Continue.
 
-- **Non-final Daily overlay:** `stop()` hides the stage-clear overlay, clears the lock/pending stage UI, stops the now-current run, restores controls, shows local `RUN ENDED`, and does **not** submit any Daily score.
-- **Final Daily overlay:** the End control is hidden/disabled while the final result awaits Continue. A programmatic `stop()` is a no-op: it leaves the final stage-clear overlay and pending win intact and does not submit. Continue remains the only transition to completed-result submission.
+### 11.4 Daily End
 
-All start/fail/cleanup paths clear stage-result DOM state, locks, and pending win state.
+Daily `stop()` is deliberately different from Campaign partial submission:
 
-There is no auto-dismiss timer. Reduced-motion users therefore have no forced delay.
+- if Daily is active and `status === 'playing'`, stop it, clear any non-final stage overlay/lock, restore controls, show local `RUN ENDED` with the current score **even when score is zero**, and never submit;
+- retain the stored Daily retry snapshot so Play Again reproduces the same run;
+- Campaign keeps its existing positive-score partial submission behavior.
+
+After final win, normal result UI has already replaced gameplay controls, so no final-overlay End state machine is needed.
 
 ## 12. Daily HUD and Page UI
 
-Keep all page markup local to `src/pages/ice-slide/index.astro`; no shared component/API changes are needed.
+Keep markup page-local.
 
-### 12.1 Pre-run selector
+### 12.1 Selector
 
-Add a semantic Campaign/Daily selector above the canvas. Campaign is selected by default. Only exact query value `daily` changes that preselection. The selector is disabled while a run is active and re-enabled by Change Mode.
+Use a semantic Campaign/Daily fieldset/radio control patterned after existing page-local controls. Do not override the GamePage controls slot, because that would require recreating Start/End/Reset controls.
 
 ### 12.2 HUD ownership
 
-`init.ts` extends `syncHud()` so the objective state cannot drift from the already-loaded game stage.
+Extend `init.ts` `syncHud()`:
 
-For Campaign:
+Campaign:
 
 - hide `#daily-meta`;
-- preserve existing score/level/moves/crystals/time/name behavior.
-
-For Daily:
-
-- show `#daily-meta`;
-- set `#daily-date` from the captured/retried Daily date key;
-- set `#daily-reset` to `Resets at 00:00 UTC` plus the next UTC date;
-- set `#daily-stage-progress` to `Stage N / 5`;
-- set Clear text for reaching the goal;
-- set Efficient text from current `state.parMoves`;
-- set bonus text from `ICE_SLIDE_OBJECTIVE_LABELS[state.objectiveIds[0]]`.
-
-Call this synchronization on initial Daily Start, normal `syncHud()` paths, and again after stage-clear Continue. Therefore every new Daily board exposes its three objectives before its first accepted move.
-
-Do not add a UTC countdown scheduler.
-
-### 12.3 Stage-clear overlay
-
-Add a page-local opaque overlay inside the board area containing stage name/number, all three earned/missed objective rows, stage score gained, and a real Continue button. Use text/symbols in addition to color.
-
-### 12.4 Result overlay and Change Mode
-
-Keep shared GameOverlay's Play Again button. Add a page-local `#change-mode-btn` through `final-stats`.
-
-- Play Again calls `gameHandle.playAgain()`.
-- Change Mode hides the result overlay, shows the pre-run status/selector, re-enables mode controls, and does not auto-start.
-
-No `GameOverlay` API change is required.
-
-### 12.5 Scoring copy
-
-Keep Campaign scoring copy and add a concise Daily note: +100 for each Efficient/bonus star and a 5:00 completion budget.
-
-## 13. Score Submission and Anonymous Play
-
-Campaign remains behavior-compatible:
-
-- completed Campaign submits unscoped;
-- manually ended Campaign with positive score still submits partial score.
+- preserve existing score/level/moves/crystals/time/name rendering.
 
 Daily:
 
-- any partial End never submits;
-- only final-stage Continue may initiate completed submission;
-- submission includes current game data and:
+- show `#daily-meta`;
+- set `#daily-date` from captured/retried date key;
+- set `#daily-reset` to the next UTC day boundary (`Resets at 00:00 UTC …`);
+- set `#daily-stage-progress` to `Stage N / 5`;
+- set Clear copy;
+- set Efficient copy from `state.parMoves`;
+- set bonus copy from `ICE_SLIDE_OBJECTIVE_LABELS[state.objectiveIds[0]]`.
+
+Call HUD sync on initial Start, normal move/render paths, and after Continue. Every Daily stage therefore shows objectives before its first accepted move.
+
+### 12.3 Result markup
+
+Use the existing `final-stats` slot for two page-local pieces:
+
+- a hidden Daily final-stage result block with Clear/Efficient/bonus earned/missed rows;
+- `#change-mode-btn`.
+
+No `GameOverlay` API change.
+
+### 12.4 Page wiring
+
+- Start reads the selected radio and calls `gameHandle.start(mode)`.
+- Play Again calls `gameHandle.playAgain()`.
+- Change Mode hides result UI, restores the pre-run status/selector, re-enables mode controls, and does not start anything.
+
+Do not add leaderboard copy before HPA-488.
+
+## 13. Submission and Anonymous Play
+
+### 13.1 Reuse the existing score request
+
+Do not perform an `authClient.getSession()` preflight. The score endpoint is already authoritative and returns 401 for anonymous users.
+
+Extend the existing client result channel additively:
+
+```ts
+export type ScoreSubmissionPublicErrorCode =
+  | 'SCORE_CONTEXT_UNAVAILABLE'
+  | 'UNAUTHENTICATED'
+```
+
+In `submitScore()`, map HTTP 401 to `code: 'UNAUTHENTICATED'` regardless of response-body code.
+
+Expose the structured failure through the existing callback without breaking one-argument callers:
+
+```ts
+onError?: (error: string, result?: ScoreSubmissionResult) => void
+```
+
+`saveGameScore()` invokes `onError(message, result)` for a completed non-success response; transport exceptions still call it without a structured result.
+
+Daily `init.ts` then:
+
+- submits immediately from final `onWin` with contextual game data;
+- suppresses visible `Score not saved` UI only when `result?.code === 'UNAUTHENTICATED'`;
+- reports other save/network failures normally;
+- retains existing run-guard stale-response behavior in `saveGameScore()`.
+
+This avoids an extra session request and a second staleness check while preserving local anonymous completion.
+
+### 13.2 Daily context
+
+Completed Daily submits:
 
 ```ts
 {
@@ -549,26 +605,17 @@ Daily:
 }
 ```
 
-Before Daily submission, call `authClient.getSession()`:
-
-- confirmed no session/no auth error => local result only;
-- session exists => submit normally;
-- session check fails => let the existing score endpoint remain authoritative instead of silently discarding a possibly authenticated result.
-
-Capture the run guard before awaiting auth and re-check staleness afterward.
-
-A score-save failure never invalidates local completion. HPA-488 adds server-side solved/run/version admission and ranking.
+Daily partial End never submits. Campaign remains unscoped. HPA-488 adds server-side solved/run/version admission and ranking.
 
 ## 14. Error Handling
 
-- Invalid/malformed mode query values fall back to Campaign without auto-start.
-- Daily materialization failures use existing `failRun()` cleanup.
-- Failed renderer setup keeps existing cleanup behavior.
-- Fresh/retry start clears stale stage/result overlay state before creating a game.
-- Run guards continue to suppress stale async callbacks.
-- Daily score failure uses existing `Score not saved` reporting without removing local completion UI.
-- Confirmed anonymous Daily completion is not an error.
-- No path falls back to nondeterministic generation.
+- malformed/unavailable mode query => Campaign selection, no auto-start;
+- materialization failure => existing `failRun()` cleanup/player-safe error;
+- renderer failure => existing cleanup path;
+- start/fail/cleanup => clear mid-run overlay/lock state;
+- Daily 401 => local completed result, no save-error toast;
+- other Daily score failure => local result remains visible and normal save error is reported;
+- no nondeterministic generation fallback.
 
 ## 15. File Boundaries
 
@@ -586,105 +633,112 @@ A score-save failure never invalidates local completion. HPA-488 adds server-sid
 - `src/lib/games/ice-slide/run.ts`
 - `src/lib/games/ice-slide/scoring.ts`
 - `src/lib/games/ice-slide/test-fixtures.ts`
-- `src/lib/games/ice-slide/game.ts` and existing game tests
-- `src/lib/games/ice-slide/init.ts` and `init.test.ts`
+- `src/lib/games/ice-slide/game.ts` and focused tests
+- `src/lib/games/ice-slide/init.ts` and tests
+- `src/lib/services/scoreService.ts` and tests (additive unauthenticated error propagation)
 - `src/pages/ice-slide/index.astro`
 - `src/pages/game-board-markup.test.ts`
 - `e2e/games/play-coverage.spec.ts`
 
-### Do not modify for HPA-487
+### Do not modify
 
 - database schema/query code;
 - `/api/leaderboard` or leaderboard pages;
-- server-side Daily admission logic;
-- Expedition templates/generation;
+- server Daily semantic admission;
 - shared `GamePage`/`GameOverlay` APIs;
+- Expedition/templates/snow/cracked ice;
 - platform Daily Challenge rotation.
 
 ## 16. Testing Strategy
 
-### Pure generation
+### Daily materializer
 
-- shared UTC date-key helper accepts/rejects calendar dates once for both run validation and Daily materialization;
-- exact seed/run-key for `2026-08-12`;
-- literal generator-v1 golden tuple from §6.6;
-- exactly five stages with pool-valid, non-repeated source template IDs;
-- unique final canonical boards;
-- source resolution by `level.id`, copied source name, and Campaign difficulty mapping;
-- same date/version is byte-equivalent;
-- representative different dates vary deterministically;
-- every par equals the production solver result and assigned objective is feasible;
-- every date in calendar year 2026 materializes without throwing;
-- run signatures validate through `assertValidIceSlideRunDefinition()`.
+- strict shared UTC date validation;
+- exact run key/seed;
+- literal `2026-08-12` golden tuple;
+- all 365 dates in 2026 materialize without throw;
+- pool membership/source-template uniqueness;
+- canonical final-board uniqueness;
+- production quality validation returns accepted and verified par;
+- exactly one feasible bonus objective;
+- full run passes `assertValidIceSlideRunDefinition()`.
 
-### Objectives/scoring
+Do not add a synthetic dependency-injected Daily generator solely to force rejection; `quality.test.ts` already owns rejection branch coverage.
 
-- collect-all success/failure and zero-crystal behavior;
-- no-falls success/failure;
-- no-reset distinguishes manual/hazard reset history;
-- Efficient uses `<= par`;
-- exact Daily star bonus and 300-second completion boundaries;
-- Campaign scoring remains unchanged.
+### Objective/runtime/scoring
 
-### Game runtime
-
-- manual Reset increments reset counters once;
-- hazard increments fall/reset counters once and preserves move semantics;
-- per-stage counters survive same-stage reload and reset on advance;
-- Daily clear result reports exact stars/score gained;
-- cumulative Daily stars carry across stages;
-- final callback order stays `onLevelClear` then `onWin`;
-- Campaign score/progression/reset/hazard behavior remains compatible.
+- collect-all/no-falls/no-reset stage facts;
+- stage-1 mistake does not poison stage-2 clean objective results;
+- Efficient boolean drives both existing perfect-level behavior and Daily star;
+- reset/hazard counters increment exactly once;
+- Daily stage star bonus through `levelScore(..., DAILY_SCORING_CONFIG)`;
+- Daily 300-second `timeBonus(..., DAILY_SCORING_CONFIG)` boundaries;
+- Campaign scoring unchanged with default config;
+- final callback order remains level-clear then win.
 
 ### Browser integration
 
 - fresh Daily captures current UTC date;
-- `playAgain()` reproduces the exact run/signatures after simulated UTC rollover;
-- fresh Daily after rollover uses the new date;
-- Campaign hides Daily HUD;
-- Daily start populates date/reset/stage/par/bonus HUD before the first move;
-- Continue re-syncs the next stage HUD;
-- non-final overlay End terminates locally with no submission;
-- final overlay `onWin` remains pending until Continue; final overlay End is inert;
-- partial Daily End never calls `saveGameScore()`;
-- completed Daily uses exact context once;
-- confirmed anonymous completion skips submission;
-- keyboard/swipe/reset remain locked while stage result is active;
-- cleanup/failure clears locks/overlays/pending win;
-- Campaign partial/full submissions remain unscoped.
+- handle `playAgain()` retains exact run across rollover;
+- fresh Daily after rollover uses new date;
+- Daily HUD is populated before first move and after Continue;
+- non-final Continue gates keyboard/swipe/Reset;
+- Daily End at zero score shows local `RUN ENDED` and does not submit;
+- completed Daily submits immediately from final `onWin` with exact context;
+- final result overlay contains final stage star outcome;
+- `UNAUTHENTICATED` result is silent/local; other save errors remain visible;
+- Campaign full/partial submission stays unscoped.
 
 ### Page/E2E
 
-- `/ice-slide` defaults to Campaign;
-- `/ice-slide?mode=daily` preselects Daily;
-- malformed/unavailable mode falls back to Campaign;
-- Daily Start shows date/stage/objectives;
-- Playwright fixes browser time before UTC rollover, starts Daily, ends locally, advances clock across midnight, clicks Play Again, and verifies the displayed Daily date is unchanged;
-- Change Mode returns to an enabled selector/pre-run state without auto-start;
-- Campaign happy path remains covered;
-- manual Continue has keyboard-accessible behavior and no reduced-motion wait.
+- default/query mode selection;
+- actual Play Again button preserves Daily date across simulated UTC rollover;
+- Change Mode returns to idle without auto-start;
+- Daily HUD/objectives visible before first move;
+- Campaign smoke remains intact;
+- malformed/unavailable modes fall back to Campaign.
 
-## 17. Acceptance Criteria
+Static markup tests assert stable DOM IDs/semantics only. They do not assert source-code snippets such as `gameHandle?.playAgain()` or non-contract copy strings; Playwright owns those behaviors.
+
+## 17. Coverage and Verification
+
+The repository's Vitest config does not define a local numeric threshold, but `codecov.yml` currently requires **95% project and 95% patch coverage**. HPA-487 must satisfy the repository's existing Codecov status gate; this feature does not introduce or change that threshold.
+
+Final implementation verification:
+
+```bash
+bun run format:check
+bun run lint
+bun run typecheck
+bun run test:run
+bun run test:coverage
+bun run build
+bun run test:e2e -- e2e/games/play-coverage.spec.ts --grep "Ice Slide"
+```
+
+Any pre-existing typecheck baseline may be documented only if it is byte-identical on `main`; diagnostics in HPA-487-touched files must be fixed.
+
+## 18. Acceptance Criteria
 
 HPA-487 is complete when:
 
-1. the generator-v1 golden `2026-08-12` tuple and same-date byte equivalence are locked;
-2. the complete 2026 UTC date sweep materializes without failure and representative dates vary;
-3. every run has five unique source templates and canonical boards, recomputed pars, and one feasible bonus objective;
-4. stars correctly reflect par, crystals, hazards, manual Reset, and hazard reset;
-5. Daily scoring uses the documented stage formula and 300-second budget while Campaign stays unchanged;
-6. final engine callbacks keep `onLevelClear` then `onWin`, while browser completion/submission waits for final Continue;
-7. partial/overlay End behavior is deterministic and never admits a partial Daily submission;
-8. Daily HUD is correct before each stage's first accepted move;
-9. Play Again retry identity is covered both in handle tests across UTC rollover and in page-level Playwright wiring; Change Mode has no auto-start;
-10. only completed Daily runs attempt contextual submission and confirmed anonymous runs remain local;
-11. no HPA-488 ranking/server-admission or Expedition/evolving-tile work is pulled into this implementation.
+1. the frozen generator-v1 date produces its exact golden run and the 2026 sweep succeeds;
+2. each Daily run contains five pool-valid unique templates and unique materialized canonical boards;
+3. every materialized stage passes the production quality/solver verification and uses the returned par;
+4. bonus objectives and stars use **stage-scoped** crystal/fall/reset facts;
+5. Campaign scoring/output remain unchanged while Daily uses the same scoring functions with Daily config;
+6. non-final stage results gate input until Continue; final stars appear in the normal final result overlay without an extra Continue;
+7. completed Daily submits immediately with scoped context, while Daily End never submits and anonymous 401 remains local/silent;
+8. fresh Start vs Play Again preserve the documented UTC rollover identity through the real page wiring;
+9. Daily HUD shows date/reset/stage/par/bonus objective before each stage's first accepted move;
+10. no HPA-488 ranking/server-admission or Expedition/evolving-tile work enters this implementation.
 
-## 18. Spec Self-Review
+## 19. Spec Self-Review
 
-- **Placeholder scan:** no TBD/TODO remains.
-- **Consistency:** one materialized-run boundary; one UTC calendar validator; one frozen RNG-label/output contract.
-- **Scope:** HPA-488 and HPA-489+ remain separate.
-- **YAGNI:** no generic generator pipeline, mode registry, persistence service, shared overlay abstraction, countdown scheduler, or game-engine pause state.
-- **Lifecycle ambiguity:** final callback order, final Continue, non-final/final End, HUD re-sync, Play Again, and Change Mode are explicit.
-- **Versioning:** a same-date materialization change is a generator-version change, not a silent patch.
+- **Scope:** still six bounded implementation tasks; no new subsystem.
+- **Reuse:** existing run/RNG/transforms/quality/physics/score/overlay seams remain authoritative.
+- **Determinism:** source content edits are explicitly generator-versioned and the golden vector is a tripwire, not a snapshot to casually update.
+- **Lifecycle:** only non-final Daily stages need a Continue state; final completion uses the existing result/submission path.
+- **Stage policy:** stage counters cannot be confused with cumulative run counters.
+- **Submission:** no auth preflight; the existing response channel gains one additive structured code.
+- **Coverage:** 95% is an existing Codecov policy, not a new Vitest threshold introduced by HPA-487.

--- a/docs/superpowers/specs/2026-08-12-ice-slide-daily-challenge-design.md
+++ b/docs/superpowers/specs/2026-08-12-ice-slide-daily-challenge-design.md
@@ -4,85 +4,104 @@
 - **Status:** Proposed for HPA-487 implementation
 - **Repository:** `cwchanap/cetus`
 - **Linear issue:** HPA-487 — Ship Ice Slide Daily Challenge MVP with mode selection and three-star objectives
+- **Planning PR:** #60
 - **Parent design:** `docs/superpowers/specs/2026-07-30-ice-slide-replayability-design.md`
 
 ## 1. Summary
 
-HPA-487 is the next unblocked Ice Slide replayability task. Its prerequisites are already merged: HPA-484 added optional score context, HPA-485 added deterministic run definitions/RNG/transforms, and HPA-486 added the production solver and stage-quality validator.
+HPA-487 is the next unblocked Ice Slide replayability task. HPA-484 already added optional score context, HPA-485 added deterministic run definitions/RNG/transforms, and HPA-486 added the production solver and stage-quality validator.
 
-This change should therefore be an integration feature, not a new game framework. Daily generation materializes an `IceSlideRunDefinition` before play starts; `IceSlideGame` continues to consume materialized runs. Pure helpers own Daily generation, objective evaluation, and scoring. `init.ts` owns the clock boundary, retry identity, local UI gating, and submission choice.
+This is an integration feature, not a new game framework. Daily generation materializes an `IceSlideRunDefinition` before play starts; `IceSlideGame` continues to consume materialized runs. Pure helpers own Daily generation, objective evaluation, and scoring. `init.ts` owns the clock boundary, exact retry identity, Daily HUD synchronization, stage-result gating, and submission choice.
 
 The MVP ships only two selectable modes:
 
 - **Campaign** — unchanged default behavior.
 - **Daily** — one deterministic five-stage run per UTC date and version pair.
 
-HPA-488 remains responsible for server-side semantic admission and the Daily leaderboard UI/query flow.
+HPA-488 remains responsible for server-side Daily semantic admission and the Daily leaderboard UI/query flow.
 
 ## 2. Why HPA-487 Is Next
 
-Linear currently models HPA-487 as blocked by HPA-484, HPA-485, and HPA-486. All three are Done. HPA-487 in turn blocks HPA-488, HPA-489, and HPA-490, so completing it unlocks both the Daily ranking finish work and Expedition generation work.
+Linear models HPA-487 as blocked by HPA-484, HPA-485, and HPA-486. All three are Done. HPA-487 then unlocks HPA-488, HPA-489, and HPA-490.
 
-No HPA-487 branch or PR currently exists in GitHub.
+The planning work lives in draft PR #60. HPA-487 remains a planning-only Backlog item until implementation begins.
 
 ## 3. Existing Boundaries to Reuse
 
 The current code already provides the important foundations:
 
-- `run.ts` owns run schema/version checks, exact Daily run-key/seed validation, stage signatures, Campaign materialization, and defensive cloning.
+- `run.ts` owns run schema/version checks, Daily run-key/seed validation, stage signatures, Campaign materialization, and defensive cloning.
 - `seeded-rng.ts` owns stable FNV-1a/Mulberry32 RNG and labeled forks.
 - `transforms.ts` owns all eight transforms and canonical deduplication through `getUniqueBoardTransforms()`.
-- `quality.ts` owns solver-backed board, par, duplicate, and objective-feasibility validation.
-- `game.ts` already accepts `start(run?: IceSlideRunDefinition)` and reports run/version metadata in state/game data.
+- `solver.ts` and `quality.ts` own bounded solve facts and stage admission.
+- `game.ts` already accepts `start(run?: IceSlideRunDefinition)` and reports run/version metadata.
 - `scoreService.ts` already accepts contextual submissions through `SaveScoreOptions.context`.
-- `index.astro` already owns the page-level Start/End/Reset/Play Again wiring.
+- `index.astro` already owns page-level Start/End/Reset/Play Again wiring.
 
-HPA-487 should extend these seams rather than introduce a generic generator framework, mode registry, overlay framework, or new persistence service.
+HPA-487 extends these seams. It does not introduce `generator.ts`, a generic generated-run service, a mode registry, a new persistence service, or a shared overlay framework.
 
 ## 4. Approaches Considered
 
 ### 4.1 Recommended: thin Daily materializer + pure policy helpers
 
-Add a focused `daily.ts` that turns an explicit UTC date key into a complete five-stage run, plus `objectives.ts` for objective evaluation. Extend existing scoring/game/init/page surfaces only where Daily behavior differs.
+Add a focused `daily.ts` that turns an explicit UTC date key into a complete five-stage run, plus `objectives.ts` for objective evaluation. Extend existing scoring/game/init/page surfaces only where Daily differs.
 
-**Why this fits now**
-
-- Reuses every HPA-484/485/486 primitive directly.
-- Keeps date/random selection out of `IceSlideGame`.
-- Keeps Expedition-specific template/retry orchestration out of HPA-487.
-- Produces deterministic, independently testable contracts.
-- Is small enough to replace later only if Expedition proves a shared abstraction is actually useful.
+This reuses every HPA-484/485/486 primitive directly and keeps the clock/RNG out of `IceSlideGame`.
 
 ### 4.2 Generic generated-run service
 
-Create a reusable generator pipeline with policies for pools, retries, objectives, fallbacks, and modes.
-
-**Rejected for HPA-487:** only Daily uses generated content today. HPA-489 has materially different authored mutation templates and bounded candidate generation. Generalizing before that code exists would encode guesses and increase the implementation surface.
+Rejected. Only Daily uses generated content today, while HPA-489 has materially different authored mutation templates and bounded candidate generation. Generalizing now would encode guesses.
 
 ### 4.3 Put Daily generation inside `IceSlideGame`
 
-Have the game inspect the current date and construct Daily stages internally.
-
-**Rejected:** this breaks the already-established materialized-run boundary, makes rollover/retry testing harder, and couples gameplay state to clock/RNG policy.
+Rejected. It breaks the materialized-run boundary and couples gameplay state to the current clock and random-selection policy.
 
 ## 5. Fixed Product Decisions
 
-1. Campaign remains the default and keeps its existing score/submission semantics.
-2. Daily is the only additional selectable mode. Do not show Expedition placeholders.
-3. `/ice-slide?mode=daily` preselects Daily. Any other/malformed value selects Campaign. Query selection never auto-starts a run.
-4. A fresh Daily Start captures the current UTC date once and materializes a run from that date.
+1. Campaign remains the default and keeps existing score/submission semantics.
+2. Daily is the only additional selectable mode. Do not show an Expedition placeholder.
+3. `/ice-slide?mode=daily` preselects Daily. Any other/malformed value selects Campaign. Query selection never auto-starts.
+4. A fresh Daily Start captures the current UTC date once and materializes a run for that date.
 5. `Play Again` reuses the exact previously materialized Daily run, even after UTC rollover.
-6. A player can choose **Change Mode** from the result overlay to return to the idle selector; starting Daily from there captures the then-current UTC date.
-7. Daily has exactly five stages and one seeded bonus objective per stage.
+6. **Change Mode** from the result overlay returns to the idle selector without starting a run; a later Daily Start captures the then-current UTC date.
+7. Daily has exactly five stages and exactly one seeded feasible bonus objective per stage.
 8. Stage-clear feedback uses an explicit **Continue** button. There is no auto-advance timer or forced animation delay.
-9. Daily partial End is local only and never sends a score.
-10. Daily completed authenticated runs send contextual scores. A positively confirmed anonymous session stays local without producing a score-save error.
-11. HPA-488 owns server-side Daily admission rules and leaderboard presentation; HPA-487 does not duplicate them.
-12. Expedition, mutation templates, snow, cracked ice, abilities, and the platform-wide Daily Challenge rotation remain out of scope.
+9. A partial Daily End is local only and never sends a score.
+10. A completed authenticated Daily sends contextual score data. A positively confirmed anonymous session stays local without a score-save error.
+11. HPA-488 owns server-side Daily admission and ranked presentation.
+12. The finite authored Daily candidate set throws if it cannot materialize a valid stage; HPA-487 does not add the parent roadmap's mutation-generation fallback/retry service.
+13. Expedition, mutation templates, snow, cracked ice, abilities, and the platform-wide Daily Challenge rotation remain out of scope.
 
 ## 6. Daily Run Materialization
 
-### 6.1 Version and identity
+### 6.1 Shared UTC date-key validation
+
+The existing calendar-valid `YYYY-MM-DD` check inside `assertValidIceSlideRunDefinition()` must become one exported `run.ts` helper instead of being copied into `daily.ts`:
+
+```ts
+export function assertValidIceSlideUtcDateKey(dateKey: string): void
+```
+
+The helper requires the exact `YYYY-MM-DD` shape, constructs a UTC calendar date, round-trips year/month/day, and throws `RangeError` for malformed or impossible dates.
+
+`assertValidIceSlideRunDefinition()` calls this helper for the date segment captured by the Daily run-key regex.
+
+`daily.ts` exposes:
+
+```ts
+export function toIceSlideUtcDateKey(date: Date): string {
+  if (!Number.isFinite(date.getTime())) {
+    throw new RangeError('date must be valid')
+  }
+  const dateKey = date.toISOString().slice(0, 10)
+  assertValidIceSlideUtcDateKey(dateKey)
+  return dateKey
+}
+```
+
+`createIceSlideDailyRunDefinition(dateKey)` also calls `assertValidIceSlideUtcDateKey(dateKey)` before constructing any seed or run key. There is one calendar-validation contract, not a second Daily parser.
+
+### 6.2 Version and identity
 
 Add:
 
@@ -91,68 +110,176 @@ export const ICE_SLIDE_DAILY_GENERATOR_VERSION = 1
 export const ICE_SLIDE_DAILY_SOLVER_MAX_STATES = 10_000
 ```
 
-For an explicit `dateKey: YYYY-MM-DD`:
+For an explicit `dateKey`:
 
 ```text
 seed = ice-slide:daily:<generatorVersion>:<rulesetVersion>:YYYY-MM-DD
 runKey = ice-slide:daily:YYYY-MM-DD:g<generatorVersion>:r<rulesetVersion>
 ```
 
-The generator uses the existing `ICE_SLIDE_RULESET_VERSION`. `init.ts`, not the generator or game engine, converts `new Date()` to a UTC date key.
+The generator uses the existing `ICE_SLIDE_RULESET_VERSION`. It never reads the current clock itself.
 
-### 6.2 Tier pools
+### 6.3 Tier pools and source resolution
 
-Daily stage pools are fixed to the parent design:
+Daily stage pools are fixed:
 
 ```ts
-[
+export const ICE_SLIDE_DAILY_STAGE_POOLS = [
   [1, 2],
   [2, 3],
   [3, 4, 5],
   [5, 6, 7],
   [7, 8],
+] as const
+```
+
+Pool values are authored `IceSlideLevel.id` values, never array offsets. Resolve a source by searching `ICE_SLIDE_LEVELS` for matching `level.id`; do not use `ICE_SLIDE_LEVELS[id - 1]`.
+
+`run.ts` exports its existing difficulty mapping as:
+
+```ts
+export const CAMPAIGN_STAGE_DIFFICULTIES: readonly IceSlideDifficulty[]
+```
+
+After resolving the level, use that level's actual array index to read its Campaign difficulty.
+
+### 6.4 Frozen stage metadata
+
+Every selected Daily stage materializes these exact identity fields:
+
+```ts
+{
+  id: `daily:${dateKey}:${stageNumber}`,
+  name: source.name,
+  templateId: `campaign:${source.id}`,
+  difficulty: CAMPAIGN_STAGE_DIFFICULTIES[sourceIndex],
+  rows: variant.rows,
+  parMoves: quality.parMoves,
+  transform: variant.transform,
+  mutationIds: [],
+  objectiveIds: [bonusObjective],
+  scoreMultiplierBps: 10_000,
+}
+```
+
+Compute `signature` from that complete object with `createIceSlideStageSignature()`.
+
+These fields are part of the deterministic generator contract. A change that alters them for an existing date requires a Daily generator-version bump.
+
+### 6.5 Exact deterministic selection algorithm
+
+The selection algorithm is frozen as follows:
+
+1. Create `rootRng = createSeededRng(seed)`.
+2. For 1-based stage `N`, create `stageRng = rootRng.fork(`stage:${N}`)`.
+3. Shuffle that stage's level-ID pool with `stageRng.fork('template').shuffle(pool)`.
+4. Iterate the shuffled IDs and skip any `campaign:<id>` template already used by the run.
+5. Resolve the source by `level.id` and call `getUniqueBoardTransforms(source.rows)`.
+6. Shuffle those canonical-deduplicated variants with:
+
+   ```ts
+   stageRng
+     .fork(`transform:${source.id}`)
+     .shuffle(getUniqueBoardTransforms(source.rows))
+   ```
+
+7. Iterate variants and call `validateIceSlideStageQuality()` with:
+   - `objectiveIds: []`;
+   - par band exactly equal to `source.parMoves`;
+   - `maxStates = 10_000`;
+   - canonical keys already accepted for earlier stages.
+8. The first accepted candidate wins; use `quality.parMoves` as the materialized par.
+9. Build eligible bonus objectives from `quality.objectiveFeasibility` in this fixed order:
+
+   ```ts
+   [
+     'collect_all_crystals',
+     'no_falls',
+     'no_reset',
+   ]
+   ```
+
+10. Pick exactly one with `stageRng.fork('objective').pick(eligibleObjectives)`.
+11. Materialize the frozen metadata from §6.4 and compute the signature.
+12. Record its template ID and canonical key, then continue.
+13. After five stages, call `assertValidIceSlideRunDefinition(run)` before returning it.
+
+`no_reset` is feasible for every accepted solvable board, so the eligible-objective list cannot be empty.
+
+The largest stage pool has three sources and each source has at most eight unique transforms. The finite authored search is therefore below the parent design's 64-candidate bound without adding a retry/fallback subsystem. If no source/variant satisfies the frozen contract, `createIceSlideDailyRunDefinition()` throws and the existing `failRun()` lifecycle owns cleanup/error display.
+
+### 6.6 Generator-v1 golden output
+
+Generator version 1 is not defined only by invariants. The full deterministic tuple for `2026-08-12` is frozen:
+
+```ts
+[
+  {
+    id: 'daily:2026-08-12:1',
+    name: 'Corner Pocket',
+    templateId: 'campaign:2',
+    transform: 'identity',
+    objectiveIds: ['no_reset'],
+    parMoves: 3,
+    difficulty: 'easy',
+    signature: 'is2-8c5387f7',
+  },
+  {
+    id: 'daily:2026-08-12:2',
+    name: 'Bank Shot',
+    templateId: 'campaign:3',
+    transform: 'rotate_180',
+    objectiveIds: ['no_reset'],
+    parMoves: 4,
+    difficulty: 'easy',
+    signature: 'is2-c8c370cb',
+  },
+  {
+    id: 'daily:2026-08-12:3',
+    name: 'Crystal Cache',
+    templateId: 'campaign:5',
+    transform: 'reflect_anti_diagonal',
+    objectiveIds: ['collect_all_crystals'],
+    parMoves: 6,
+    difficulty: 'medium',
+    signature: 'is2-2394afd9',
+  },
+  {
+    id: 'daily:2026-08-12:4',
+    name: 'Deep Freeze',
+    templateId: 'campaign:7',
+    transform: 'reflect_vertical',
+    objectiveIds: ['collect_all_crystals'],
+    parMoves: 6,
+    difficulty: 'hard',
+    signature: 'is2-07d0c27d',
+  },
+  {
+    id: 'daily:2026-08-12:5',
+    name: 'Absolute Zero',
+    templateId: 'campaign:8',
+    transform: 'reflect_main_diagonal',
+    objectiveIds: ['no_reset'],
+    parMoves: 6,
+    difficulty: 'hard',
+    signature: 'is2-c31fa49b',
+  },
 ]
 ```
 
-The values are authored Campaign level IDs, not array offsets.
+`daily.test.ts` asserts this literal projection in addition to run-key/seed and structural invariants.
 
-`run.ts` should expose the existing Campaign difficulty mapping under a stable exported name so `daily.ts` does not duplicate level-to-difficulty knowledge.
+Before generator v1 is considered frozen, the test suite also materializes every UTC date from `2026-01-01` through `2026-12-31` and asserts that none throws. This is a bounded content-validity sweep, not a statistical quality guarantee.
 
-### 6.3 Exact deterministic selection algorithm
+Any future change to pool contents/order, fork labels, transform candidate order, objective ordering, source metadata mapping, stage-signature inputs, or another generator choice that changes the same date's materialized run increments `ICE_SLIDE_DAILY_GENERATOR_VERSION`. Competitive physics/objective/scoring meaning continues to use `ICE_SLIDE_RULESET_VERSION`.
 
-The algorithm is deliberately finite and bounded by the small authored pools:
+### 6.7 No hidden nondeterminism
 
-1. Create `rootRng = createSeededRng(seed)`.
-2. For stage number `N` (1-based), create `stageRng = rootRng.fork('stage:N')`.
-3. Shuffle that stage's level pool with `stageRng.fork('template').shuffle(pool)`.
-4. Iterate the shuffled level IDs and skip any template ID already used by this run.
-5. For each remaining source level, call `getUniqueBoardTransforms(level.rows)`. This removes symmetric duplicate transforms before random choice.
-6. Shuffle those unique variants with `stageRng.fork('transform:<levelId>').shuffle(variants)`.
-7. Iterate variants and call `validateIceSlideStageQuality()` with:
-   - `objectiveIds: []`;
-   - `parBand.minMoves = source.parMoves`;
-   - `parBand.maxMoves = source.parMoves`;
-   - `maxStates = 10_000`;
-   - the canonical keys already accepted for earlier stages.
-8. The first accepted candidate wins. Its returned `parMoves` becomes the materialized par.
-9. Build the eligible bonus-objective list from the validator's `objectiveFeasibility` in this fixed order:
-   `collect_all_crystals`, `no_falls`, `no_reset`.
-10. Pick exactly one with `stageRng.fork('objective').pick(eligibleObjectives)`.
-11. Materialize the stage with the selected transform, no mutation IDs, `scoreMultiplierBps = 10000`, and a signature from `createIceSlideStageSignature()`.
-12. Record the source template ID and canonical key, then continue to the next stage.
-13. After five stages, call `assertValidIceSlideRunDefinition(run)` before returning it.
-
-`no_reset` is feasible for every solvable board, so the eligible-objective list is non-empty after quality acceptance.
-
-The complete search space is at most three authored templates × eight unique transforms for any one Daily stage, so it stays below the parent design's 64-candidate cap without introducing a retry service. If the checked-in authored content cannot produce a valid unique candidate, `createIceSlideDailyRunDefinition()` throws. The existing `failRun` path owns cleanup and player-safe error display.
-
-### 6.4 No hidden nondeterminism
-
-`daily.ts` must not call `Math.random()`, `crypto.getRandomValues()`, or read the current clock. All entropy comes from the explicit seed and labeled RNG forks.
+`daily.ts` does not call `Math.random()`, `crypto.getRandomValues()`, or read the current clock. All entropy comes from the explicit seed and the frozen labeled RNG forks.
 
 ## 7. Objective and Star Model
 
-Add a pure `objectives.ts` helper rather than embedding policy in the renderer or page.
+Add a pure `objectives.ts` helper:
 
 ```ts
 export interface IceSlideObjectiveFacts {
@@ -176,17 +303,17 @@ Completion rules:
 - `no_falls`: no hazard was entered during the stage.
 - `no_reset`: neither manual Reset nor hazard reset occurred during the stage.
 
-Daily stars are computed at clear time:
+Daily stars at clear time:
 
-- Clear: always earned when the result is produced.
+- Clear: always earned.
 - Efficient: `movesUsed <= parMoves`.
-- Bonus: evaluate the stage's single `objectiveIds[0]` with the facts above.
+- Bonus: evaluate the stage's single `objectiveIds[0]`.
 
-The game records the cumulative Daily star count in the existing `starsEarned` field. Campaign continues to report `starsEarned = 0`.
+The game records cumulative Daily stars in the existing `starsEarned` field. Campaign continues to report zero Daily stars.
 
 ## 8. Runtime State and Stage Results
 
-Extend `IceSlideState` only with data needed to render/evaluate the active stage:
+Extend `IceSlideState` only with active-stage facts needed by policy/UI:
 
 ```ts
 parMoves: number
@@ -195,18 +322,18 @@ levelFalls: number
 levelResets: number
 ```
 
-`getState()` must defensively copy `objectiveIds`.
+`getState()` defensively copies `objectiveIds`.
 
 Counter rules:
 
-- A normal committed move keeps the existing move behavior.
+- A normal committed move keeps existing move behavior.
 - Manual Reset increments `resets` and `levelResets`; it does not increment falls.
 - Hazard entry increments `falls`, `resets`, `levelFalls`, and `levelResets` exactly once.
-- Existing hazard behavior continues to preserve the hazard move in `levelMoves`.
-- Starting a new stage resets `levelFalls`/`levelResets` to zero.
-- Reloading the same stage because of Reset/hazard preserves those stage counters.
+- Hazard reload preserves the hazard move in `levelMoves`.
+- A new stage resets `levelFalls`/`levelResets` to zero.
+- Same-stage Reset/hazard reload preserves those stage attempt counters.
 
-Replace the numeric `onLevelClear(level)` payload with a focused result object because the callback is local to Ice Slide and the new UI needs the facts anyway:
+Replace numeric `onLevelClear(level)` with:
 
 ```ts
 export interface IceSlideStageClearResult {
@@ -225,15 +352,24 @@ export interface IceSlideStageClearResult {
 }
 ```
 
-For Campaign, `bonus` is `null` and cumulative `starsEarned` remains unchanged. The `efficient` fact may still be reported for consistency, but Campaign UI does not show star feedback.
+Campaign may report Efficient as a fact but shows no star UI and does not increment `starsEarned`.
 
-The game can prepare the next stage immediately after producing this result. The browser integration places an opaque stage-clear overlay above the canvas before `afterMove()` renders again, so the player sees the completed-stage result before interacting with the next board without adding a new game-engine pause/advance state.
+### 8.1 Preserve the current callback order
+
+Do not redesign `IceSlideGame` into a paused-stage state machine.
+
+- On a non-final clear, the game computes the completed-stage result, prepares the next stage using the existing immediate-load flow, and invokes `onLevelClear(result)`.
+- On a final clear, it applies the correct completion bonus, sets `status = 'won'`, stops the timer, invokes `onLevelClear(result)`, then invokes `onWin(finalScore)` synchronously.
+
+Tests lock final callback order as `level-clear` then `win`.
+
+The browser overlay, not the game engine, prevents interaction with the already-prepared next stage.
 
 ## 9. Scoring
 
-Existing Campaign functions and constants remain unchanged.
+Existing Campaign functions/constants remain unchanged.
 
-Add pure Daily functions in `scoring.ts`:
+Add:
 
 ```ts
 export const DAILY_SCORING_CONFIG = {
@@ -253,7 +389,7 @@ export function dailyStageScore(params: {
 export function dailyTimeBonus(elapsedSeconds: number): number
 ```
 
-`dailyStageScore` reuses the current Campaign primitives for base clear, move efficiency, and crystals:
+Daily stage score:
 
 ```text
 200 × stageNumber
@@ -262,19 +398,19 @@ export function dailyTimeBonus(elapsedSeconds: number): number
 + 100 × optionalStarsEarned
 ```
 
-`optionalStarsEarned` is the number of earned Efficient/bonus stars (`0..2`); the Clear star is represented by the base clear points.
+`optionalStarsEarned` counts Efficient and bonus stars only (`0..2`). Clear is represented by the base clear points.
 
-The Daily completion bonus is:
+Daily completion bonus:
 
 ```text
 max(0, (300 - elapsedSeconds) × 5)
 ```
 
-Only `mode === 'daily'` uses these new functions. Campaign keeps the existing 360-second completion bonus. Expedition scoring is not implemented or changed by HPA-487.
+Campaign keeps the existing 360-second completion bonus. Expedition scoring is untouched.
 
 ## 10. Browser Lifecycle and Retry Semantics
 
-Change the handle to expose the two shipped choices without inventing a mode registry:
+Use the two shipped choices only:
 
 ```ts
 export type IceSlidePlayableMode = 'campaign' | 'daily'
@@ -289,105 +425,118 @@ export interface IceSlideHandle {
 }
 ```
 
-`start(mode)` means a **fresh** run:
+`start(mode)` means a fresh run:
 
-- Campaign creates the normal Campaign run.
-- Daily captures `new Date().toISOString().slice(0, 10)`, materializes the Daily run, and stores a defensive copy as the retry run.
+- Campaign starts the normal Campaign.
+- Daily calls `toIceSlideUtcDateKey(new Date())`, materializes the Daily, and stores a defensive copy plus the captured date key for retry/HUD use.
 
-`playAgain()` means **retry the last started run**:
+`playAgain()` retries the last started run:
 
 - Campaign starts Campaign again.
-- Daily starts a clone of the exact stored run. It never re-reads the date.
+- Daily starts a clone of the exact stored run and reuses its captured date key. It does not read the clock.
 
-This distinction directly handles UTC rollover without adding clock state to `IceSlideGame`.
+This is the only fresh-vs-retry distinction needed for UTC rollover.
 
-## 11. Stage-Clear and Input Gating
+## 11. Stage-Clear, Final-Win, and End Semantics
 
-`init.ts` owns a small `inputLocked` flag.
+`init.ts` owns `inputLocked`, the stage-clear DOM state, and `pendingDailyWinScore`.
 
-Input is accepted only while:
+Movement is accepted only when:
 
 ```text
 game.status === 'playing' && inputLocked === false
 ```
 
-Both keyboard and pointer/swipe paths use the same condition.
+Keyboard and pointer/swipe use the same predicate. Reset also no-ops while the stage-clear overlay is active.
 
-For Daily stage clear:
+### 11.1 Daily non-final clear
 
-1. Receive `IceSlideStageClearResult`.
-2. Set `inputLocked = true`.
-3. Fill the stage-clear overlay with Clear/Efficient/bonus states and score gained.
-4. Show the overlay and focus its Continue button.
-5. On Continue, hide the overlay, clear the lock, render/sync the next stage.
+1. `onLevelClear(result)` sets `inputLocked = true`.
+2. Fill/show the stage-clear overlay and focus Continue.
+3. `afterMove()` may render/synchronize the already-prepared next stage underneath the opaque overlay.
+4. Continue hides the overlay, clears the lock, and calls render/HUD sync again before the player can move.
 
-There is no auto-dismiss timer. This makes keyboard behavior deterministic and inherently satisfies reduced-motion requirements.
+### 11.2 Daily final clear
 
-On the fifth Daily stage, `onWin` records the pending final score while the stage-clear overlay remains visible. Continue then transitions to the existing mission-complete overlay, invokes the external win callback, and submits the completed result.
+Keep the engine callback order from §8.1.
 
-All failure/cleanup/start paths clear pending overlay state and input locks.
+1. Final `onLevelClear(result)` shows/locks the stage-clear overlay.
+2. The immediately following Daily `onWin(finalScore)` **only** stores `pendingDailyWinScore = finalScore`; it does not show `MISSION COMPLETE`, call the external `callbacks.onWin`, reset buttons, authenticate, or submit.
+3. Continue on that final overlay clears the stage overlay, shows `MISSION COMPLETE`, invokes the external win callback, resets controls, and starts the completed Daily submission flow exactly once.
 
-## 12. Page UI
+This guarantees that the final stage result is visible before the result overlay or network work.
 
-Keep the UI local to `src/pages/ice-slide/index.astro`.
+### 11.3 End while a stage-clear overlay is visible
 
-### 12.1 Pre-run mode selector
+The behavior is explicit because the engine has already advanced/finished underneath the overlay:
 
-Add a compact semantic selector above the canvas:
+- **Non-final Daily overlay:** `stop()` hides the stage-clear overlay, clears the lock/pending stage UI, stops the now-current run, restores controls, shows local `RUN ENDED`, and does **not** submit any Daily score.
+- **Final Daily overlay:** the End control is hidden/disabled while the final result awaits Continue. A programmatic `stop()` is a no-op: it leaves the final stage-clear overlay and pending win intact and does not submit. Continue remains the only transition to completed-result submission.
 
-- Campaign
-- Daily
+All start/fail/cleanup paths clear stage-result DOM state, locks, and pending win state.
 
-Campaign starts selected. The page reads `URLSearchParams` once during initialization; only the exact string `daily` preselects Daily. `campaign`, missing values, `expedition`, and malformed values all select Campaign.
+There is no auto-dismiss timer. Reduced-motion users therefore have no forced delay.
 
-The selector is disabled while a run is active.
+## 12. Daily HUD and Page UI
 
-### 12.2 Daily HUD
+Keep all page markup local to `src/pages/ice-slide/index.astro`; no shared component/API changes are needed.
 
-Show only in Daily mode:
+### 12.1 Pre-run selector
 
-- UTC competition date.
-- `Resets at 00:00 UTC` plus the next UTC date.
-- `Stage N / 5`.
-- active objective rows for Clear, Efficient (`≤ par`), and the seeded bonus objective.
+Add a semantic Campaign/Daily selector above the canvas. Campaign is selected by default. Only exact query value `daily` changes that preselection. The selector is disabled while a run is active and re-enabled by Change Mode.
 
-Do not add a countdown timer; the existing elapsed-time ticker should not be overloaded with UTC boundary scheduling.
+### 12.2 HUD ownership
+
+`init.ts` extends `syncHud()` so the objective state cannot drift from the already-loaded game stage.
+
+For Campaign:
+
+- hide `#daily-meta`;
+- preserve existing score/level/moves/crystals/time/name behavior.
+
+For Daily:
+
+- show `#daily-meta`;
+- set `#daily-date` from the captured/retried Daily date key;
+- set `#daily-reset` to `Resets at 00:00 UTC` plus the next UTC date;
+- set `#daily-stage-progress` to `Stage N / 5`;
+- set Clear text for reaching the goal;
+- set Efficient text from current `state.parMoves`;
+- set bonus text from `ICE_SLIDE_OBJECTIVE_LABELS[state.objectiveIds[0]]`.
+
+Call this synchronization on initial Daily Start, normal `syncHud()` paths, and again after stage-clear Continue. Therefore every new Daily board exposes its three objectives before its first accepted move.
+
+Do not add a UTC countdown scheduler.
 
 ### 12.3 Stage-clear overlay
 
-Add a page-local overlay inside the board area with:
+Add a page-local opaque overlay inside the board area containing stage name/number, all three earned/missed objective rows, stage score gained, and a real Continue button. Use text/symbols in addition to color.
 
-- stage name/number;
-- three objective rows with earned/missed states;
-- stage score gained;
-- Continue button.
+### 12.4 Result overlay and Change Mode
 
-Use text/symbol state in addition to color.
+Keep shared GameOverlay's Play Again button. Add a page-local `#change-mode-btn` through `final-stats`.
 
-### 12.4 Result overlay escape path
+- Play Again calls `gameHandle.playAgain()`.
+- Change Mode hides the result overlay, shows the pre-run status/selector, re-enables mode controls, and does not auto-start.
 
-Keep the shared GameOverlay's primary **Play Again** button. Add a small **Change Mode** button through the existing `final-stats` slot. It hides the result overlay, returns to the idle selector, and does not start a run.
-
-This preserves the required Daily retry behavior while still letting a player switch mode or start a new post-rollover Daily run.
+No `GameOverlay` API change is required.
 
 ### 12.5 Scoring copy
 
-Keep existing Campaign scoring copy and add one concise Daily note: Daily gives +100 for each Efficient/bonus star and uses a 5:00 completion budget.
-
-No new shared UI component is needed for one page.
+Keep Campaign scoring copy and add a concise Daily note: +100 for each Efficient/bonus star and a 5:00 completion budget.
 
 ## 13. Score Submission and Anonymous Play
 
-Campaign submission remains byte-for-behavior compatible:
+Campaign remains behavior-compatible:
 
 - completed Campaign submits unscoped;
-- manually ended Campaign with positive score still submits its partial score.
+- manually ended Campaign with positive score still submits partial score.
 
-Daily behavior:
+Daily:
 
-- manual End never submits;
-- only the final completed five-stage run submits;
-- submission uses current game data and:
+- any partial End never submits;
+- only final-stage Continue may initiate completed submission;
+- submission includes current game data and:
 
 ```ts
 {
@@ -400,128 +549,142 @@ Daily behavior:
 }
 ```
 
-Before a Daily submission, call the existing `authClient.getSession()`:
+Before Daily submission, call `authClient.getSession()`:
 
-- if it positively returns no session and no error, keep the result local and skip `saveGameScore()`;
-- if a session exists, submit normally;
-- if the session check itself fails, allow the existing score endpoint to remain authoritative rather than silently discarding a potentially authenticated result.
+- confirmed no session/no auth error => local result only;
+- session exists => submit normally;
+- session check fails => let the existing score endpoint remain authoritative instead of silently discarding a possibly authenticated result.
 
-A score-save failure never invalidates the completed local run.
+Capture the run guard before awaiting auth and re-check staleness afterward.
 
-HPA-487 performs only this client lifecycle guard. HPA-488 will add server-side checks for solved state, matching Daily key/version identity, and leaderboard admission.
+A score-save failure never invalidates local completion. HPA-488 adds server-side solved/run/version admission and ranking.
 
 ## 14. Error Handling
 
 - Invalid/malformed mode query values fall back to Campaign without auto-start.
-- Daily materialization failures flow through the existing `failRun()` cleanup path.
-- Failed renderer setup retains the existing cleanup behavior.
-- `start()` clears stale stage/result overlay state before creating a new game.
-- Run guard semantics continue to suppress stale achievement callbacks.
-- Daily score failures use the existing `Score not saved` reporting but do not remove local completion UI.
-- A confirmed anonymous Daily completion is not an error.
+- Daily materialization failures use existing `failRun()` cleanup.
+- Failed renderer setup keeps existing cleanup behavior.
+- Fresh/retry start clears stale stage/result overlay state before creating a game.
+- Run guards continue to suppress stale async callbacks.
+- Daily score failure uses existing `Score not saved` reporting without removing local completion UI.
+- Confirmed anonymous Daily completion is not an error.
 - No path falls back to nondeterministic generation.
 
 ## 15. File Boundaries
 
 ### Create
 
-- `src/lib/games/ice-slide/daily.ts` — deterministic Daily identity/stage materialization.
-- `src/lib/games/ice-slide/daily.test.ts` — deterministic pools/transforms/quality/version tests.
-- `src/lib/games/ice-slide/objectives.ts` — pure objective completion and display labels.
-- `src/lib/games/ice-slide/objectives.test.ts` — objective rules.
+- `src/lib/games/ice-slide/daily.ts`
+- `src/lib/games/ice-slide/daily.test.ts`
+- `src/lib/games/ice-slide/objectives.ts`
+- `src/lib/games/ice-slide/objectives.test.ts`
+- `src/lib/games/ice-slide/scoring.test.ts`
 
 ### Modify
 
-- `src/lib/games/ice-slide/types.ts` — active-stage facts, stage-clear result, playable mode type.
-- `src/lib/games/ice-slide/run.ts` — expose Campaign difficulty mapping for reuse.
-- `src/lib/games/ice-slide/scoring.ts` and tests — Daily pure score functions.
-- `src/lib/games/ice-slide/game.ts` and tests — counters, Daily stars/scoring/result payload.
-- `src/lib/games/ice-slide/init.ts` and tests — fresh-vs-retry runs, input gate, overlays, scoped completed submission, anonymous guard.
-- `src/pages/ice-slide/index.astro` — selector, Daily HUD, stage/result controls and URL preselection.
-- `e2e/games/play-coverage.spec.ts` — preserve Campaign smoke and add focused Daily selector/query/lifecycle coverage.
+- `src/lib/games/ice-slide/types.ts`
+- `src/lib/games/ice-slide/run.ts`
+- `src/lib/games/ice-slide/scoring.ts`
+- `src/lib/games/ice-slide/test-fixtures.ts`
+- `src/lib/games/ice-slide/game.ts` and existing game tests
+- `src/lib/games/ice-slide/init.ts` and `init.test.ts`
+- `src/pages/ice-slide/index.astro`
+- `src/pages/game-board-markup.test.ts`
+- `e2e/games/play-coverage.spec.ts`
 
 ### Do not modify for HPA-487
 
 - database schema/query code;
 - `/api/leaderboard` or leaderboard pages;
-- server-side score admission logic;
+- server-side Daily admission logic;
 - Expedition templates/generation;
-- shared `GamePage`/`GameOverlay` APIs unless implementation discovers an actual blocker;
+- shared `GamePage`/`GameOverlay` APIs;
 - platform Daily Challenge rotation.
 
 ## 16. Testing Strategy
 
 ### Pure generation
 
-- exact seed/run-key format for a fixed UTC date;
-- exactly five stages;
-- stage templates follow pools and never repeat;
-- all final canonical boards are unique;
-- same date/version produces deeply equal run definitions;
-- multiple representative dates produce deterministic variation;
-- every materialized par equals the production solver result;
-- every assigned objective is feasible;
-- generated signatures pass `assertValidIceSlideRunDefinition()`.
+- shared UTC date-key helper accepts/rejects calendar dates once for both run validation and Daily materialization;
+- exact seed/run-key for `2026-08-12`;
+- literal generator-v1 golden tuple from §6.6;
+- exactly five stages with pool-valid, non-repeated source template IDs;
+- unique final canonical boards;
+- source resolution by `level.id`, copied source name, and Campaign difficulty mapping;
+- same date/version is byte-equivalent;
+- representative different dates vary deterministically;
+- every par equals the production solver result and assigned objective is feasible;
+- every date in calendar year 2026 materializes without throwing;
+- run signatures validate through `assertValidIceSlideRunDefinition()`.
 
 ### Objectives/scoring
 
-- collect-all success/failure;
+- collect-all success/failure and zero-crystal behavior;
 - no-falls success/failure;
 - no-reset distinguishes manual/hazard reset history;
 - Efficient uses `<= par`;
-- Daily optional-star bonus and 300-second completion bonus exact boundaries;
-- existing Campaign scoring tests stay unchanged.
+- exact Daily star bonus and 300-second completion boundaries;
+- Campaign scoring remains unchanged.
 
 ### Game runtime
 
 - manual Reset increments reset counters once;
 - hazard increments fall/reset counters once and preserves move semantics;
-- per-stage attempt counters survive reload then reset on next stage;
-- Daily clear result reports exact star outcome/score gained;
+- per-stage counters survive same-stage reload and reset on advance;
+- Daily clear result reports exact stars/score gained;
 - cumulative Daily stars carry across stages;
-- Campaign score, stars, progression, reset/hazard behavior remain compatible.
+- final callback order stays `onLevelClear` then `onWin`;
+- Campaign score/progression/reset/hazard behavior remains compatible.
 
 ### Browser integration
 
 - fresh Daily captures current UTC date;
-- `playAgain()` reproduces exact run/signatures after simulated UTC rollover;
-- a new Daily `start('daily')` after rollover uses the new date;
-- partial Daily End does not call `saveGameScore()`;
-- completed Daily uses exact score context;
+- `playAgain()` reproduces the exact run/signatures after simulated UTC rollover;
+- fresh Daily after rollover uses the new date;
+- Campaign hides Daily HUD;
+- Daily start populates date/reset/stage/par/bonus HUD before the first move;
+- Continue re-syncs the next stage HUD;
+- non-final overlay End terminates locally with no submission;
+- final overlay `onWin` remains pending until Continue; final overlay End is inert;
+- partial Daily End never calls `saveGameScore()`;
+- completed Daily uses exact context once;
 - confirmed anonymous completion skips submission;
-- stage-clear overlay gates keyboard and swipe until Continue;
-- cleanup/failure clears locks/overlays;
-- Campaign partial/full submission remains unscoped.
+- keyboard/swipe/reset remain locked while stage result is active;
+- cleanup/failure clears locks/overlays/pending win;
+- Campaign partial/full submissions remain unscoped.
 
 ### Page/E2E
 
 - `/ice-slide` defaults to Campaign;
 - `/ice-slide?mode=daily` preselects Daily;
-- malformed/unavailable `mode` falls back to Campaign;
+- malformed/unavailable mode falls back to Campaign;
 - Daily Start shows date/stage/objectives;
+- Playwright fixes browser time before UTC rollover, starts Daily, ends locally, advances clock across midnight, clicks Play Again, and verifies the displayed Daily date is unchanged;
+- Change Mode returns to an enabled selector/pre-run state without auto-start;
 - Campaign happy path remains covered;
-- stage-clear Continue path is keyboard accessible;
-- Change Mode returns to the selector;
-- reduced-motion mode has no mandatory wait because the overlay is manual.
+- manual Continue has keyboard-accessible behavior and no reduced-motion wait.
 
 ## 17. Acceptance Criteria
 
 HPA-487 is complete when:
 
-1. same UTC date + versions produces byte-equivalent five-stage Daily run data across retries/clients;
-2. representative dates deterministically vary while templates/final boards do not repeat within a run;
-3. every Daily stage is solver-validated, has recomputed par, and has one feasible seeded bonus objective;
+1. the generator-v1 golden `2026-08-12` tuple and same-date byte equivalence are locked;
+2. the complete 2026 UTC date sweep materializes without failure and representative dates vary;
+3. every run has five unique source templates and canonical boards, recomputed pars, and one feasible bonus objective;
 4. stars correctly reflect par, crystals, hazards, manual Reset, and hazard reset;
-5. Daily scoring uses the documented stage formula and 300-second time budget;
-6. only completed Daily runs attempt contextual submission and confirmed anonymous runs remain local;
-7. Campaign behavior, scoring, achievements, partial End semantics, and unscoped submission remain unchanged;
-8. mode selection, URL preselection, stage metadata, objective feedback, retry identity, input gating, keyboard/swipe parity, cleanup, and reduced-motion behavior are covered by tests;
-9. no HPA-488 leaderboard/server-admission work or Expedition/evolving-tile work is pulled into this implementation.
+5. Daily scoring uses the documented stage formula and 300-second budget while Campaign stays unchanged;
+6. final engine callbacks keep `onLevelClear` then `onWin`, while browser completion/submission waits for final Continue;
+7. partial/overlay End behavior is deterministic and never admits a partial Daily submission;
+8. Daily HUD is correct before each stage's first accepted move;
+9. Play Again retry identity is covered both in handle tests across UTC rollover and in page-level Playwright wiring; Change Mode has no auto-start;
+10. only completed Daily runs attempt contextual submission and confirmed anonymous runs remain local;
+11. no HPA-488 ranking/server-admission or Expedition/evolving-tile work is pulled into this implementation.
 
 ## 18. Spec Self-Review
 
-- **Placeholder scan:** no TBD/TODO or deferred decision exists inside HPA-487 scope.
-- **Consistency:** Daily generation remains outside `IceSlideGame`; the game consumes only materialized runs.
-- **Scope:** HPA-488 server admission/leaderboard work and HPA-489+ Expedition work remain explicitly separate.
-- **YAGNI:** no mode registry, generic generator pipeline, new persistence service, shared overlay abstraction, UTC countdown scheduler, or automatic stage-delay state machine is introduced.
-- **Ambiguity:** fresh Start vs Play Again has explicit rollover semantics; objective RNG order and selection labels are fixed; partial Daily End submission behavior is explicit.
+- **Placeholder scan:** no TBD/TODO remains.
+- **Consistency:** one materialized-run boundary; one UTC calendar validator; one frozen RNG-label/output contract.
+- **Scope:** HPA-488 and HPA-489+ remain separate.
+- **YAGNI:** no generic generator pipeline, mode registry, persistence service, shared overlay abstraction, countdown scheduler, or game-engine pause state.
+- **Lifecycle ambiguity:** final callback order, final Continue, non-final/final End, HUD re-sync, Play Again, and Change Mode are explicit.
+- **Versioning:** a same-date materialization change is a generator-version change, not a silent patch.


### PR DESCRIPTION
## Summary

Plans [HPA-487](https://linear.app/cwchanap/issue/HPA-487/ship-ice-slide-daily-challenge-mvp-with-mode-selection-and-three-star) — the next unblocked Ice Slide replayability task after HPA-484/485/486.

This remains a documentation-only draft PR. The architecture is still deliberately small: materialize a complete Daily run before play, keep objective/scoring policy pure, and reuse the existing Ice Slide runtime/init/page/score seams.

## Current design direction

- Reuse `IceSlideGame.start(run)`; no second engine or generic generator service.
- One pure `daily.ts` materializer over the existing seeded RNG, transforms, run contract, production solver, and quality gate.
- Frozen generator-v1 contract: exact fork labels, source-by-`level.id` mapping, stage metadata, literal `2026-08-12` tuple/signatures, and a 365-date 2026 no-throw sweep.
- Extract one shared calendar-valid UTC date-key validator from `run.ts`; keep an explicit-Date Ice Slide formatter aligned with the platform UTC-day boundary.
- Stage-scoped objective facts (`stageFalls`/`stageResets`) so earlier-stage mistakes cannot poison later objectives.
- One configurable `levelScore()` / `timeBonus()` shape with `DAILY_SCORING_CONFIG`; no Daily-named duplicate scoring functions.
- Manual Continue only for non-final Daily stages. The final stage renders its stars in the existing result overlay and `onWin` submits immediately, avoiding a pending-win/final-Continue state.
- Daily End always remains local-only and shows `RUN ENDED` even at score 0, preserving Play Again/Change Mode access.
- No auth preflight: the existing score response channel gains additive `UNAUTHENTICATED` propagation so anonymous completion stays local without another request/staleness branch.
- `init.ts` owns Daily date/reset/stage/par/bonus HUD sync before each stage's first accepted move.
- Actual Play Again + UTC-rollover + Change Mode behavior is locked in Playwright; static markup tests assert durable DOM IDs only.

## Review outcome

The latest ten-point review was incorporated with one correction:

- **Accepted/simplified:** final submission lifecycle, stage-scoped facts, zero-score Daily End behavior, current-v1 quality-gate semantics, source-content generator-version rule, structured unauthenticated handling, configurable scoring, shared UTC boundary wording, and removal of brittle source-text markup assertions.
- **Partially accepted:** the Daily quality gate stays because HPA-487 explicitly requires production-solver validation; the plan now states current v1 content accepts the first candidate and does not add a synthetic Daily rejection harness.
- **Rejected:** the claim that no 95% coverage gate exists. Current `codecov.yml` requires 95% project and patch coverage; the plan keeps that existing gate and clarifies that Vitest itself does not define the threshold.

## Important scope boundary

HPA-487 only sends contextual completed Daily results. **HPA-488 remains the owner of server-side solved/run/version admission and the per-day leaderboard UI/query flow.** No ranking, mutation-template, Expedition, snow, cracked-ice, or shared-overlay subsystem work is pulled forward.

## Documents

- Design: `docs/superpowers/specs/2026-08-12-ice-slide-daily-challenge-design.md`
- Implementation plan: `docs/superpowers/plans/2026-08-12-ice-slide-daily-challenge.md`

The plan remains six TDD tasks:

1. deterministic Daily materialization + generator-v1 freeze;
2. stage-scoped objectives + configurable scoring;
3. runtime counters/results/stars + callback-order regression;
4. retry/HUD/non-final overlay/Daily End/submission + score-error channel;
5. page-local selector/HUD/final stats/Play Again/Change Mode;
6. browser rollover proof + full regression/coverage verification.

## YAGNI boundaries

No generator framework, fallback subsystem, mode registry, auth preflight, final pending-win state, UTC countdown scheduler, shared overlay API, persistence service, HPA-488 ranking work, or Expedition/evolving-tile scope.

## Verification

Documentation-only branch verification against current `main`:

- branch is 6 commits ahead / 0 behind;
- changed files: exactly the two design/plan documents above;
- no production or test files changed, so no runtime test result is claimed by this PR.