### PR TITLE
feat(ice-slide): implement Daily leaderboard with validation and display

### DIFF
--- a/docs/superpowers/plans/2026-08-13-ice-slide-daily-leaderboard.md
+++ b/docs/superpowers/plans/2026-08-13-ice-slide-daily-leaderboard.md
@@ -4,9 +4,9 @@
 
 **Goal:** Admit only valid completed Ice Slide Daily scores, rank one best result per player for the exact Daily competition, and show/refetch that ranking on the Ice Slide page without changing Campaign behavior.
 
-**Architecture:** Reuse HPA-484's existing score-context persistence and `getScopedGameLeaderboard()` window query. Ice Slide-specific semantic admission stays at the existing score/leaderboard API boundary; the Ice Slide page owns one static Astro leaderboard card and a small request-token loader, while `init.ts` only reports a successful score save through an additive callback.
+**Architecture:** Reuse HPA-484's existing score-context persistence and `getScopedGameLeaderboard()` window query unchanged. `run.ts` owns the single Daily-key parser plus pure Daily admission semantics; `/api/scores` and `/api/leaderboard` remain the only network seams. A small Ice-Slide-specific `daily-leaderboard.ts` module owns fetch/render/request-token behavior so the Astro page stays wiring-only and the risky async UI logic is unit-testable.
 
-**Tech Stack:** Astro 5, TypeScript, Tailwind CSS 4, Better Auth, Kysely + LibSQL/Turso, Vitest, Playwright, Bun 1.3.1.
+**Tech Stack:** Astro 5, TypeScript, Tailwind CSS 4, Better Auth, Kysely + LibSQL/Turso, Vitest/jsdom, Playwright, Bun 1.3.1.
 
 ## Global Constraints
 
@@ -14,40 +14,47 @@
 - Daily competition keys remain `ice-slide:daily:YYYY-MM-DD:g<generatorVersion>:r<rulesetVersion>` and use UTC dates.
 - Daily ranking order remains score DESC, elapsed seconds ASC, total moves ASC, submission time ASC; row ID is only the existing final deterministic fallback for exact ties.
 - Repeated attempts remain stored; only the existing best-per-user query chooses the displayed row.
+- `getScopedGameLeaderboard()` and `ScopedLeaderboardQuery` remain unchanged in HPA-488; the exact competition key is the competitive scope.
 - Do not add database schema, a new endpoint, a best-score cache/table, a generic mode registry, a shared leaderboard component, or an auth preflight request.
-- Do not add replay verification, score recomputation, historical Daily navigation, Expedition ranking, or current-user rank lookup beyond returned rows.
-- Astro owns durable HTML; client TypeScript may only update/toggle existing structure and create leaderboard row children without `innerHTML`.
+- Do not add replay verification, score recomputation, historical Daily navigation, Expedition ranking, read-repair for pre-HPA-488 malformed rows, or current-user rank lookup beyond returned rows.
+- Astro owns durable HTML; client TypeScript may update/toggle existing structure and create leaderboard row children without `innerHTML`.
 - Leaderboard or viewer-auth lookup failure must never enter the Ice Slide `failRun` path or invalidate a local result.
 - Preserve HPA-487's captured Daily run identity across UTC rollover and Play Again.
+- Reuse `src/lib/games/shared/utils.ts::formatTime`; do not add another M:SS formatter.
 - Keep existing remote Codecov project/patch coverage requirements at 95%.
 
 ---
 
 ## File map
 
-No new production module is needed.
+One new production module is intentional because it turns page-local async/render behavior into executable unit tests.
 
-- `src/lib/games/ice-slide/run.ts` — parse the already-frozen Daily run-key identity.
-- `src/lib/games/ice-slide/daily.ts` — centralize construction of the already-frozen Daily competition key.
-- `src/pages/api/scores.ts` — reject invalid Ice Slide Daily claims before persistence.
-- `src/lib/server/db/scoped-leaderboard.ts` — optionally constrain an existing scoped query to one ruleset version.
-- `src/pages/api/leaderboard.ts` — require exact Ice Slide Daily identity and add viewer metadata only to scoped responses.
-- `src/lib/games/ice-slide/init.ts` — report a successful, non-stale score save to the page.
-- `src/pages/ice-slide/index.astro` — static Daily leaderboard card plus page-local fetch/render/staleness logic.
-- Existing colocated tests and `e2e/games/play-coverage.spec.ts` — contract and browser coverage.
+- `src/lib/games/ice-slide/run.ts` — single Daily run-key parser plus pure Daily score-admission helper.
+- `src/lib/games/ice-slide/daily.ts` — centralize construction of the frozen Daily competition key.
+- `src/lib/games/ice-slide/init.ts` — consume the one parser for captured date identity, reuse shared `formatTime`, and report successful score saves.
+- `src/pages/api/scores.ts` — call the pure Ice Slide Daily admission helper before persistence.
+- `src/pages/api/leaderboard.ts` — require exact Ice Slide Daily identity and add viewer metadata to scoped responses.
+- `src/lib/games/ice-slide/daily-leaderboard.ts` — Ice-Slide-specific URL/state/row/fetch/request-token logic.
+- `src/pages/ice-slide/index.astro` — static Daily leaderboard card plus event wiring only.
+- Existing colocated tests and `e2e/games/play-coverage.spec.ts` — contract, DOM, async-state, and browser coverage.
+
+Explicitly **not modified**:
+
+- `src/lib/server/db/scoped-leaderboard.ts`
+- `src/lib/server/db/scoped-leaderboard.integration.test.ts`
 
 ---
 
-### Task 1: Freeze one Daily competition-identity seam
+### Task 1: Make one Daily competition-identity parser serve every consumer
 
 **Files:**
 - Modify: `src/lib/games/ice-slide/run.ts`
 - Modify: `src/lib/games/ice-slide/run.test.ts`
 - Modify: `src/lib/games/ice-slide/daily.ts`
 - Modify: `src/lib/games/ice-slide/daily.test.ts`
+- Modify: `src/lib/games/ice-slide/init.ts`
 
 **Interfaces:**
-- Produces:
 
 ```ts
 export interface IceSlideDailyRunIdentity {
@@ -63,11 +70,11 @@ export function parseIceSlideDailyRunKey(
 export function createIceSlideDailyCompetitionKey(dateKey: string): string
 ```
 
-- `createIceSlideDailyRunDefinition(dateKey)` must continue producing byte-equivalent generator-v1 run keys and seeds.
+`createIceSlideDailyRunDefinition(dateKey)` must continue producing byte-equivalent generator-v1 run keys, seeds, stages, objectives, and signatures.
 
 - [ ] **Step 1: Write failing parser tests in `run.test.ts`**
 
-Add the parser import and lock valid identity plus malformed/calendar-invalid keys:
+Add the parser import and lock exact identity plus malformed/calendar-invalid/unsafe versions:
 
 ```ts
 it('parses an exact Daily competition identity', () => {
@@ -85,15 +92,15 @@ it.each([
     'ice-slide:daily:2026-08-12:g0:r1',
     'ice-slide:daily:2026-08-12:g1:r0',
     'ice-slide:daily:2026-08-12:g1',
+    'ice-slide:daily:2026-08-12:g1:r1:extra',
     'daily:2026-08-12:g1:r1',
+    'ice-slide:daily:2026-08-12:g999999999999999999999:r1',
 ])('rejects invalid Daily competition key %s', runKey => {
     expect(parseIceSlideDailyRunKey(runKey)).toBeNull()
 })
 ```
 
-- [ ] **Step 2: Run the focused run tests and confirm red**
-
-Run:
+- [ ] **Step 2: Run the focused run suite and confirm red**
 
 ```bash
 bun run test:run src/lib/games/ice-slide/run.test.ts
@@ -103,7 +110,7 @@ Expected: FAIL because `parseIceSlideDailyRunKey` is not exported.
 
 - [ ] **Step 3: Implement the parser and reuse it in Daily run validation**
 
-In `run.ts`, keep `DAILY_KEY_PATTERN` as the single syntax regex and add:
+Keep `DAILY_KEY_PATTERN` as the single syntax regex. Parse versions once and reject anything outside the existing positive signed-integer contract:
 
 ```ts
 export interface IceSlideDailyRunIdentity {
@@ -120,21 +127,26 @@ export function parseIceSlideDailyRunKey(
         return null
     }
 
+    const generatorVersion = Number(match[2])
+    const rulesetVersion = Number(match[3])
+
     try {
         assertValidIceSlideUtcDateKey(match[1])
+        assertPositiveInt(generatorVersion, 'generatorVersion')
+        assertPositiveInt(rulesetVersion, 'rulesetVersion')
     } catch {
         return null
     }
 
     return {
         dateKey: match[1],
-        generatorVersion: Number(match[2]),
-        rulesetVersion: Number(match[3]),
+        generatorVersion,
+        rulesetVersion,
     }
 }
 ```
 
-Replace the Daily branch's independent numeric extraction with the parsed identity:
+Replace the Daily branch's independent regex extraction with:
 
 ```ts
 const identity = parseIceSlideDailyRunKey(run.runKey)
@@ -152,7 +164,9 @@ const expectedSeed =
     `${identity.rulesetVersion}:${identity.dateKey}`
 ```
 
-- [ ] **Step 4: Add the competition-key helper test in `daily.test.ts`**
+Do not retain another Daily-key regex parser elsewhere in `run.ts`.
+
+- [ ] **Step 4: Add the competition-key constructor test in `daily.test.ts`**
 
 ```ts
 it('builds the frozen generator-v1 Daily competition key', () => {
@@ -160,11 +174,15 @@ it('builds the frozen generator-v1 Daily competition key', () => {
         'ice-slide:daily:2026-08-12:g1:r1'
     )
 })
+
+it('rejects an invalid Daily competition date', () => {
+    expect(() => createIceSlideDailyCompetitionKey('2026-02-29')).toThrow(
+        RangeError
+    )
+})
 ```
 
-The existing generator-v1 fixture must remain unchanged.
-
-- [ ] **Step 5: Implement `createIceSlideDailyCompetitionKey()` and use it in the run materializer**
+- [ ] **Step 5: Implement the constructor and use it in the Daily materializer**
 
 In `daily.ts`:
 
@@ -178,7 +196,7 @@ export function createIceSlideDailyCompetitionKey(dateKey: string): string {
 }
 ```
 
-Then replace only the `runKey` literal construction:
+Replace only the run-key literal:
 
 ```ts
 runKey: createIceSlideDailyCompetitionKey(dateKey),
@@ -186,40 +204,88 @@ runKey: createIceSlideDailyCompetitionKey(dateKey),
 
 Do not change the Daily seed, fork labels, stage pools, transform/objective selection, or version constants.
 
-- [ ] **Step 6: Run both focused suites**
+- [ ] **Step 6: Remove the weaker `init.ts` Daily-date parser**
 
-```bash
-bun run test:run src/lib/games/ice-slide/run.test.ts src/lib/games/ice-slide/daily.test.ts
+Import `parseIceSlideDailyRunKey` from `./run`, delete:
+
+```ts
+function extractDailyDateKey(runKey: string): string | null {
+    return /^ice-slide:daily:(\d{4}-\d{2}-\d{2}):/.exec(runKey)?.[1] ?? null
+}
 ```
 
-Expected: PASS, including the existing literal `2026-08-12` generator-v1 fixture.
+Replace both live consumers:
 
-- [ ] **Step 7: Commit**
+```ts
+const capturedDateKey =
+    dailyDateKey ?? parseIceSlideDailyRunKey(state.runKey)?.dateKey ?? ''
+```
+
+and:
+
+```ts
+dailyDateKey = parseIceSlideDailyRunKey(run.runKey)?.dateKey ?? null
+```
+
+The `startRun()` Daily branch uses the same expression when it needs to recover the captured date from an explicit run.
+
+- [ ] **Step 7: Run identity/generator/init regressions**
+
+```bash
+bun run test:run \
+  src/lib/games/ice-slide/run.test.ts \
+  src/lib/games/ice-slide/daily.test.ts \
+  src/lib/games/ice-slide/init.test.ts
+```
+
+Expected: PASS, including the existing literal `2026-08-12` generator-v1 fixture and rollover/Play Again tests.
+
+- [ ] **Step 8: Commit**
 
 ```bash
 git add src/lib/games/ice-slide/run.ts src/lib/games/ice-slide/run.test.ts \
-  src/lib/games/ice-slide/daily.ts src/lib/games/ice-slide/daily.test.ts
+  src/lib/games/ice-slide/daily.ts src/lib/games/ice-slide/daily.test.ts \
+  src/lib/games/ice-slide/init.ts
 git commit -m "refactor(ice-slide): centralize Daily competition identity"
 ```
 
 ---
 
-### Task 2: Reject invalid Ice Slide Daily score claims before persistence
+### Task 2: Put Ice Slide Daily score admission in pure domain code
 
 **Files:**
+- Modify: `src/lib/games/ice-slide/run.ts`
+- Modify: `src/lib/games/ice-slide/run.test.ts`
 - Modify: `src/pages/api/scores.ts`
 - Modify: `src/pages/api/scores.test.ts`
 
 **Interfaces:**
-- Consumes: `parseIceSlideDailyRunKey()` from Task 1 and the existing `ScoreSubmissionInput` shape.
-- Produces: no new endpoint or public error code; invalid semantic Daily claims return the existing HTTP 400 bad-request response and never call `saveGameScoreWithAchievements()`.
-
-- [ ] **Step 1: Add one valid Daily admission fixture to `scores.test.ts`**
-
-Use the real `GameID.ICE_SLIDE` and a game fixture whose ID is `ice_slide`. The accepted request body is:
 
 ```ts
-const dailyGameData = {
+export function iceSlideDailyAdmissionError(
+    context: {
+        mode: string
+        competitionKey?: string
+        rulesetVersion: number
+    } | undefined,
+    gameData: Record<string, unknown> | undefined
+): string | null
+```
+
+The route calls this only for `GameID.ICE_SLIDE`. Invalid semantic Daily claims return the existing HTTP 400 bad-request response and never call `saveGameScoreWithAchievements()`.
+
+- [ ] **Step 1: Add pure admission fixtures to `run.test.ts`**
+
+Define one valid payload:
+
+```ts
+const validDailyContext = {
+    mode: 'daily',
+    competitionKey: 'ice-slide:daily:2026-08-12:g1:r1',
+    rulesetVersion: 1,
+}
+
+const validDailyGameData = {
     levelsCleared: 5,
     totalMoves: 31,
     crystalsCollected: 2,
@@ -237,88 +303,57 @@ const dailyGameData = {
     resets: 0,
     stageSignatures: ['a', 'b', 'c', 'd', 'e'],
 }
-
-const body = {
-    gameId: 'ice_slide',
-    score: 4321,
-    gameData: dailyGameData,
-    context: {
-        mode: 'daily',
-        competitionKey: dailyGameData.runKey,
-        rulesetVersion: 1,
-    },
-}
 ```
 
-Assert 200 and that persistence receives exactly that game data plus:
-
-```ts
-{
-    mode: 'daily',
-    competitionKey: 'ice-slide:daily:2026-08-12:g1:r1',
-    rulesetVersion: 1,
-    gameDataJson: JSON.stringify(dailyGameData),
-}
-```
-
-- [ ] **Step 2: Add a table of invalid Daily claims**
-
-Each case must return 400 and leave `saveGameScoreWithAchievements` uncalled:
+Assert the valid claim returns `null`, then cover every domain invariant:
 
 ```ts
 it.each([
-    ['missing context', body => ({ ...body, context: undefined })],
-    ['unsolved', body => ({ ...body, gameData: { ...body.gameData, solved: false } })],
-    ['game-data mode mismatch', body => ({ ...body, gameData: { ...body.gameData, mode: 'expedition' } })],
-    ['context mode mismatch', body => ({ ...body, context: { ...body.context, mode: 'expedition' } })],
-    ['run-key mismatch', body => ({ ...body, gameData: { ...body.gameData, runKey: 'ice-slide:daily:2026-08-11:g1:r1' } })],
-    ['generator mismatch', body => ({ ...body, gameData: { ...body.gameData, generatorVersion: 2 } })],
-    ['game-data ruleset mismatch', body => ({ ...body, gameData: { ...body.gameData, rulesetVersion: 2 } })],
-    ['context ruleset mismatch', body => ({ ...body, context: { ...body.context, rulesetVersion: 2 } })],
-    ['missing elapsed metric', body => {
-        const gameData = { ...body.gameData }
-        delete gameData.elapsedSeconds
-        return { ...body, gameData }
-    }],
-    ['missing move metric', body => {
-        const gameData = { ...body.gameData }
-        delete gameData.totalMoves
-        return { ...body, gameData }
-    }],
-])('rejects Ice Slide Daily claim: %s', async (_name, mutate) => {
-    // clone the valid body, mutate one semantic invariant, POST it,
-    // expect status 400 and no persistence call.
+    ['missing context', undefined, validDailyGameData],
+    ['unsolved', validDailyContext, { ...validDailyGameData, solved: false }],
+    ['game-data mode mismatch', validDailyContext, { ...validDailyGameData, mode: 'expedition' }],
+    ['context mode mismatch', { ...validDailyContext, mode: 'expedition' }, validDailyGameData],
+    ['malformed competition key', { ...validDailyContext, competitionKey: 'ice-slide:daily:2026-02-29:g1:r1' }, { ...validDailyGameData, runKey: 'ice-slide:daily:2026-02-29:g1:r1' }],
+    ['run-key mismatch', validDailyContext, { ...validDailyGameData, runKey: 'ice-slide:daily:2026-08-11:g1:r1' }],
+    ['generator mismatch', validDailyContext, { ...validDailyGameData, generatorVersion: 2 }],
+    ['game-data ruleset mismatch', validDailyContext, { ...validDailyGameData, rulesetVersion: 2 }],
+    ['context ruleset mismatch', { ...validDailyContext, rulesetVersion: 2 }, validDailyGameData],
+    ['negative elapsed', validDailyContext, { ...validDailyGameData, elapsedSeconds: -1 }],
+    ['negative moves', validDailyContext, { ...validDailyGameData, totalMoves: -1 }],
+])('rejects Daily admission: %s', (_name, context, gameData) => {
+    expect(iceSlideDailyAdmissionError(context, gameData)).not.toBeNull()
 })
 ```
 
-Also add an explicit case where `context.mode='daily'` and `gameData.mode='expedition'` so an Expedition payload cannot enter Daily ranking by context spoofing.
+Also cover missing `elapsedSeconds` and `totalMoves` by cloning/deleting those keys before calling the helper.
 
-- [ ] **Step 3: Run the API suite and confirm the invalid cases are currently green-to-save or otherwise fail expectations**
+Finally assert a non-Daily Ice Slide payload such as `{ mode: 'expedition' }` + `{ mode: 'expedition' }` returns `null`; HPA-488 must not accidentally implement Expedition admission.
+
+- [ ] **Step 2: Run the run suite and confirm red**
 
 ```bash
-bun run test:run src/pages/api/scores.test.ts
+bun run test:run src/lib/games/ice-slide/run.test.ts
 ```
 
-Expected: the new semantic-admission assertions FAIL because the route currently persists transport-valid Daily claims without comparing their identities.
+Expected: FAIL because `iceSlideDailyAdmissionError` does not exist.
 
-- [ ] **Step 4: Add a local semantic validator to `scores.ts`**
+- [ ] **Step 3: Implement the pure helper next to the parser**
 
-Keep it in the route file because HPA-488 has one caller:
+Use one local integer guard and the parser from Task 1:
 
 ```ts
 function isNonNegativeInteger(value: unknown): value is number {
     return typeof value === 'number' && Number.isInteger(value) && value >= 0
 }
 
-function validateIceSlideDailyClaim(
-    gameId: GameID,
-    context: ScoreSubmissionInput['context'],
-    gameData: ScoreSubmissionInput['gameData']
+export function iceSlideDailyAdmissionError(
+    context: {
+        mode: string
+        competitionKey?: string
+        rulesetVersion: number
+    } | undefined,
+    gameData: Record<string, unknown> | undefined
 ): string | null {
-    if (gameId !== GameID.ICE_SLIDE) {
-        return null
-    }
-
     const claimsDaily =
         context?.mode === 'daily' || gameData?.mode === 'daily'
     if (!claimsDaily) {
@@ -348,134 +383,190 @@ function validateIceSlideDailyClaim(
 }
 ```
 
-Import `ScoreSubmissionInput` and `parseIceSlideDailyRunKey`. After `getGameById()` succeeds and before building `PersistedScoreContext`:
+Do not import `ScoreSubmissionInput`, `GameID`, server modules, or auth into `run.ts`.
+
+- [ ] **Step 4: Add score-route red tests**
+
+In `scores.test.ts`, add an Ice Slide game fixture and a valid request using the same payload. Assert 200 and the existing persistence call shape.
+
+Add representative HTTP 400/no-persist cases for:
+
+1. `solved:false`;
+2. malformed but transport-safe `competitionKey='ice-slide:daily:2026-02-29:g1:r1'` with matching `gameData.runKey`;
+3. `context.mode='daily'` with `gameData.mode='expedition'`;
+4. `elapsedSeconds:-1` and `totalMoves:-1` — these are expected to be caught by generic Zod before domain admission, but still must return 400 and skip persistence.
+
+Keep or add one non-Ice-Slide contextual score regression proving a generic Tetris scoped submission is still accepted; the route must dispatch Daily semantics only for `GameID.ICE_SLIDE`.
+
+- [ ] **Step 5: Wire one route call before `PersistedScoreContext` construction**
+
+Import `iceSlideDailyAdmissionError`. After game resolution:
 
 ```ts
-const dailyAdmissionError = validateIceSlideDailyClaim(
-    validatedGameId,
-    context,
-    gameData
-)
-if (dailyAdmissionError) {
-    return badRequestResponse(dailyAdmissionError)
+if (validatedGameId === GameID.ICE_SLIDE) {
+    const dailyAdmissionError = iceSlideDailyAdmissionError(context, gameData)
+    if (dailyAdmissionError) {
+        return badRequestResponse(dailyAdmissionError)
+    }
 }
 ```
 
-Do not regenerate the Daily, recompute score, inspect stage rows, or introduce a new error-code branch.
+Do not add a route-local semantic closure, new error code, stage regeneration, score recomputation, or board inspection.
 
-- [ ] **Step 5: Run score API and score-service regressions**
+- [ ] **Step 6: Run score/domain regressions**
 
 ```bash
-bun run test:run src/pages/api/scores.test.ts src/lib/services/scoreService.test.ts
+bun run test:run \
+  src/lib/games/ice-slide/run.test.ts \
+  src/pages/api/scores.test.ts \
+  src/lib/services/scoreService.test.ts
 ```
 
-Expected: PASS. Existing non-Ice-Slide and Campaign score requests remain unchanged.
+Expected: PASS.
 
-- [ ] **Step 6: Commit**
+- [ ] **Step 7: Commit**
 
 ```bash
-git add src/pages/api/scores.ts src/pages/api/scores.test.ts
+git add src/lib/games/ice-slide/run.ts src/lib/games/ice-slide/run.test.ts \
+  src/pages/api/scores.ts src/pages/api/scores.test.ts
 git commit -m "feat(ice-slide): admit valid Daily scores only"
 ```
 
 ---
 
-### Task 3: Constrain Daily reads and add private viewer matching
+### Task 3: Require exact Daily reads and add privacy-safe viewer metadata
 
 **Files:**
-- Modify: `src/lib/server/db/scoped-leaderboard.ts`
-- Modify: `src/lib/server/db/scoped-leaderboard.integration.test.ts`
 - Modify: `src/pages/api/leaderboard.ts`
 - Modify: `src/pages/api/leaderboard.test.ts`
 
 **Interfaces:**
-- Extends:
+
+- `getScopedGameLeaderboard()` remains:
 
 ```ts
-export interface ScopedLeaderboardQuery {
-    gameId: string
-    mode: string
-    competitionKey?: string
-    rulesetVersion?: number
-    limit?: number
-}
-```
-
-- Scoped API rows gain `isCurrentUser: boolean`.
-- Scoped API response gains `viewerAuthenticated: boolean`.
-- Unscoped Campaign response shape remains unchanged.
-
-- [ ] **Step 1: Add a real-LibSQL exact-ruleset regression**
-
-Extend the integration seed helper if necessary to use `gameId: 'ice_slide'`, then insert two users under the same exact competition key with different stored ruleset versions. Query:
-
-```ts
-const result = await getScopedGameLeaderboard({
-    gameId: 'ice_slide',
-    mode: 'daily',
-    competitionKey: 'ice-slide:daily:2026-08-12:g1:r1',
-    rulesetVersion: 1,
-    limit: 10,
+getScopedGameLeaderboard({
+    gameId,
+    mode,
+    competitionKey,
+    limit,
 })
 ```
 
-Assert only the `ruleset_version=1` row is returned. Do not duplicate the existing score/elapsed/moves/created-at tie-break matrix; those HPA-484 tests remain authoritative.
+No `rulesetVersion` field is added.
 
-- [ ] **Step 2: Run the integration test and confirm red**
+- Every scoped API row gains `isCurrentUser: boolean`.
+- Every scoped API response gains `viewerAuthenticated: boolean`.
+- Unscoped Campaign response shape remains unchanged.
 
-```bash
-bun run test:run src/lib/server/db/scoped-leaderboard.integration.test.ts
-```
+- [ ] **Step 1: Update test mocks before adding new assertions**
 
-Expected: FAIL because the query contract does not accept/apply `rulesetVersion` yet.
-
-- [ ] **Step 3: Add the optional SQL ruleset predicate**
-
-In `scoped-leaderboard.ts`:
+In `leaderboard.test.ts`, extend the mocked `GameID` immediately:
 
 ```ts
-const rulesetFilter =
-    query.rulesetVersion === undefined
-        ? sql``
-        : sql`AND gs.ruleset_version = ${query.rulesetVersion}`
+GameID: {
+    TETRIS: 'tetris',
+    ICE_SLIDE: 'ice_slide',
+},
 ```
 
-Apply it in the `scoped` CTE beside the existing game/mode/competition predicates:
-
-```sql
-AND gs.ruleset_version IS NOT NULL
-${competitionFilter}
-${rulesetFilter}
-```
-
-When omitted, behavior must remain byte-for-byte equivalent to HPA-484's generic scoped query.
-
-- [ ] **Step 4: Add Ice Slide Daily API admission tests**
-
-Update the game mock to expose both `tetris` and `ice_slide`. Add tests that:
+Add the file-level auth mock, matching `scores.test.ts`:
 
 ```ts
-// Missing exact key is rejected only for Ice Slide Daily.
-GET /api/leaderboard?gameId=ice_slide&mode=daily -> 400
+vi.mock('@/lib/auth', () => ({
+    auth: {
+        api: {
+            getSession: vi.fn(),
+        },
+    },
+}))
+```
 
-// Invalid/calendar-invalid exact key is rejected.
-GET /api/leaderboard?gameId=ice_slide&mode=daily&competitionKey=ice-slide:daily:2026-02-29:g1:r1 -> 400
+Import `auth` for `vi.mocked(auth.api.getSession)` assertions.
 
-// Exact key forwards its parsed ruleset.
+Update `beforeEach()` so auth defaults to signed out:
+
+```ts
+vi.mocked(auth.api.getSession).mockResolvedValue(null)
+```
+
+Do this before writing Ice Slide assertions; otherwise importing real `auth.ts` requires secrets and the Tetris-only `GameID` mock makes the Daily branch unreachable.
+
+- [ ] **Step 2: Update the existing scoped Tetris response assertion for additive viewer fields**
+
+The current mode-only Tetris scoped request remains valid. Its response now intentionally contains:
+
+```ts
+expect(body.viewerAuthenticated).toBe(false)
+expect(body.leaderboard).toEqual([
+    {
+        rank: 1,
+        name: 'Player',
+        username: 'player',
+        image: null,
+        score: 500,
+        created_at: '2026-08-01T00:00:00.000Z',
+        mode: 'daily',
+        competitionKey: null,
+        rulesetVersion: 2,
+        elapsedSeconds: 12,
+        totalMoves: 34,
+        isCurrentUser: false,
+    },
+])
+```
+
+This is an additive scoped contract change. Do not weaken the unscoped shape assertions.
+
+- [ ] **Step 3: Add Ice Slide Daily read-admission tests**
+
+Mock an Ice Slide game entry and assert:
+
+```text
+GET /api/leaderboard?gameId=ice_slide&mode=daily
+=> 400, query not called
+```
+
+```text
+GET /api/leaderboard?gameId=ice_slide&mode=daily&competitionKey=ice-slide:daily:2026-02-29:g1:r1
+=> 400, query not called
+```
+
+For a valid key:
+
+```ts
 expect(getScopedGameLeaderboard).toHaveBeenCalledWith({
     gameId: 'ice_slide',
     mode: 'daily',
     competitionKey: 'ice-slide:daily:2026-08-12:g1:r1',
-    rulesetVersion: 1,
     limit: 10,
 })
-
-// Existing generic mode-only Tetris request remains legal and forwards no ruleset.
 ```
 
-- [ ] **Step 5: Add viewer-metadata tests before implementation**
+Retain the existing generic mode-only Tetris test and assert it still forwards:
 
-Mock `@/lib/auth`. For a scoped row with private `userId: 'u1'`:
+```ts
+{
+    gameId: 'tetris',
+    mode: 'daily',
+    competitionKey: undefined,
+    limit: 10,
+}
+```
+
+- [ ] **Step 4: Add authenticated, signed-out, and auth-failure viewer tests**
+
+The route signature will use `{ url, request }`, so new scoped tests pass a real request:
+
+```ts
+const url = new URL(
+    'http://localhost/api/leaderboard?gameId=ice_slide&mode=daily&competitionKey=ice-slide%3Adaily%3A2026-08-12%3Ag1%3Ar1'
+)
+const request = new Request(url)
+const response = await GET({ url, request } as never)
+```
+
+For a private row `userId:'u1'`, mock:
 
 ```ts
 vi.mocked(auth.api.getSession).mockResolvedValue({
@@ -484,32 +575,70 @@ vi.mocked(auth.api.getSession).mockResolvedValue({
 } as never)
 ```
 
-Call `GET` with a real `Request` and assert:
+Assert:
 
 ```ts
 expect(body.viewerAuthenticated).toBe(true)
 expect(body.leaderboard[0]).toMatchObject({
-    isCurrentUser: true,
     rank: 1,
+    isCurrentUser: true,
 })
 expect(body.leaderboard[0]).not.toHaveProperty('userId')
 ```
 
-Add signed-out (`getSession -> null`) and auth-lookup-rejection cases; both must still return the public leaderboard with `viewerAuthenticated:false` and `isCurrentUser:false`.
+Then cover:
 
-Also assert an unscoped `?gameId=ice_slide` response does **not** gain `viewerAuthenticated` or `isCurrentUser`.
+- `getSession -> null`: 200, `viewerAuthenticated:false`, all `isCurrentUser:false`;
+- `getSession` rejects: same public 200/false behavior;
+- `GET ?gameId=ice_slide` unscoped: no `viewerAuthenticated`, no `isCurrentUser`, and auth lookup is not required.
 
-- [ ] **Step 6: Run the API suite and confirm red**
+- [ ] **Step 5: Run the API suite and confirm red**
 
 ```bash
 bun run test:run src/pages/api/leaderboard.test.ts
 ```
 
-Expected: new Ice Slide admission and viewer metadata tests FAIL.
+Expected: the new exact-key and viewer-metadata assertions FAIL.
 
-- [ ] **Step 7: Implement the Ice Slide Daily branch and optional viewer lookup**
+- [ ] **Step 6: Implement exact Ice Slide Daily admission without changing the query contract**
 
-Import `GameID`, `parseIceSlideDailyRunKey`, and `auth`. Add a small best-effort helper:
+Change the route signature:
+
+```ts
+export const GET: APIRoute = async ({ url, request }) => {
+```
+
+Import `GameID`, `parseIceSlideDailyRunKey`, and `auth`.
+
+Before the scoped query:
+
+```ts
+if (gameId === GameID.ICE_SLIDE && mode === 'daily') {
+    if (!competitionKey) {
+        return badRequestResponse(
+            'competitionKey is required for Ice Slide Daily'
+        )
+    }
+    if (!parseIceSlideDailyRunKey(competitionKey)) {
+        return badRequestResponse('Invalid Ice Slide Daily competitionKey')
+    }
+}
+```
+
+Keep the existing call shape exactly:
+
+```ts
+const scoped = await getScopedGameLeaderboard({
+    gameId,
+    mode,
+    competitionKey,
+    limit,
+})
+```
+
+- [ ] **Step 7: Add best-effort viewer lookup only after a successful scoped query**
+
+Use a helper that tolerates older tests passing no `request`:
 
 ```ts
 async function getViewerUserId(
@@ -527,33 +656,7 @@ async function getViewerUserId(
 }
 ```
 
-In the scoped branch:
-
-```ts
-let rulesetVersion: number | undefined
-if (gameId === GameID.ICE_SLIDE && mode === 'daily') {
-    if (!competitionKey) {
-        return badRequestResponse(
-            'competitionKey is required for Ice Slide Daily'
-        )
-    }
-    const identity = parseIceSlideDailyRunKey(competitionKey)
-    if (!identity) {
-        return badRequestResponse('Invalid Ice Slide Daily competitionKey')
-    }
-    rulesetVersion = identity.rulesetVersion
-}
-
-const scoped = await getScopedGameLeaderboard({
-    gameId,
-    mode,
-    competitionKey,
-    rulesetVersion,
-    limit,
-})
-```
-
-After a successful query:
+After `scoped.success`:
 
 ```ts
 const viewerUserId = await getViewerUserId(request)
@@ -571,46 +674,86 @@ return jsonResponse({
 })
 ```
 
-Do not run session lookup for unscoped responses.
+Do not run auth lookup for unscoped responses and do not expose `userId`.
 
-- [ ] **Step 8: Run all scoped query/API regressions**
+- [ ] **Step 8: Run API plus unchanged DB-ranking regressions**
 
 ```bash
 bun run test:run \
-  src/lib/server/db/scoped-leaderboard.integration.test.ts \
   src/pages/api/leaderboard.test.ts \
+  src/lib/server/db/scoped-leaderboard.integration.test.ts \
   src/lib/server/validations.test.ts
 ```
 
-Expected: PASS, including existing generic Tetris mode-only behavior and unscoped response contracts.
+Expected: PASS. The DB file is included only to prove HPA-484's best-per-user/tie-break query remains unchanged and green.
 
 - [ ] **Step 9: Commit**
 
 ```bash
-git add src/lib/server/db/scoped-leaderboard.ts \
-  src/lib/server/db/scoped-leaderboard.integration.test.ts \
-  src/pages/api/leaderboard.ts src/pages/api/leaderboard.test.ts
+git add src/pages/api/leaderboard.ts src/pages/api/leaderboard.test.ts
 git commit -m "feat(ice-slide): scope Daily leaderboard reads"
 ```
 
 ---
 
-### Task 4: Refresh the page-local Daily leaderboard after successful saves
+### Task 4: Put Daily leaderboard async/render state in a unit-tested game module
 
 **Files:**
+- Create: `src/lib/games/ice-slide/daily-leaderboard.ts`
+- Create: `src/lib/games/ice-slide/daily-leaderboard.test.ts`
 - Modify: `src/lib/games/ice-slide/init.ts`
 - Modify: `src/lib/games/ice-slide/init.test.ts`
 - Modify: `src/pages/ice-slide/index.astro`
 - Modify: `src/pages/game-board-markup.test.ts`
 
 **Interfaces:**
-- Extends `IceSlideUICallbacks` with:
+
+`IceSlideUICallbacks` gains:
 
 ```ts
 onScoreSaved?: (gameData: IceSlideGameData) => void
 ```
 
-- Adds durable page IDs:
+The new module exports:
+
+```ts
+export interface DailyLeaderboardEntry {
+    rank: number
+    name: string
+    score: number
+    elapsedSeconds: number | null
+    totalMoves: number | null
+    isCurrentUser: boolean
+}
+
+export interface DailyLeaderboardResponse {
+    viewerAuthenticated: boolean
+    leaderboard: DailyLeaderboardEntry[]
+}
+
+export type DailyLeaderboardPanelState =
+    | 'loading'
+    | 'empty'
+    | 'unavailable'
+    | 'rows'
+
+export interface DailyLeaderboardElements {
+    panel: HTMLElement
+    date: HTMLElement
+    signedOut: HTMLElement
+    loading: HTMLElement
+    empty: HTMLElement
+    unavailable: HTMLElement
+    rows: HTMLElement
+}
+
+export interface DailyLeaderboardController {
+    load: (competitionKey: string) => Promise<void>
+    hide: () => void
+}
+```
+
+Durable page IDs:
 
 ```text
 daily-leaderboard
@@ -622,15 +765,15 @@ daily-leaderboard-unavailable
 daily-leaderboard-rows
 ```
 
-- [ ] **Step 1: Add `init.test.ts` callback-order/staleness tests**
+- [ ] **Step 1: Add `init.test.ts` score-saved callback red tests**
 
-Reuse the existing mocked `saveGameScore`. Add three focused assertions:
+Reuse the existing mocked `saveGameScore` and add:
 
-1. current successful Daily save calls `onScoreSaved` once with `game.getGameData()`;
-2. score error/`UNAUTHENTICATED` never calls `onScoreSaved`;
-3. if a new run invalidates the run guard before the old success callback fires, the stale callback never reaches `onScoreSaved`.
+1. current successful Daily save calls `onScoreSaved` once with the submitted `gameData`;
+2. `UNAUTHENTICATED`/other score error never calls it;
+3. if a newer run invalidates the run guard before the old success callback fires, the stale callback never reaches it.
 
-The success assertion should match at least:
+Match at least:
 
 ```ts
 expect(onScoreSaved).toHaveBeenCalledWith(
@@ -643,27 +786,182 @@ expect(onScoreSaved).toHaveBeenCalledWith(
 )
 ```
 
-- [ ] **Step 2: Run the focused init suite and confirm red**
+- [ ] **Step 2: Run `init.test.ts` and confirm red**
 
 ```bash
 bun run test:run src/lib/games/ice-slide/init.test.ts
 ```
 
-Expected: FAIL because `onScoreSaved` does not exist/fire.
+Expected: FAIL because the callback does not exist/fire.
 
-- [ ] **Step 3: Add the optional callback in `init.ts`**
+- [ ] **Step 3: Add `onScoreSaved` and remove Ice Slide's duplicate formatter**
 
-Import `IceSlideGameData` for the callback type. In the existing score success callback, after the stale guard and achievement dispatch:
+Import `IceSlideGameData` for the callback type and `formatTime` from `../shared/utils`. Delete the local `formatTime()` implementation from `init.ts`.
+
+In the existing score success callback, after the stale check and achievement dispatch:
 
 ```ts
 callbacks.onScoreSaved?.(gameData)
 ```
 
-Do not issue a leaderboard fetch from `init.ts`; network/display ownership stays on the Astro page.
+Do not fetch leaderboard data from `init.ts`.
 
-- [ ] **Step 4: Add the static Astro leaderboard card**
+- [ ] **Step 4: Write failing unit tests for `daily-leaderboard.ts`**
 
-Place it directly below `#daily-meta` so it follows the Daily brief without covering the Pixi board:
+Create a jsdom fixture with all seven elements. Tests must cover:
+
+```ts
+expect(
+    buildIceSlideDailyLeaderboardUrl(
+        'ice-slide:daily:2026-08-12:g1:r1'
+    )
+).toBe(
+    '/api/leaderboard?gameId=ice_slide&mode=daily&competitionKey=' +
+        'ice-slide%3Adaily%3A2026-08-12%3Ag1%3Ar1&limit=10'
+)
+
+expect(formatDailyLeaderboardElapsed(null)).toBe('—')
+expect(formatDailyLeaderboardElapsed(87)).toBe('1:27')
+```
+
+For row construction, assert a current-user row contains rank/name/formatted score/elapsed/moves plus literal `YOU`, and a non-current row does not contain `YOU`.
+
+For state toggling, assert exactly one of loading/empty/unavailable/rows is visible for each `DailyLeaderboardPanelState`.
+
+For the controller:
+
+- a successful empty signed-out response shows panel/date/signed-out + empty state;
+- a 503 shows unavailable without throwing;
+- a delayed response resolved after `hide()` does not append rows or unhide the panel;
+- a delayed older load resolved after a newer load cannot replace the newer date/rows.
+
+- [ ] **Step 5: Run the new module suite and confirm red**
+
+```bash
+bun run test:run src/lib/games/ice-slide/daily-leaderboard.test.ts
+```
+
+Expected: FAIL because the module does not exist.
+
+- [ ] **Step 6: Implement the focused helper module**
+
+Use `formatTime` from `../shared/utils`, `GameID.ICE_SLIDE`, and `parseIceSlideDailyRunKey`.
+
+URL builder:
+
+```ts
+export function buildIceSlideDailyLeaderboardUrl(
+    competitionKey: string
+): string {
+    return (
+        `/api/leaderboard?gameId=${GameID.ICE_SLIDE}&mode=daily&` +
+        `competitionKey=${encodeURIComponent(competitionKey)}&limit=10`
+    )
+}
+```
+
+Elapsed wrapper:
+
+```ts
+export function formatDailyLeaderboardElapsed(
+    seconds: number | null
+): string {
+    return seconds === null ? '—' : formatTime(seconds)
+}
+```
+
+State helper:
+
+```ts
+export function setDailyLeaderboardPanelState(
+    elements: DailyLeaderboardElements,
+    state: DailyLeaderboardPanelState
+): void {
+    elements.loading.classList.toggle('hidden', state !== 'loading')
+    elements.empty.classList.toggle('hidden', state !== 'empty')
+    elements.unavailable.classList.toggle('hidden', state !== 'unavailable')
+    elements.rows.classList.toggle('hidden', state !== 'rows')
+}
+```
+
+`createDailyLeaderboardRowElement()` must use `document.createElement`, `textContent`, and classes only; never `innerHTML`. Format scores with `toLocaleString()`. Render a literal `YOU` badge only for `isCurrentUser`.
+
+Implement `createDailyLeaderboardController(elements, fetcher = fetch)` as one closure with `let requestToken = 0`:
+
+```ts
+export function createDailyLeaderboardController(
+    elements: DailyLeaderboardElements,
+    fetcher: typeof fetch = fetch
+): DailyLeaderboardController {
+    let requestToken = 0
+
+    return {
+        async load(competitionKey) {
+            const identity = parseIceSlideDailyRunKey(competitionKey)
+            if (!identity) {
+                return
+            }
+
+            const token = ++requestToken
+            elements.panel.classList.remove('hidden')
+            elements.date.textContent = identity.dateKey
+            elements.signedOut.classList.add('hidden')
+            setDailyLeaderboardPanelState(elements, 'loading')
+
+            try {
+                const response = await fetcher(
+                    buildIceSlideDailyLeaderboardUrl(competitionKey)
+                )
+                if (token !== requestToken) {
+                    return
+                }
+                if (!response.ok) {
+                    setDailyLeaderboardPanelState(elements, 'unavailable')
+                    return
+                }
+
+                const data =
+                    (await response.json()) as DailyLeaderboardResponse
+                if (token !== requestToken) {
+                    return
+                }
+
+                while (elements.rows.firstChild) {
+                    elements.rows.removeChild(elements.rows.firstChild)
+                }
+                for (const entry of data.leaderboard) {
+                    elements.rows.appendChild(
+                        createDailyLeaderboardRowElement(entry, document)
+                    )
+                }
+                elements.signedOut.classList.toggle(
+                    'hidden',
+                    data.viewerAuthenticated
+                )
+                setDailyLeaderboardPanelState(
+                    elements,
+                    data.leaderboard.length > 0 ? 'rows' : 'empty'
+                )
+            } catch {
+                if (token === requestToken) {
+                    setDailyLeaderboardPanelState(elements, 'unavailable')
+                }
+            }
+        },
+
+        hide() {
+            requestToken += 1
+            elements.panel.classList.add('hidden')
+        },
+    }
+}
+```
+
+Do not add `AbortController`, a store, event bus, class hierarchy, or generic leaderboard abstraction.
+
+- [ ] **Step 7: Add the static Astro card and structural markup assertions**
+
+Place below `#daily-meta`:
 
 ```astro
 <Card id="daily-leaderboard" variant="glass" class="hidden p-4">
@@ -676,153 +974,156 @@ Place it directly below `#daily-meta` so it follows the Daily brief without cove
   <p id="daily-leaderboard-signed-out" class="hidden mt-2 text-xs text-cetus-ink-muted">
     Sign in to submit a ranked result. You can still view today's ranking.
   </p>
-  <p id="daily-leaderboard-loading" class="mt-3 text-sm text-cetus-ink-muted">Loading ranking…</p>
-  <p id="daily-leaderboard-empty" class="hidden mt-3 text-sm text-cetus-ink-muted">No ranked finishes yet.</p>
-  <p id="daily-leaderboard-unavailable" class="hidden mt-3 text-sm text-cetus-ink-muted">Ranking is temporarily unavailable.</p>
+  <p id="daily-leaderboard-loading" class="mt-3 text-sm text-cetus-ink-muted">
+    Loading ranking…
+  </p>
+  <p id="daily-leaderboard-empty" class="hidden mt-3 text-sm text-cetus-ink-muted">
+    No ranked finishes yet.
+  </p>
+  <p id="daily-leaderboard-unavailable" class="hidden mt-3 text-sm text-cetus-ink-muted">
+    Ranking is temporarily unavailable.
+  </p>
   <div id="daily-leaderboard-rows" class="hidden mt-3 space-y-2"></div>
 </Card>
 ```
 
-Add all seven IDs to `src/pages/game-board-markup.test.ts`; keep the test structural and do not assert client source text.
+Add all seven IDs to `src/pages/game-board-markup.test.ts`. Keep that test structural; behavior belongs in `daily-leaderboard.test.ts` and Playwright.
 
-- [ ] **Step 5: Add page-local response types and formatting helpers**
+- [ ] **Step 8: Make the Astro script wiring-only**
 
-Inside the existing client script:
-
-```ts
-type DailyLeaderboardEntry = {
-  rank: number
-  name: string
-  score: number
-  elapsedSeconds: number | null
-  totalMoves: number | null
-  isCurrentUser: boolean
-}
-
-type DailyLeaderboardResponse = {
-  viewerAuthenticated: boolean
-  leaderboard: DailyLeaderboardEntry[]
-}
-
-const formatElapsed = (seconds: number | null) => {
-  if (seconds === null) return '—'
-  const minutes = Math.floor(seconds / 60)
-  const remainder = seconds % 60
-  return `${minutes}:${remainder.toString().padStart(2, '0')}`
-}
-```
-
-Query all seven static elements during `init()` and include them in the existing required-element guard.
-
-- [ ] **Step 6: Implement token-based load/render logic without `innerHTML`**
-
-Maintain exactly one page-local counter:
+Import:
 
 ```ts
-let leaderboardRequestToken = 0
+import {
+  createDailyLeaderboardController,
+  type DailyLeaderboardElements,
+} from '@/lib/games/ice-slide/daily-leaderboard'
+import {
+  createIceSlideDailyCompetitionKey,
+  toIceSlideUtcDateKey,
+} from '@/lib/games/ice-slide/daily'
 ```
 
-A load increments/captures it and uses the exact key:
-
-```ts
-const loadDailyLeaderboard = async (competitionKey: string) => {
-  const token = ++leaderboardRequestToken
-  const identity = parseIceSlideDailyRunKey(competitionKey)
-  if (!identity) return
-
-  dailyLeaderboard.classList.remove('hidden')
-  dailyLeaderboardDate.textContent = identity.dateKey
-  setLeaderboardState('loading')
-
-  try {
-    const response = await fetch(
-      `/api/leaderboard?gameId=ice_slide&mode=daily&competitionKey=${encodeURIComponent(competitionKey)}&limit=10`
-    )
-    if (token !== leaderboardRequestToken) return
-    if (!response.ok) {
-      setLeaderboardState('unavailable')
-      return
-    }
-
-    const data = (await response.json()) as DailyLeaderboardResponse
-    if (token !== leaderboardRequestToken) return
-    renderLeaderboardRows(data.leaderboard)
-    dailyLeaderboardSignedOut.classList.toggle(
-      'hidden',
-      data.viewerAuthenticated
-    )
-    setLeaderboardState(data.leaderboard.length ? 'rows' : 'empty')
-  } catch {
-    if (token === leaderboardRequestToken) {
-      setLeaderboardState('unavailable')
-    }
-  }
-}
-```
-
-`renderLeaderboardRows()` must clear children with `while (firstChild) removeChild(firstChild)` and construct each row with `document.createElement`, `textContent`, and classes. For `entry.isCurrentUser`, render a literal `YOU` badge plus a stronger border/background class; otherwise render no badge.
-
-`setLeaderboardState()` toggles only the four state containers (`loading`, `empty`, `unavailable`, `rows`). It must not hide the game board, Daily result overlay, or error surface.
-
-- [ ] **Step 7: Wire selection, captured run identity, success refresh, and invalidation**
-
-Import `createIceSlideDailyCompetitionKey`, `toIceSlideUtcDateKey`, and `parseIceSlideDailyRunKey` into the page script.
-
-Use these exact transitions:
+Query the seven elements, build `DailyLeaderboardElements`, and instantiate one controller. Keep page helpers limited to identity handoff:
 
 ```ts
 const currentUtcDailyKey = () =>
   createIceSlideDailyCompetitionKey(toIceSlideUtcDateKey(new Date()))
 
-const invalidateLeaderboard = () => {
-  leaderboardRequestToken += 1
-  dailyLeaderboard.classList.add('hidden')
+const loadCurrentDailyLeaderboard = () =>
+  dailyLeaderboardController.load(currentUtcDailyKey())
+
+const loadCapturedDailyLeaderboard = () => {
+  const state = gameHandle?.getGame()?.getState()
+  if (state?.mode === 'daily') {
+    void dailyLeaderboardController.load(state.runKey)
+  }
 }
 ```
 
-- after `initializeIceSlide()` resolves, load `currentUtcDailyKey()` only when the selected radio is Daily;
-- on a radio change to Daily while idle, load the current UTC key;
-- on a radio change to Campaign, call `invalidateLeaderboard()`;
-- after `await gameHandle.start('daily')`, read `gameHandle.getGame()?.getState().runKey` and load that captured key;
-- after `await gameHandle.playAgain()` in Daily, reload the returned state's same captured key;
-- implement `onScoreSaved(gameData)` and call `loadDailyLeaderboard(gameData.runKey)` only for `gameData.mode === 'daily'`;
-- Change Mode returns to idle controls, then shows/loads the leaderboard only if the still-selected radio is Daily; choosing Campaign hides it;
-- `cleanup()`/page unload naturally invalidates by leaving the page; no global listener/store is added.
+Wire exact transitions:
 
-This guarantees a run started before rollover refreshes its original competition instead of today's newly computed key.
+- after initialization, if selected radio is Daily, load today's key;
+- idle radio change to Daily -> load today's key;
+- idle radio change to Campaign -> `hide()`;
+- after successful `await gameHandle.start('daily')` -> load captured `state.runKey`;
+- after successful Daily `playAgain()` -> load captured `state.runKey`;
+- `onScoreSaved(gameData)` -> if `gameData.mode === 'daily'`, load `gameData.runKey`;
+- Change Mode -> return to idle controls; if selected radio is Daily load today's current key, otherwise hide;
+- leaderboard errors remain inside the controller and never touch `#game-error`/`failRun`.
 
-- [ ] **Step 8: Run focused DOM/init regressions**
+This keeps rollover behavior correct: in-progress/post-save refresh uses captured identity; idle selection uses the current UTC identity.
+
+- [ ] **Step 9: Run focused DOM/client/init suites**
 
 ```bash
 bun run test:run \
   src/lib/games/ice-slide/init.test.ts \
+  src/lib/games/ice-slide/daily-leaderboard.test.ts \
   src/pages/game-board-markup.test.ts
 ```
 
-Expected: PASS.
+Expected: PASS, including stale-response tests before browser coverage runs.
 
-- [ ] **Step 9: Commit**
+- [ ] **Step 10: Commit**
 
 ```bash
 git add src/lib/games/ice-slide/init.ts src/lib/games/ice-slide/init.test.ts \
+  src/lib/games/ice-slide/daily-leaderboard.ts \
+  src/lib/games/ice-slide/daily-leaderboard.test.ts \
   src/pages/ice-slide/index.astro src/pages/game-board-markup.test.ts
 git commit -m "feat(ice-slide): show Daily leaderboard"
 ```
 
 ---
 
-### Task 5: Lock browser flows and run the repository gates
+### Task 5: Lock the frozen Daily playthrough before using it in Playwright
 
 **Files:**
+- Modify: `src/lib/games/ice-slide/daily.test.ts`
 - Modify: `e2e/games/play-coverage.spec.ts`
 
 **Interfaces:**
 - Consumes the exact HPA-487 generator-v1 fixture for `2026-08-12`.
 - No production interface changes.
 
-- [ ] **Step 1: Add a helper that completes the frozen `2026-08-12` Daily**
+- [ ] **Step 1: Add a unit replay for the exact five browser sequences**
 
-The existing generator-v1 fixture has five minimum solutions. Keep this helper in the Ice Slide Playwright section so a generator-version bump forces a deliberate test update:
+In `daily.test.ts`, import `IceSlideGame` and `Direction`. Lock the exact directions:
+
+```ts
+const DAILY_2026_08_12_DIRECTIONS: readonly (readonly Direction[])[] = [
+    ['S', 'E', 'S'],
+    ['N', 'W', 'N', 'W'],
+    ['W', 'N', 'E', 'S', 'W', 'N'],
+    ['S', 'W', 'N', 'E', 'S', 'W'],
+    ['E', 'S', 'W', 'N', 'E', 'S'],
+]
+```
+
+Replay them through the real game/runtime contract:
+
+```ts
+it('locks the 2026-08-12 browser playthrough against the materialized Daily', () => {
+    const run = createIceSlideDailyRunDefinition('2026-08-12')
+    const game = new IceSlideGame()
+
+    try {
+        game.start(run)
+        for (const [stageIndex, directions] of
+            DAILY_2026_08_12_DIRECTIONS.entries()) {
+            expect(directions).toHaveLength(run.stages[stageIndex].parMoves)
+            for (const direction of directions) {
+                game.move(direction)
+            }
+        }
+
+        expect(game.getState().status).toBe('won')
+        expect(game.getGameData()).toMatchObject({
+            mode: 'daily',
+            runKey: 'ice-slide:daily:2026-08-12:g1:r1',
+            solved: true,
+            levelsCleared: 5,
+        })
+    } finally {
+        game.destroy()
+    }
+})
+```
+
+Stages 3 and 4 have `collect_all_crystals` as an optional bonus. The test requires a completed run, not all optional stars; this directly validates the same crystal-mutating runtime that Playwright will drive.
+
+- [ ] **Step 2: Run the unit fixture before adding browser dependence**
+
+```bash
+bun run test:run src/lib/games/ice-slide/daily.test.ts
+```
+
+Expected: PASS. If any sequence is wrong, correct it here first; do not discover the mistake for the first time in Playwright.
+
+- [ ] **Step 3: Add the matching Playwright helper**
+
+Use the exact arrow-key translation of the unit fixture:
 
 ```ts
 const DAILY_2026_08_12_SOLUTIONS = [
@@ -847,11 +1148,11 @@ async function completeFrozenDaily(page: Page): Promise<void> {
 }
 ```
 
-- [ ] **Step 2: Cover signed-out + empty and required row rendering with mocked leaderboard responses**
+- [ ] **Step 4: Cover signed-out/empty and ranked-current-user rendering**
 
-Use `page.clock.setFixedTime(new Date('2026-08-12T20:00:00Z'))` and `page.route('**/api/leaderboard?*', ...)`.
+With fixed time `2026-08-12T20:00:00Z`, intercept `**/api/leaderboard?*`.
 
-First return:
+Empty signed-out response:
 
 ```json
 {
@@ -862,12 +1163,14 @@ First return:
 }
 ```
 
-Assert the request contains the exact key `ice-slide:daily:2026-08-12:g1:r1`, the empty state is visible, and the signed-out copy is visible.
+Assert the request contains exact competition key `ice-slide:daily:2026-08-12:g1:r1`, the empty state is visible, and the sign-in note is visible.
 
-In a second test return one row:
+Current-user row response:
 
 ```json
 {
+  "gameId": "ice_slide",
+  "gameName": "Ice Slide",
   "viewerAuthenticated": true,
   "leaderboard": [{
     "rank": 1,
@@ -880,30 +1183,41 @@ In a second test return one row:
 }
 ```
 
-Assert `#daily-leaderboard-rows` shows rank `1`, `Pilot`, `4,321`, `1:27`, `31`, and visible `YOU` text.
+Assert rows show `1`, `Pilot`, `4,321`, `1:27`, `31`, and visible `YOU` text.
 
-- [ ] **Step 3: Cover unavailable-with-playability**
+- [ ] **Step 5: Cover unavailable ranking without blocking play**
 
-Fulfill the leaderboard route with status 503 and the normal coded error body. Assert `#daily-leaderboard-unavailable` becomes visible, then start Daily and verify the Pixi canvas plus `#end-btn` are still usable. Do not expect the generic `#game-error` surface for a leaderboard-only failure.
+Return status 503 with the normal scoped-unavailable body. Assert `#daily-leaderboard-unavailable` is visible, then start Daily and verify the Pixi canvas and `#end-btn` remain usable. `#game-error` must stay hidden for a leaderboard-only failure.
 
-- [ ] **Step 4: Cover successful-submit refresh on the captured key**
+- [ ] **Step 6: Cover successful-submit refresh on the captured key**
 
-Mock `/api/scores` with a 200 success body and count leaderboard requests. Start fixed-date Daily, capture the current leaderboard request count, call `completeFrozenDaily(page)`, then:
+Mock `/api/scores` with a 200 success body and count leaderboard requests. Start the fixed-date Daily, record the request count, call `completeFrozenDaily(page)`, then assert a later request occurs and its `competitionKey` remains:
 
-```ts
-await expect.poll(() => leaderboardRequestCount).toBeGreaterThan(beforeCompletion)
-expect(lastCompetitionKey).toBe(
-    'ice-slide:daily:2026-08-12:g1:r1'
-)
+```text
+ice-slide:daily:2026-08-12:g1:r1
 ```
 
-The POST body should also be inspected once to prove the completed submission carries `context.mode='daily'`, the same competition key, and `gameData.solved=true`.
+Inspect the POST once and assert:
 
-- [ ] **Step 5: Cover stale leaderboard suppression**
+```ts
+context.mode === 'daily'
+context.competitionKey === 'ice-slide:daily:2026-08-12:g1:r1'
+gameData.solved === true
+```
 
-Delay one Daily leaderboard response with a promise. While it is pending, switch the idle mode selection to Campaign. Release the old response and assert `#daily-leaderboard` remains hidden and the delayed row text never appears. This is the browser proof for the request-token guard; do not add `AbortController` only for the test.
+This proves `onScoreSaved` refreshes the captured competition rather than recomputing today's identity.
 
-- [ ] **Step 6: Run focused Ice Slide browser coverage**
+- [ ] **Step 7: Keep one browser integration proof for stale suppression**
+
+Delay one Daily leaderboard response. While pending, switch the idle mode selection to Campaign. Release the old response and assert:
+
+- `#daily-leaderboard` remains hidden;
+- delayed row text never appears;
+- Campaign remains selectable/startable.
+
+The detailed request-token semantics are already red/green in `daily-leaderboard.test.ts`; this test proves page wiring invokes invalidation correctly.
+
+- [ ] **Step 8: Run focused Ice Slide browser coverage**
 
 ```bash
 bun run test:e2e -- e2e/games/play-coverage.spec.ts --grep "Ice Slide"
@@ -911,13 +1225,14 @@ bun run test:e2e -- e2e/games/play-coverage.spec.ts --grep "Ice Slide"
 
 Expected: all existing HPA-487 cases plus the new leaderboard cases PASS.
 
-- [ ] **Step 7: Run focused unit/integration suites once more**
+- [ ] **Step 9: Run focused unit/API/integration suites once more**
 
 ```bash
 bun run test:run \
   src/lib/games/ice-slide/run.test.ts \
   src/lib/games/ice-slide/daily.test.ts \
   src/lib/games/ice-slide/init.test.ts \
+  src/lib/games/ice-slide/daily-leaderboard.test.ts \
   src/lib/server/db/scoped-leaderboard.integration.test.ts \
   src/pages/api/scores.test.ts \
   src/pages/api/leaderboard.test.ts \
@@ -926,7 +1241,7 @@ bun run test:run \
 
 Expected: PASS.
 
-- [ ] **Step 8: Run full repository verification**
+- [ ] **Step 10: Run full repository verification**
 
 ```bash
 bun run test:run
@@ -938,13 +1253,15 @@ bun run test:coverage
 ```
 
 Expected:
-- tests/typecheck/lint/format/build exit 0;
-- local coverage does not regress the repository below the configured 95% project target; remote Codecov project and patch checks remain authoritative after push.
 
-- [ ] **Step 9: Commit the E2E coverage**
+- tests/typecheck/lint/format/build exit 0;
+- local coverage does not regress the repository below the configured 95% project target;
+- remote Codecov project and patch checks remain authoritative after push.
+
+- [ ] **Step 11: Commit the deterministic fixture and E2E coverage**
 
 ```bash
-git add e2e/games/play-coverage.spec.ts
+git add src/lib/games/ice-slide/daily.test.ts e2e/games/play-coverage.spec.ts
 git commit -m "test(ice-slide): cover Daily leaderboard flows"
 ```
 
@@ -952,7 +1269,10 @@ git commit -m "test(ice-slide): cover Daily leaderboard flows"
 
 ## Plan self-review
 
-- **Spec coverage:** Daily admission, exact competition/ruleset isolation, best-per-user reuse, viewer highlighting, signed-out/loading/empty/unavailable states, successful-save refresh, stale suppression, Campaign compatibility, and failure isolation each map to a concrete task above.
+- **Spec coverage:** Daily identity/admission, exact-key read isolation, unchanged best-per-user ranking, viewer highlighting, signed-out/loading/empty/unavailable states, successful-save refresh, stale suppression, Campaign compatibility, and failure isolation each map to a concrete task.
+- **Parser consistency:** `assertValidIceSlideRunDefinition`, `init.ts`, score admission, leaderboard admission, and client identity display all consume `parseIceSlideDailyRunKey`; `extractDailyDateKey` is removed.
+- **Query consistency:** no `ScopedLeaderboardQuery.rulesetVersion` field or duplicate ruleset filter is introduced; exact competition key is the Daily scope.
+- **Test seams:** score semantics live in a pure helper; async page behavior lives in `daily-leaderboard.ts`; the frozen browser keypresses are validated by a unit replay before Playwright.
+- **Existing-test compatibility:** the plan explicitly mocks `@/lib/auth`, adds `GameID.ICE_SLIDE`, threads `request`, and updates the existing scoped Tetris response for additive viewer fields.
 - **Placeholder scan:** no TBD/TODO/future implementation step remains.
-- **Type consistency:** `parseIceSlideDailyRunKey`, `createIceSlideDailyCompetitionKey`, `ScopedLeaderboardQuery.rulesetVersion`, `viewerAuthenticated`, `isCurrentUser`, and `onScoreSaved(IceSlideGameData)` use one spelling/signature throughout.
-- **Scope check:** no schema, endpoint family, shared UI abstraction, replay verifier, historical browser, Expedition ranking, or current-user rank query has entered the plan.
+- **Scope check:** no schema, endpoint family, shared UI abstraction, replay verifier, historical browser, Expedition ranking, read repair, or current-user rank query has entered the plan.

--- a/docs/superpowers/plans/2026-08-13-ice-slide-daily-leaderboard.md
+++ b/docs/superpowers/plans/2026-08-13-ice-slide-daily-leaderboard.md
@@ -1,0 +1,958 @@
+# Ice Slide Daily Leaderboard Implementation Plan
+
+> **For agentic workers:** REQUIRED SUB-SKILL: Use superpowers:subagent-driven-development (recommended) or superpowers:executing-plans to implement this plan task-by-task. Steps use checkbox (`- [ ]`) syntax for tracking.
+
+**Goal:** Admit only valid completed Ice Slide Daily scores, rank one best result per player for the exact Daily competition, and show/refetch that ranking on the Ice Slide page without changing Campaign behavior.
+
+**Architecture:** Reuse HPA-484's existing score-context persistence and `getScopedGameLeaderboard()` window query. Ice Slide-specific semantic admission stays at the existing score/leaderboard API boundary; the Ice Slide page owns one static Astro leaderboard card and a small request-token loader, while `init.ts` only reports a successful score save through an additive callback.
+
+**Tech Stack:** Astro 5, TypeScript, Tailwind CSS 4, Better Auth, Kysely + LibSQL/Turso, Vitest, Playwright, Bun 1.3.1.
+
+## Global Constraints
+
+- Keep `/api/leaderboard?gameId=ice_slide` on the existing unscoped Campaign response path.
+- Daily competition keys remain `ice-slide:daily:YYYY-MM-DD:g<generatorVersion>:r<rulesetVersion>` and use UTC dates.
+- Daily ranking order remains score DESC, elapsed seconds ASC, total moves ASC, submission time ASC; row ID is only the existing final deterministic fallback for exact ties.
+- Repeated attempts remain stored; only the existing best-per-user query chooses the displayed row.
+- Do not add database schema, a new endpoint, a best-score cache/table, a generic mode registry, a shared leaderboard component, or an auth preflight request.
+- Do not add replay verification, score recomputation, historical Daily navigation, Expedition ranking, or current-user rank lookup beyond returned rows.
+- Astro owns durable HTML; client TypeScript may only update/toggle existing structure and create leaderboard row children without `innerHTML`.
+- Leaderboard or viewer-auth lookup failure must never enter the Ice Slide `failRun` path or invalidate a local result.
+- Preserve HPA-487's captured Daily run identity across UTC rollover and Play Again.
+- Keep existing remote Codecov project/patch coverage requirements at 95%.
+
+---
+
+## File map
+
+No new production module is needed.
+
+- `src/lib/games/ice-slide/run.ts` — parse the already-frozen Daily run-key identity.
+- `src/lib/games/ice-slide/daily.ts` — centralize construction of the already-frozen Daily competition key.
+- `src/pages/api/scores.ts` — reject invalid Ice Slide Daily claims before persistence.
+- `src/lib/server/db/scoped-leaderboard.ts` — optionally constrain an existing scoped query to one ruleset version.
+- `src/pages/api/leaderboard.ts` — require exact Ice Slide Daily identity and add viewer metadata only to scoped responses.
+- `src/lib/games/ice-slide/init.ts` — report a successful, non-stale score save to the page.
+- `src/pages/ice-slide/index.astro` — static Daily leaderboard card plus page-local fetch/render/staleness logic.
+- Existing colocated tests and `e2e/games/play-coverage.spec.ts` — contract and browser coverage.
+
+---
+
+### Task 1: Freeze one Daily competition-identity seam
+
+**Files:**
+- Modify: `src/lib/games/ice-slide/run.ts`
+- Modify: `src/lib/games/ice-slide/run.test.ts`
+- Modify: `src/lib/games/ice-slide/daily.ts`
+- Modify: `src/lib/games/ice-slide/daily.test.ts`
+
+**Interfaces:**
+- Produces:
+
+```ts
+export interface IceSlideDailyRunIdentity {
+    dateKey: string
+    generatorVersion: number
+    rulesetVersion: number
+}
+
+export function parseIceSlideDailyRunKey(
+    runKey: string
+): IceSlideDailyRunIdentity | null
+
+export function createIceSlideDailyCompetitionKey(dateKey: string): string
+```
+
+- `createIceSlideDailyRunDefinition(dateKey)` must continue producing byte-equivalent generator-v1 run keys and seeds.
+
+- [ ] **Step 1: Write failing parser tests in `run.test.ts`**
+
+Add the parser import and lock valid identity plus malformed/calendar-invalid keys:
+
+```ts
+it('parses an exact Daily competition identity', () => {
+    expect(
+        parseIceSlideDailyRunKey('ice-slide:daily:2026-08-12:g3:r2')
+    ).toEqual({
+        dateKey: '2026-08-12',
+        generatorVersion: 3,
+        rulesetVersion: 2,
+    })
+})
+
+it.each([
+    'ice-slide:daily:2026-02-29:g1:r1',
+    'ice-slide:daily:2026-08-12:g0:r1',
+    'ice-slide:daily:2026-08-12:g1:r0',
+    'ice-slide:daily:2026-08-12:g1',
+    'daily:2026-08-12:g1:r1',
+])('rejects invalid Daily competition key %s', runKey => {
+    expect(parseIceSlideDailyRunKey(runKey)).toBeNull()
+})
+```
+
+- [ ] **Step 2: Run the focused run tests and confirm red**
+
+Run:
+
+```bash
+bun run test:run src/lib/games/ice-slide/run.test.ts
+```
+
+Expected: FAIL because `parseIceSlideDailyRunKey` is not exported.
+
+- [ ] **Step 3: Implement the parser and reuse it in Daily run validation**
+
+In `run.ts`, keep `DAILY_KEY_PATTERN` as the single syntax regex and add:
+
+```ts
+export interface IceSlideDailyRunIdentity {
+    dateKey: string
+    generatorVersion: number
+    rulesetVersion: number
+}
+
+export function parseIceSlideDailyRunKey(
+    runKey: string
+): IceSlideDailyRunIdentity | null {
+    const match = DAILY_KEY_PATTERN.exec(runKey)
+    if (!match) {
+        return null
+    }
+
+    try {
+        assertValidIceSlideUtcDateKey(match[1])
+    } catch {
+        return null
+    }
+
+    return {
+        dateKey: match[1],
+        generatorVersion: Number(match[2]),
+        rulesetVersion: Number(match[3]),
+    }
+}
+```
+
+Replace the Daily branch's independent numeric extraction with the parsed identity:
+
+```ts
+const identity = parseIceSlideDailyRunKey(run.runKey)
+if (!identity) {
+    throw new RangeError('daily runKey must match the daily key format')
+}
+if (run.generatorVersion !== identity.generatorVersion) {
+    throw new RangeError('daily generatorVersion must match the runKey')
+}
+if (run.rulesetVersion !== identity.rulesetVersion) {
+    throw new RangeError('daily rulesetVersion must match the runKey')
+}
+const expectedSeed =
+    `ice-slide:daily:${identity.generatorVersion}:` +
+    `${identity.rulesetVersion}:${identity.dateKey}`
+```
+
+- [ ] **Step 4: Add the competition-key helper test in `daily.test.ts`**
+
+```ts
+it('builds the frozen generator-v1 Daily competition key', () => {
+    expect(createIceSlideDailyCompetitionKey('2026-08-12')).toBe(
+        'ice-slide:daily:2026-08-12:g1:r1'
+    )
+})
+```
+
+The existing generator-v1 fixture must remain unchanged.
+
+- [ ] **Step 5: Implement `createIceSlideDailyCompetitionKey()` and use it in the run materializer**
+
+In `daily.ts`:
+
+```ts
+export function createIceSlideDailyCompetitionKey(dateKey: string): string {
+    assertValidIceSlideUtcDateKey(dateKey)
+    return (
+        `ice-slide:daily:${dateKey}:` +
+        `g${ICE_SLIDE_DAILY_GENERATOR_VERSION}:r${ICE_SLIDE_RULESET_VERSION}`
+    )
+}
+```
+
+Then replace only the `runKey` literal construction:
+
+```ts
+runKey: createIceSlideDailyCompetitionKey(dateKey),
+```
+
+Do not change the Daily seed, fork labels, stage pools, transform/objective selection, or version constants.
+
+- [ ] **Step 6: Run both focused suites**
+
+```bash
+bun run test:run src/lib/games/ice-slide/run.test.ts src/lib/games/ice-slide/daily.test.ts
+```
+
+Expected: PASS, including the existing literal `2026-08-12` generator-v1 fixture.
+
+- [ ] **Step 7: Commit**
+
+```bash
+git add src/lib/games/ice-slide/run.ts src/lib/games/ice-slide/run.test.ts \
+  src/lib/games/ice-slide/daily.ts src/lib/games/ice-slide/daily.test.ts
+git commit -m "refactor(ice-slide): centralize Daily competition identity"
+```
+
+---
+
+### Task 2: Reject invalid Ice Slide Daily score claims before persistence
+
+**Files:**
+- Modify: `src/pages/api/scores.ts`
+- Modify: `src/pages/api/scores.test.ts`
+
+**Interfaces:**
+- Consumes: `parseIceSlideDailyRunKey()` from Task 1 and the existing `ScoreSubmissionInput` shape.
+- Produces: no new endpoint or public error code; invalid semantic Daily claims return the existing HTTP 400 bad-request response and never call `saveGameScoreWithAchievements()`.
+
+- [ ] **Step 1: Add one valid Daily admission fixture to `scores.test.ts`**
+
+Use the real `GameID.ICE_SLIDE` and a game fixture whose ID is `ice_slide`. The accepted request body is:
+
+```ts
+const dailyGameData = {
+    levelsCleared: 5,
+    totalMoves: 31,
+    crystalsCollected: 2,
+    elapsedSeconds: 87,
+    solved: true,
+    perfectLevels: 3,
+    mode: 'daily',
+    runKey: 'ice-slide:daily:2026-08-12:g1:r1',
+    runSchemaVersion: 1,
+    generatorVersion: 1,
+    rulesetVersion: 1,
+    stagesTotal: 5,
+    starsEarned: 13,
+    falls: 0,
+    resets: 0,
+    stageSignatures: ['a', 'b', 'c', 'd', 'e'],
+}
+
+const body = {
+    gameId: 'ice_slide',
+    score: 4321,
+    gameData: dailyGameData,
+    context: {
+        mode: 'daily',
+        competitionKey: dailyGameData.runKey,
+        rulesetVersion: 1,
+    },
+}
+```
+
+Assert 200 and that persistence receives exactly that game data plus:
+
+```ts
+{
+    mode: 'daily',
+    competitionKey: 'ice-slide:daily:2026-08-12:g1:r1',
+    rulesetVersion: 1,
+    gameDataJson: JSON.stringify(dailyGameData),
+}
+```
+
+- [ ] **Step 2: Add a table of invalid Daily claims**
+
+Each case must return 400 and leave `saveGameScoreWithAchievements` uncalled:
+
+```ts
+it.each([
+    ['missing context', body => ({ ...body, context: undefined })],
+    ['unsolved', body => ({ ...body, gameData: { ...body.gameData, solved: false } })],
+    ['game-data mode mismatch', body => ({ ...body, gameData: { ...body.gameData, mode: 'expedition' } })],
+    ['context mode mismatch', body => ({ ...body, context: { ...body.context, mode: 'expedition' } })],
+    ['run-key mismatch', body => ({ ...body, gameData: { ...body.gameData, runKey: 'ice-slide:daily:2026-08-11:g1:r1' } })],
+    ['generator mismatch', body => ({ ...body, gameData: { ...body.gameData, generatorVersion: 2 } })],
+    ['game-data ruleset mismatch', body => ({ ...body, gameData: { ...body.gameData, rulesetVersion: 2 } })],
+    ['context ruleset mismatch', body => ({ ...body, context: { ...body.context, rulesetVersion: 2 } })],
+    ['missing elapsed metric', body => {
+        const gameData = { ...body.gameData }
+        delete gameData.elapsedSeconds
+        return { ...body, gameData }
+    }],
+    ['missing move metric', body => {
+        const gameData = { ...body.gameData }
+        delete gameData.totalMoves
+        return { ...body, gameData }
+    }],
+])('rejects Ice Slide Daily claim: %s', async (_name, mutate) => {
+    // clone the valid body, mutate one semantic invariant, POST it,
+    // expect status 400 and no persistence call.
+})
+```
+
+Also add an explicit case where `context.mode='daily'` and `gameData.mode='expedition'` so an Expedition payload cannot enter Daily ranking by context spoofing.
+
+- [ ] **Step 3: Run the API suite and confirm the invalid cases are currently green-to-save or otherwise fail expectations**
+
+```bash
+bun run test:run src/pages/api/scores.test.ts
+```
+
+Expected: the new semantic-admission assertions FAIL because the route currently persists transport-valid Daily claims without comparing their identities.
+
+- [ ] **Step 4: Add a local semantic validator to `scores.ts`**
+
+Keep it in the route file because HPA-488 has one caller:
+
+```ts
+function isNonNegativeInteger(value: unknown): value is number {
+    return typeof value === 'number' && Number.isInteger(value) && value >= 0
+}
+
+function validateIceSlideDailyClaim(
+    gameId: GameID,
+    context: ScoreSubmissionInput['context'],
+    gameData: ScoreSubmissionInput['gameData']
+): string | null {
+    if (gameId !== GameID.ICE_SLIDE) {
+        return null
+    }
+
+    const claimsDaily =
+        context?.mode === 'daily' || gameData?.mode === 'daily'
+    if (!claimsDaily) {
+        return null
+    }
+
+    if (context?.mode !== 'daily' || !context.competitionKey || !gameData) {
+        return 'Invalid Ice Slide Daily score data'
+    }
+
+    const identity = parseIceSlideDailyRunKey(context.competitionKey)
+    if (
+        !identity ||
+        gameData.mode !== 'daily' ||
+        gameData.solved !== true ||
+        gameData.runKey !== context.competitionKey ||
+        gameData.generatorVersion !== identity.generatorVersion ||
+        gameData.rulesetVersion !== context.rulesetVersion ||
+        context.rulesetVersion !== identity.rulesetVersion ||
+        !isNonNegativeInteger(gameData.elapsedSeconds) ||
+        !isNonNegativeInteger(gameData.totalMoves)
+    ) {
+        return 'Invalid Ice Slide Daily score data'
+    }
+
+    return null
+}
+```
+
+Import `ScoreSubmissionInput` and `parseIceSlideDailyRunKey`. After `getGameById()` succeeds and before building `PersistedScoreContext`:
+
+```ts
+const dailyAdmissionError = validateIceSlideDailyClaim(
+    validatedGameId,
+    context,
+    gameData
+)
+if (dailyAdmissionError) {
+    return badRequestResponse(dailyAdmissionError)
+}
+```
+
+Do not regenerate the Daily, recompute score, inspect stage rows, or introduce a new error-code branch.
+
+- [ ] **Step 5: Run score API and score-service regressions**
+
+```bash
+bun run test:run src/pages/api/scores.test.ts src/lib/services/scoreService.test.ts
+```
+
+Expected: PASS. Existing non-Ice-Slide and Campaign score requests remain unchanged.
+
+- [ ] **Step 6: Commit**
+
+```bash
+git add src/pages/api/scores.ts src/pages/api/scores.test.ts
+git commit -m "feat(ice-slide): admit valid Daily scores only"
+```
+
+---
+
+### Task 3: Constrain Daily reads and add private viewer matching
+
+**Files:**
+- Modify: `src/lib/server/db/scoped-leaderboard.ts`
+- Modify: `src/lib/server/db/scoped-leaderboard.integration.test.ts`
+- Modify: `src/pages/api/leaderboard.ts`
+- Modify: `src/pages/api/leaderboard.test.ts`
+
+**Interfaces:**
+- Extends:
+
+```ts
+export interface ScopedLeaderboardQuery {
+    gameId: string
+    mode: string
+    competitionKey?: string
+    rulesetVersion?: number
+    limit?: number
+}
+```
+
+- Scoped API rows gain `isCurrentUser: boolean`.
+- Scoped API response gains `viewerAuthenticated: boolean`.
+- Unscoped Campaign response shape remains unchanged.
+
+- [ ] **Step 1: Add a real-LibSQL exact-ruleset regression**
+
+Extend the integration seed helper if necessary to use `gameId: 'ice_slide'`, then insert two users under the same exact competition key with different stored ruleset versions. Query:
+
+```ts
+const result = await getScopedGameLeaderboard({
+    gameId: 'ice_slide',
+    mode: 'daily',
+    competitionKey: 'ice-slide:daily:2026-08-12:g1:r1',
+    rulesetVersion: 1,
+    limit: 10,
+})
+```
+
+Assert only the `ruleset_version=1` row is returned. Do not duplicate the existing score/elapsed/moves/created-at tie-break matrix; those HPA-484 tests remain authoritative.
+
+- [ ] **Step 2: Run the integration test and confirm red**
+
+```bash
+bun run test:run src/lib/server/db/scoped-leaderboard.integration.test.ts
+```
+
+Expected: FAIL because the query contract does not accept/apply `rulesetVersion` yet.
+
+- [ ] **Step 3: Add the optional SQL ruleset predicate**
+
+In `scoped-leaderboard.ts`:
+
+```ts
+const rulesetFilter =
+    query.rulesetVersion === undefined
+        ? sql``
+        : sql`AND gs.ruleset_version = ${query.rulesetVersion}`
+```
+
+Apply it in the `scoped` CTE beside the existing game/mode/competition predicates:
+
+```sql
+AND gs.ruleset_version IS NOT NULL
+${competitionFilter}
+${rulesetFilter}
+```
+
+When omitted, behavior must remain byte-for-byte equivalent to HPA-484's generic scoped query.
+
+- [ ] **Step 4: Add Ice Slide Daily API admission tests**
+
+Update the game mock to expose both `tetris` and `ice_slide`. Add tests that:
+
+```ts
+// Missing exact key is rejected only for Ice Slide Daily.
+GET /api/leaderboard?gameId=ice_slide&mode=daily -> 400
+
+// Invalid/calendar-invalid exact key is rejected.
+GET /api/leaderboard?gameId=ice_slide&mode=daily&competitionKey=ice-slide:daily:2026-02-29:g1:r1 -> 400
+
+// Exact key forwards its parsed ruleset.
+expect(getScopedGameLeaderboard).toHaveBeenCalledWith({
+    gameId: 'ice_slide',
+    mode: 'daily',
+    competitionKey: 'ice-slide:daily:2026-08-12:g1:r1',
+    rulesetVersion: 1,
+    limit: 10,
+})
+
+// Existing generic mode-only Tetris request remains legal and forwards no ruleset.
+```
+
+- [ ] **Step 5: Add viewer-metadata tests before implementation**
+
+Mock `@/lib/auth`. For a scoped row with private `userId: 'u1'`:
+
+```ts
+vi.mocked(auth.api.getSession).mockResolvedValue({
+    user: { id: 'u1' },
+    session: {},
+} as never)
+```
+
+Call `GET` with a real `Request` and assert:
+
+```ts
+expect(body.viewerAuthenticated).toBe(true)
+expect(body.leaderboard[0]).toMatchObject({
+    isCurrentUser: true,
+    rank: 1,
+})
+expect(body.leaderboard[0]).not.toHaveProperty('userId')
+```
+
+Add signed-out (`getSession -> null`) and auth-lookup-rejection cases; both must still return the public leaderboard with `viewerAuthenticated:false` and `isCurrentUser:false`.
+
+Also assert an unscoped `?gameId=ice_slide` response does **not** gain `viewerAuthenticated` or `isCurrentUser`.
+
+- [ ] **Step 6: Run the API suite and confirm red**
+
+```bash
+bun run test:run src/pages/api/leaderboard.test.ts
+```
+
+Expected: new Ice Slide admission and viewer metadata tests FAIL.
+
+- [ ] **Step 7: Implement the Ice Slide Daily branch and optional viewer lookup**
+
+Import `GameID`, `parseIceSlideDailyRunKey`, and `auth`. Add a small best-effort helper:
+
+```ts
+async function getViewerUserId(
+    request: Request | undefined
+): Promise<string | null> {
+    if (!request) {
+        return null
+    }
+    try {
+        const session = await auth.api.getSession({ headers: request.headers })
+        return session?.user.id ?? null
+    } catch {
+        return null
+    }
+}
+```
+
+In the scoped branch:
+
+```ts
+let rulesetVersion: number | undefined
+if (gameId === GameID.ICE_SLIDE && mode === 'daily') {
+    if (!competitionKey) {
+        return badRequestResponse(
+            'competitionKey is required for Ice Slide Daily'
+        )
+    }
+    const identity = parseIceSlideDailyRunKey(competitionKey)
+    if (!identity) {
+        return badRequestResponse('Invalid Ice Slide Daily competitionKey')
+    }
+    rulesetVersion = identity.rulesetVersion
+}
+
+const scoped = await getScopedGameLeaderboard({
+    gameId,
+    mode,
+    competitionKey,
+    rulesetVersion,
+    limit,
+})
+```
+
+After a successful query:
+
+```ts
+const viewerUserId = await getViewerUserId(request)
+const leaderboard = scoped.rows.map((row, index) => ({
+    rank: index + 1,
+    ...toPublicScopedLeaderboardEntry(row),
+    isCurrentUser: viewerUserId !== null && row.userId === viewerUserId,
+}))
+
+return jsonResponse({
+    gameId,
+    gameName: game.name,
+    viewerAuthenticated: viewerUserId !== null,
+    leaderboard,
+})
+```
+
+Do not run session lookup for unscoped responses.
+
+- [ ] **Step 8: Run all scoped query/API regressions**
+
+```bash
+bun run test:run \
+  src/lib/server/db/scoped-leaderboard.integration.test.ts \
+  src/pages/api/leaderboard.test.ts \
+  src/lib/server/validations.test.ts
+```
+
+Expected: PASS, including existing generic Tetris mode-only behavior and unscoped response contracts.
+
+- [ ] **Step 9: Commit**
+
+```bash
+git add src/lib/server/db/scoped-leaderboard.ts \
+  src/lib/server/db/scoped-leaderboard.integration.test.ts \
+  src/pages/api/leaderboard.ts src/pages/api/leaderboard.test.ts
+git commit -m "feat(ice-slide): scope Daily leaderboard reads"
+```
+
+---
+
+### Task 4: Refresh the page-local Daily leaderboard after successful saves
+
+**Files:**
+- Modify: `src/lib/games/ice-slide/init.ts`
+- Modify: `src/lib/games/ice-slide/init.test.ts`
+- Modify: `src/pages/ice-slide/index.astro`
+- Modify: `src/pages/game-board-markup.test.ts`
+
+**Interfaces:**
+- Extends `IceSlideUICallbacks` with:
+
+```ts
+onScoreSaved?: (gameData: IceSlideGameData) => void
+```
+
+- Adds durable page IDs:
+
+```text
+daily-leaderboard
+daily-leaderboard-date
+daily-leaderboard-signed-out
+daily-leaderboard-loading
+daily-leaderboard-empty
+daily-leaderboard-unavailable
+daily-leaderboard-rows
+```
+
+- [ ] **Step 1: Add `init.test.ts` callback-order/staleness tests**
+
+Reuse the existing mocked `saveGameScore`. Add three focused assertions:
+
+1. current successful Daily save calls `onScoreSaved` once with `game.getGameData()`;
+2. score error/`UNAUTHENTICATED` never calls `onScoreSaved`;
+3. if a new run invalidates the run guard before the old success callback fires, the stale callback never reaches `onScoreSaved`.
+
+The success assertion should match at least:
+
+```ts
+expect(onScoreSaved).toHaveBeenCalledWith(
+    expect.objectContaining({
+        mode: 'daily',
+        solved: true,
+        runKey: 'ice-slide:daily:2026-08-12:g1:r1',
+        rulesetVersion: 1,
+    })
+)
+```
+
+- [ ] **Step 2: Run the focused init suite and confirm red**
+
+```bash
+bun run test:run src/lib/games/ice-slide/init.test.ts
+```
+
+Expected: FAIL because `onScoreSaved` does not exist/fire.
+
+- [ ] **Step 3: Add the optional callback in `init.ts`**
+
+Import `IceSlideGameData` for the callback type. In the existing score success callback, after the stale guard and achievement dispatch:
+
+```ts
+callbacks.onScoreSaved?.(gameData)
+```
+
+Do not issue a leaderboard fetch from `init.ts`; network/display ownership stays on the Astro page.
+
+- [ ] **Step 4: Add the static Astro leaderboard card**
+
+Place it directly below `#daily-meta` so it follows the Daily brief without covering the Pixi board:
+
+```astro
+<Card id="daily-leaderboard" variant="glass" class="hidden p-4">
+  <div class="flex items-baseline justify-between gap-3">
+    <h3 class="font-mono text-sm tracking-wide text-cetus-accent">
+      ▸ DAILY RANKING
+    </h3>
+    <span id="daily-leaderboard-date" class="text-xs text-cetus-ink-muted">—</span>
+  </div>
+  <p id="daily-leaderboard-signed-out" class="hidden mt-2 text-xs text-cetus-ink-muted">
+    Sign in to submit a ranked result. You can still view today's ranking.
+  </p>
+  <p id="daily-leaderboard-loading" class="mt-3 text-sm text-cetus-ink-muted">Loading ranking…</p>
+  <p id="daily-leaderboard-empty" class="hidden mt-3 text-sm text-cetus-ink-muted">No ranked finishes yet.</p>
+  <p id="daily-leaderboard-unavailable" class="hidden mt-3 text-sm text-cetus-ink-muted">Ranking is temporarily unavailable.</p>
+  <div id="daily-leaderboard-rows" class="hidden mt-3 space-y-2"></div>
+</Card>
+```
+
+Add all seven IDs to `src/pages/game-board-markup.test.ts`; keep the test structural and do not assert client source text.
+
+- [ ] **Step 5: Add page-local response types and formatting helpers**
+
+Inside the existing client script:
+
+```ts
+type DailyLeaderboardEntry = {
+  rank: number
+  name: string
+  score: number
+  elapsedSeconds: number | null
+  totalMoves: number | null
+  isCurrentUser: boolean
+}
+
+type DailyLeaderboardResponse = {
+  viewerAuthenticated: boolean
+  leaderboard: DailyLeaderboardEntry[]
+}
+
+const formatElapsed = (seconds: number | null) => {
+  if (seconds === null) return '—'
+  const minutes = Math.floor(seconds / 60)
+  const remainder = seconds % 60
+  return `${minutes}:${remainder.toString().padStart(2, '0')}`
+}
+```
+
+Query all seven static elements during `init()` and include them in the existing required-element guard.
+
+- [ ] **Step 6: Implement token-based load/render logic without `innerHTML`**
+
+Maintain exactly one page-local counter:
+
+```ts
+let leaderboardRequestToken = 0
+```
+
+A load increments/captures it and uses the exact key:
+
+```ts
+const loadDailyLeaderboard = async (competitionKey: string) => {
+  const token = ++leaderboardRequestToken
+  const identity = parseIceSlideDailyRunKey(competitionKey)
+  if (!identity) return
+
+  dailyLeaderboard.classList.remove('hidden')
+  dailyLeaderboardDate.textContent = identity.dateKey
+  setLeaderboardState('loading')
+
+  try {
+    const response = await fetch(
+      `/api/leaderboard?gameId=ice_slide&mode=daily&competitionKey=${encodeURIComponent(competitionKey)}&limit=10`
+    )
+    if (token !== leaderboardRequestToken) return
+    if (!response.ok) {
+      setLeaderboardState('unavailable')
+      return
+    }
+
+    const data = (await response.json()) as DailyLeaderboardResponse
+    if (token !== leaderboardRequestToken) return
+    renderLeaderboardRows(data.leaderboard)
+    dailyLeaderboardSignedOut.classList.toggle(
+      'hidden',
+      data.viewerAuthenticated
+    )
+    setLeaderboardState(data.leaderboard.length ? 'rows' : 'empty')
+  } catch {
+    if (token === leaderboardRequestToken) {
+      setLeaderboardState('unavailable')
+    }
+  }
+}
+```
+
+`renderLeaderboardRows()` must clear children with `while (firstChild) removeChild(firstChild)` and construct each row with `document.createElement`, `textContent`, and classes. For `entry.isCurrentUser`, render a literal `YOU` badge plus a stronger border/background class; otherwise render no badge.
+
+`setLeaderboardState()` toggles only the four state containers (`loading`, `empty`, `unavailable`, `rows`). It must not hide the game board, Daily result overlay, or error surface.
+
+- [ ] **Step 7: Wire selection, captured run identity, success refresh, and invalidation**
+
+Import `createIceSlideDailyCompetitionKey`, `toIceSlideUtcDateKey`, and `parseIceSlideDailyRunKey` into the page script.
+
+Use these exact transitions:
+
+```ts
+const currentUtcDailyKey = () =>
+  createIceSlideDailyCompetitionKey(toIceSlideUtcDateKey(new Date()))
+
+const invalidateLeaderboard = () => {
+  leaderboardRequestToken += 1
+  dailyLeaderboard.classList.add('hidden')
+}
+```
+
+- after `initializeIceSlide()` resolves, load `currentUtcDailyKey()` only when the selected radio is Daily;
+- on a radio change to Daily while idle, load the current UTC key;
+- on a radio change to Campaign, call `invalidateLeaderboard()`;
+- after `await gameHandle.start('daily')`, read `gameHandle.getGame()?.getState().runKey` and load that captured key;
+- after `await gameHandle.playAgain()` in Daily, reload the returned state's same captured key;
+- implement `onScoreSaved(gameData)` and call `loadDailyLeaderboard(gameData.runKey)` only for `gameData.mode === 'daily'`;
+- Change Mode returns to idle controls, then shows/loads the leaderboard only if the still-selected radio is Daily; choosing Campaign hides it;
+- `cleanup()`/page unload naturally invalidates by leaving the page; no global listener/store is added.
+
+This guarantees a run started before rollover refreshes its original competition instead of today's newly computed key.
+
+- [ ] **Step 8: Run focused DOM/init regressions**
+
+```bash
+bun run test:run \
+  src/lib/games/ice-slide/init.test.ts \
+  src/pages/game-board-markup.test.ts
+```
+
+Expected: PASS.
+
+- [ ] **Step 9: Commit**
+
+```bash
+git add src/lib/games/ice-slide/init.ts src/lib/games/ice-slide/init.test.ts \
+  src/pages/ice-slide/index.astro src/pages/game-board-markup.test.ts
+git commit -m "feat(ice-slide): show Daily leaderboard"
+```
+
+---
+
+### Task 5: Lock browser flows and run the repository gates
+
+**Files:**
+- Modify: `e2e/games/play-coverage.spec.ts`
+
+**Interfaces:**
+- Consumes the exact HPA-487 generator-v1 fixture for `2026-08-12`.
+- No production interface changes.
+
+- [ ] **Step 1: Add a helper that completes the frozen `2026-08-12` Daily**
+
+The existing generator-v1 fixture has five minimum solutions. Keep this helper in the Ice Slide Playwright section so a generator-version bump forces a deliberate test update:
+
+```ts
+const DAILY_2026_08_12_SOLUTIONS = [
+    ['ArrowDown', 'ArrowRight', 'ArrowDown'],
+    ['ArrowUp', 'ArrowLeft', 'ArrowUp', 'ArrowLeft'],
+    ['ArrowLeft', 'ArrowUp', 'ArrowRight', 'ArrowDown', 'ArrowLeft', 'ArrowUp'],
+    ['ArrowDown', 'ArrowLeft', 'ArrowUp', 'ArrowRight', 'ArrowDown', 'ArrowLeft'],
+    ['ArrowRight', 'ArrowDown', 'ArrowLeft', 'ArrowUp', 'ArrowRight', 'ArrowDown'],
+] as const
+
+async function completeFrozenDaily(page: Page): Promise<void> {
+    for (let stage = 0; stage < DAILY_2026_08_12_SOLUTIONS.length; stage++) {
+        for (const key of DAILY_2026_08_12_SOLUTIONS[stage]) {
+            await page.keyboard.press(key)
+        }
+        if (stage < DAILY_2026_08_12_SOLUTIONS.length - 1) {
+            await expect(page.locator('#stage-clear-overlay')).toBeVisible()
+            await page.locator('#stage-clear-continue-btn').click()
+        }
+    }
+    await expect(page.locator('#game-over-overlay')).toBeVisible()
+}
+```
+
+- [ ] **Step 2: Cover signed-out + empty and required row rendering with mocked leaderboard responses**
+
+Use `page.clock.setFixedTime(new Date('2026-08-12T20:00:00Z'))` and `page.route('**/api/leaderboard?*', ...)`.
+
+First return:
+
+```json
+{
+  "gameId": "ice_slide",
+  "gameName": "Ice Slide",
+  "viewerAuthenticated": false,
+  "leaderboard": []
+}
+```
+
+Assert the request contains the exact key `ice-slide:daily:2026-08-12:g1:r1`, the empty state is visible, and the signed-out copy is visible.
+
+In a second test return one row:
+
+```json
+{
+  "viewerAuthenticated": true,
+  "leaderboard": [{
+    "rank": 1,
+    "name": "Pilot",
+    "score": 4321,
+    "elapsedSeconds": 87,
+    "totalMoves": 31,
+    "isCurrentUser": true
+  }]
+}
+```
+
+Assert `#daily-leaderboard-rows` shows rank `1`, `Pilot`, `4,321`, `1:27`, `31`, and visible `YOU` text.
+
+- [ ] **Step 3: Cover unavailable-with-playability**
+
+Fulfill the leaderboard route with status 503 and the normal coded error body. Assert `#daily-leaderboard-unavailable` becomes visible, then start Daily and verify the Pixi canvas plus `#end-btn` are still usable. Do not expect the generic `#game-error` surface for a leaderboard-only failure.
+
+- [ ] **Step 4: Cover successful-submit refresh on the captured key**
+
+Mock `/api/scores` with a 200 success body and count leaderboard requests. Start fixed-date Daily, capture the current leaderboard request count, call `completeFrozenDaily(page)`, then:
+
+```ts
+await expect.poll(() => leaderboardRequestCount).toBeGreaterThan(beforeCompletion)
+expect(lastCompetitionKey).toBe(
+    'ice-slide:daily:2026-08-12:g1:r1'
+)
+```
+
+The POST body should also be inspected once to prove the completed submission carries `context.mode='daily'`, the same competition key, and `gameData.solved=true`.
+
+- [ ] **Step 5: Cover stale leaderboard suppression**
+
+Delay one Daily leaderboard response with a promise. While it is pending, switch the idle mode selection to Campaign. Release the old response and assert `#daily-leaderboard` remains hidden and the delayed row text never appears. This is the browser proof for the request-token guard; do not add `AbortController` only for the test.
+
+- [ ] **Step 6: Run focused Ice Slide browser coverage**
+
+```bash
+bun run test:e2e -- e2e/games/play-coverage.spec.ts --grep "Ice Slide"
+```
+
+Expected: all existing HPA-487 cases plus the new leaderboard cases PASS.
+
+- [ ] **Step 7: Run focused unit/integration suites once more**
+
+```bash
+bun run test:run \
+  src/lib/games/ice-slide/run.test.ts \
+  src/lib/games/ice-slide/daily.test.ts \
+  src/lib/games/ice-slide/init.test.ts \
+  src/lib/server/db/scoped-leaderboard.integration.test.ts \
+  src/pages/api/scores.test.ts \
+  src/pages/api/leaderboard.test.ts \
+  src/pages/game-board-markup.test.ts
+```
+
+Expected: PASS.
+
+- [ ] **Step 8: Run full repository verification**
+
+```bash
+bun run test:run
+bun run typecheck
+bun run lint
+bun run format:check
+bun run build
+bun run test:coverage
+```
+
+Expected:
+- tests/typecheck/lint/format/build exit 0;
+- local coverage does not regress the repository below the configured 95% project target; remote Codecov project and patch checks remain authoritative after push.
+
+- [ ] **Step 9: Commit the E2E coverage**
+
+```bash
+git add e2e/games/play-coverage.spec.ts
+git commit -m "test(ice-slide): cover Daily leaderboard flows"
+```
+
+---
+
+## Plan self-review
+
+- **Spec coverage:** Daily admission, exact competition/ruleset isolation, best-per-user reuse, viewer highlighting, signed-out/loading/empty/unavailable states, successful-save refresh, stale suppression, Campaign compatibility, and failure isolation each map to a concrete task above.
+- **Placeholder scan:** no TBD/TODO/future implementation step remains.
+- **Type consistency:** `parseIceSlideDailyRunKey`, `createIceSlideDailyCompetitionKey`, `ScopedLeaderboardQuery.rulesetVersion`, `viewerAuthenticated`, `isCurrentUser`, and `onScoreSaved(IceSlideGameData)` use one spelling/signature throughout.
+- **Scope check:** no schema, endpoint family, shared UI abstraction, replay verifier, historical browser, Expedition ranking, or current-user rank query has entered the plan.

--- a/docs/superpowers/plans/2026-08-13-ice-slide-daily-leaderboard.md
+++ b/docs/superpowers/plans/2026-08-13-ice-slide-daily-leaderboard.md
@@ -4,48 +4,59 @@
 
 **Goal:** Admit only valid completed Ice Slide Daily scores, rank one best result per player for the exact Daily competition, and show/refetch that ranking on the Ice Slide page without changing Campaign behavior.
 
-**Architecture:** Reuse HPA-484's existing score-context persistence and `getScopedGameLeaderboard()` window query unchanged. `run.ts` owns the single Daily-key parser plus pure Daily admission semantics; `/api/scores` and `/api/leaderboard` remain the only network seams. A small Ice-Slide-specific `daily-leaderboard.ts` module owns fetch/render/request-token behavior so the Astro page stays wiring-only and the risky async UI logic is unit-testable.
+**Architecture:** Reuse HPA-484's existing score-context persistence and `getScopedGameLeaderboard()` window query unchanged. `run.ts` owns the Daily key grammar in both directions plus pure Daily admission semantics; `/api/scores` and `/api/leaderboard` remain the only network seams. Viewer identity comes from middleware-populated `locals.user`. A small Ice-Slide-specific `daily-leaderboard.ts` module owns fetch/render/request-token behavior so the Astro page stays wiring-only and the risky async UI logic is unit-testable.
 
-**Tech Stack:** Astro 5, TypeScript, Tailwind CSS 4, Better Auth, Kysely + LibSQL/Turso, Vitest/jsdom, Playwright, Bun 1.3.1.
+**Tech Stack:** Astro 5, TypeScript, Tailwind CSS 4, Better Auth middleware locals, Kysely + LibSQL/Turso, Vitest/jsdom, Playwright, Bun 1.3.1.
 
 ## Global Constraints
 
 - Keep `/api/leaderboard?gameId=ice_slide` on the existing unscoped Campaign response path.
 - Daily competition keys remain `ice-slide:daily:YYYY-MM-DD:g<generatorVersion>:r<rulesetVersion>` and use UTC dates.
-- Daily ranking order remains score DESC, elapsed seconds ASC, total moves ASC, submission time ASC; row ID is only the existing final deterministic fallback for exact ties.
+- Daily ranking order remains score DESC, elapsed seconds ASC, total moves ASC, submission time ASC; row ID stays only the existing final deterministic fallback for exact ties.
 - Repeated attempts remain stored; only the existing best-per-user query chooses the displayed row.
-- `getScopedGameLeaderboard()` and `ScopedLeaderboardQuery` remain unchanged in HPA-488; the exact competition key is the competitive scope.
-- Do not add database schema, a new endpoint, a best-score cache/table, a generic mode registry, a shared leaderboard component, or an auth preflight request.
-- Do not add replay verification, score recomputation, historical Daily navigation, Expedition ranking, read-repair for pre-HPA-488 malformed rows, or current-user rank lookup beyond returned rows.
+- Do not modify `ScopedLeaderboardQuery`, `getScopedGameLeaderboard()`, or its real-LibSQL tie-break suite.
+- Do not add database schema, a new endpoint, a best-score cache/table, a generic mode registry, a shared leaderboard component/framework, or another auth request.
+- Do not add replay verification, score recomputation, historical Daily navigation, Expedition ranking, read-repair, or current-user rank lookup beyond returned rows.
 - Astro owns durable HTML; client TypeScript may update/toggle existing structure and create leaderboard row children without `innerHTML`.
-- Leaderboard or viewer-auth lookup failure must never enter the Ice Slide `failRun` path or invalidate a local result.
+- Leaderboard failures must never enter the Ice Slide `failRun` path or invalidate a local result.
 - Preserve HPA-487's captured Daily run identity across UTC rollover and Play Again.
-- Reuse `src/lib/games/shared/utils.ts::formatTime`; do not add another M:SS formatter.
+- Leave the existing private `init.ts::formatTime()` behavior unchanged; the new leaderboard alone reuses shared `formatTime()`.
+- Keep one frozen `2026-08-12` direction fixture in `test-fixtures.ts`; unit and E2E consumers import the same constant.
 - Keep existing remote Codecov project/patch coverage requirements at 95%.
 
 ---
 
 ## File map
 
-One new production module is intentional because it turns page-local async/render behavior into executable unit tests.
+- `src/lib/games/ice-slide/run.ts` — parse/format the frozen Daily key and expose pure Daily admission reasons.
+- `src/lib/games/ice-slide/run.test.ts` — identity round-trip and exact admission-reason tests.
+- `src/lib/games/ice-slide/daily.ts` — current-version Daily competition-key convenience constructor.
+- `src/lib/games/ice-slide/daily.test.ts` — frozen generator output plus shared playthrough replay.
+- `src/lib/games/ice-slide/test-fixtures.ts` — single frozen `2026-08-12` direction fixture.
+- `src/lib/games/ice-slide/init.ts` — consume the one Daily parser and report current successful score saves.
+- `src/lib/games/ice-slide/init.test.ts` — callback staleness/error coverage; no time-format behavior change.
+- `src/pages/api/scores.ts` — one Ice Slide dispatch to the pure admission helper.
+- `src/pages/api/scores.test.ts` — HTTP 400/no-persist boundary coverage.
+- `src/lib/server/validations.ts` — require `competitionKey` for `ice_slide + daily` alongside existing query-parameter relationship rules.
+- `src/lib/server/validations.test.ts` — presence rule and generic-mode compatibility.
+- `src/pages/api/leaderboard.ts` — semantic Daily-key validation plus viewer matching from `locals.user`.
+- `src/pages/api/leaderboard.test.ts` — exact-key/read DTO/viewer tests using `locals`, with no auth mock.
+- `src/lib/games/ice-slide/daily-leaderboard.ts` — page-local URL/state/row/fetch/request-token logic.
+- `src/lib/games/ice-slide/daily-leaderboard.test.ts` — jsdom async/render/stale-request tests.
+- `src/pages/ice-slide/index.astro` — static Daily ranking card and event wiring only.
+- `src/pages/game-board-markup.test.ts` — durable leaderboard element IDs only.
+- `e2e/games/play-coverage.spec.ts` — browser integration using the shared direction fixture.
 
-- `src/lib/games/ice-slide/run.ts` — single Daily run-key parser plus pure Daily score-admission helper.
-- `src/lib/games/ice-slide/daily.ts` — centralize construction of the frozen Daily competition key.
-- `src/lib/games/ice-slide/init.ts` — consume the one parser for captured date identity, reuse shared `formatTime`, and report successful score saves.
-- `src/pages/api/scores.ts` — call the pure Ice Slide Daily admission helper before persistence.
-- `src/pages/api/leaderboard.ts` — require exact Ice Slide Daily identity and add viewer metadata to scoped responses.
-- `src/lib/games/ice-slide/daily-leaderboard.ts` — Ice-Slide-specific URL/state/row/fetch/request-token logic.
-- `src/pages/ice-slide/index.astro` — static Daily leaderboard card plus event wiring only.
-- Existing colocated tests and `e2e/games/play-coverage.spec.ts` — contract, DOM, async-state, and browser coverage.
-
-Explicitly **not modified**:
+Explicitly unchanged:
 
 - `src/lib/server/db/scoped-leaderboard.ts`
 - `src/lib/server/db/scoped-leaderboard.integration.test.ts`
+- `src/middleware.ts`
+- `env.d.ts`
 
 ---
 
-### Task 1: Make one Daily competition-identity parser serve every consumer
+### Task 1: Make `run.ts` the single Daily-key grammar owner
 
 **Files:**
 - Modify: `src/lib/games/ice-slide/run.ts`
@@ -67,14 +78,18 @@ export function parseIceSlideDailyRunKey(
     runKey: string
 ): IceSlideDailyRunIdentity | null
 
+export function formatIceSlideDailyRunKey(
+    identity: IceSlideDailyRunIdentity
+): string
+
 export function createIceSlideDailyCompetitionKey(dateKey: string): string
 ```
 
-`createIceSlideDailyRunDefinition(dateKey)` must continue producing byte-equivalent generator-v1 run keys, seeds, stages, objectives, and signatures.
+`createIceSlideDailyCompetitionKey()` remains in `daily.ts`, but delegates grammar formatting to `run.ts` with current generator/ruleset constants.
 
-- [ ] **Step 1: Write failing parser tests in `run.test.ts`**
+- [ ] **Step 1: Add parser/formatter tests to `run.test.ts`**
 
-Add the parser import and lock exact identity plus malformed/calendar-invalid/unsafe versions:
+Add imports for `parseIceSlideDailyRunKey` and `formatIceSlideDailyRunKey`.
 
 ```ts
 it('parses an exact Daily competition identity', () => {
@@ -87,6 +102,17 @@ it('parses an exact Daily competition identity', () => {
     })
 })
 
+it('formats and round-trips a Daily competition identity', () => {
+    const identity = {
+        dateKey: '2026-08-12',
+        generatorVersion: 3,
+        rulesetVersion: 2,
+    }
+    const key = formatIceSlideDailyRunKey(identity)
+    expect(key).toBe('ice-slide:daily:2026-08-12:g3:r2')
+    expect(parseIceSlideDailyRunKey(key)).toEqual(identity)
+})
+
 it.each([
     'ice-slide:daily:2026-02-29:g1:r1',
     'ice-slide:daily:2026-08-12:g0:r1',
@@ -94,31 +120,32 @@ it.each([
     'ice-slide:daily:2026-08-12:g1',
     'ice-slide:daily:2026-08-12:g1:r1:extra',
     'daily:2026-08-12:g1:r1',
-    'ice-slide:daily:2026-08-12:g999999999999999999999:r1',
 ])('rejects invalid Daily competition key %s', runKey => {
     expect(parseIceSlideDailyRunKey(runKey)).toBeNull()
 })
+
+it.each([
+    [{ dateKey: '2026-02-29', generatorVersion: 1, rulesetVersion: 1 }],
+    [{ dateKey: '2026-08-12', generatorVersion: 0, rulesetVersion: 1 }],
+    [{ dateKey: '2026-08-12', generatorVersion: 1, rulesetVersion: 0 }],
+])('rejects invalid formatted identity %j', identity => {
+    expect(() => formatIceSlideDailyRunKey(identity)).toThrow()
+})
 ```
 
-- [ ] **Step 2: Run the focused run suite and confirm red**
+- [ ] **Step 2: Run the focused run tests and confirm red**
 
 ```bash
 bun run test:run src/lib/games/ice-slide/run.test.ts
 ```
 
-Expected: FAIL because `parseIceSlideDailyRunKey` is not exported.
+Expected: FAIL because the parser/formatter are not exported yet.
 
-- [ ] **Step 3: Implement the parser and reuse it in Daily run validation**
+- [ ] **Step 3: Implement parse/format in `run.ts` and reuse the parser in run validation**
 
-Keep `DAILY_KEY_PATTERN` as the single syntax regex. Parse versions once and reject anything outside the existing positive signed-integer contract:
+Keep the existing anchored `DAILY_KEY_PATTERN`. Add a positive-integer guard using the same signed-int domain as the run validator.
 
 ```ts
-export interface IceSlideDailyRunIdentity {
-    dateKey: string
-    generatorVersion: number
-    rulesetVersion: number
-}
-
 export function parseIceSlideDailyRunKey(
     runKey: string
 ): IceSlideDailyRunIdentity | null {
@@ -127,14 +154,20 @@ export function parseIceSlideDailyRunKey(
         return null
     }
 
-    const generatorVersion = Number(match[2])
-    const rulesetVersion = Number(match[3])
-
     try {
         assertValidIceSlideUtcDateKey(match[1])
-        assertPositiveInt(generatorVersion, 'generatorVersion')
-        assertPositiveInt(rulesetVersion, 'rulesetVersion')
     } catch {
+        return null
+    }
+
+    const generatorVersion = Number(match[2])
+    const rulesetVersion = Number(match[3])
+    if (
+        !Number.isSafeInteger(generatorVersion) ||
+        generatorVersion < 1 ||
+        !Number.isSafeInteger(rulesetVersion) ||
+        rulesetVersion < 1
+    ) {
         return null
     }
 
@@ -144,29 +177,32 @@ export function parseIceSlideDailyRunKey(
         rulesetVersion,
     }
 }
+
+export function formatIceSlideDailyRunKey(
+    identity: IceSlideDailyRunIdentity
+): string {
+    assertValidIceSlideUtcDateKey(identity.dateKey)
+    assertPositiveInt(identity.generatorVersion, 'generatorVersion')
+    assertPositiveInt(identity.rulesetVersion, 'rulesetVersion')
+    return (
+        `ice-slide:daily:${identity.dateKey}:` +
+        `g${identity.generatorVersion}:r${identity.rulesetVersion}`
+    )
+}
 ```
 
-Replace the Daily branch's independent regex extraction with:
+Replace the Daily branch's independent `DAILY_KEY_PATTERN.exec(...)` extraction with:
 
 ```ts
 const identity = parseIceSlideDailyRunKey(run.runKey)
 if (!identity) {
     throw new RangeError('daily runKey must match the daily key format')
 }
-if (run.generatorVersion !== identity.generatorVersion) {
-    throw new RangeError('daily generatorVersion must match the runKey')
-}
-if (run.rulesetVersion !== identity.rulesetVersion) {
-    throw new RangeError('daily rulesetVersion must match the runKey')
-}
-const expectedSeed =
-    `ice-slide:daily:${identity.generatorVersion}:` +
-    `${identity.rulesetVersion}:${identity.dateKey}`
 ```
 
-Do not retain another Daily-key regex parser elsewhere in `run.ts`.
+Use `identity.generatorVersion`, `identity.rulesetVersion`, and `identity.dateKey` for version and expected-seed checks.
 
-- [ ] **Step 4: Add the competition-key constructor test in `daily.test.ts`**
+- [ ] **Step 4: Add the current-version constructor test in `daily.test.ts`**
 
 ```ts
 it('builds the frozen generator-v1 Daily competition key', () => {
@@ -174,47 +210,35 @@ it('builds the frozen generator-v1 Daily competition key', () => {
         'ice-slide:daily:2026-08-12:g1:r1'
     )
 })
-
-it('rejects an invalid Daily competition date', () => {
-    expect(() => createIceSlideDailyCompetitionKey('2026-02-29')).toThrow(
-        RangeError
-    )
-})
 ```
 
-- [ ] **Step 5: Implement the constructor and use it in the Daily materializer**
+The existing literal `2026-08-12` generator fixture must remain byte-equivalent.
+
+- [ ] **Step 5: Delegate the Daily constructor to `run.ts`**
 
 In `daily.ts`:
 
 ```ts
 export function createIceSlideDailyCompetitionKey(dateKey: string): string {
-    assertValidIceSlideUtcDateKey(dateKey)
-    return (
-        `ice-slide:daily:${dateKey}:` +
-        `g${ICE_SLIDE_DAILY_GENERATOR_VERSION}:r${ICE_SLIDE_RULESET_VERSION}`
-    )
+    return formatIceSlideDailyRunKey({
+        dateKey,
+        generatorVersion: ICE_SLIDE_DAILY_GENERATOR_VERSION,
+        rulesetVersion: ICE_SLIDE_RULESET_VERSION,
+    })
 }
 ```
 
-Replace only the run-key literal:
+Then keep:
 
 ```ts
 runKey: createIceSlideDailyCompetitionKey(dateKey),
 ```
 
-Do not change the Daily seed, fork labels, stage pools, transform/objective selection, or version constants.
+Do not change the seed, fork labels, stage pools, transform/objective selection, or version constants.
 
-- [ ] **Step 6: Remove the weaker `init.ts` Daily-date parser**
+- [ ] **Step 6: Delete `extractDailyDateKey()` from `init.ts`**
 
-Import `parseIceSlideDailyRunKey` from `./run`, delete:
-
-```ts
-function extractDailyDateKey(runKey: string): string | null {
-    return /^ice-slide:daily:(\d{4}-\d{2}-\d{2}):/.exec(runKey)?.[1] ?? null
-}
-```
-
-Replace both live consumers:
+Import `parseIceSlideDailyRunKey` from `./run` and replace both current callers:
 
 ```ts
 const capturedDateKey =
@@ -227,9 +251,9 @@ and:
 dailyDateKey = parseIceSlideDailyRunKey(run.runKey)?.dateKey ?? null
 ```
 
-The `startRun()` Daily branch uses the same expression when it needs to recover the captured date from an explicit run.
+Do **not** touch the existing private `formatTime()` in this task.
 
-- [ ] **Step 7: Run identity/generator/init regressions**
+- [ ] **Step 7: Run the identity/generator/init regressions**
 
 ```bash
 bun run test:run \
@@ -238,7 +262,7 @@ bun run test:run \
   src/lib/games/ice-slide/init.test.ts
 ```
 
-Expected: PASS, including the existing literal `2026-08-12` generator-v1 fixture and rollover/Play Again tests.
+Expected: PASS, including existing UTC-rollover/retry behavior and the frozen generator fixture.
 
 - [ ] **Step 8: Commit**
 
@@ -251,7 +275,7 @@ git commit -m "refactor(ice-slide): centralize Daily competition identity"
 
 ---
 
-### Task 2: Put Ice Slide Daily score admission in pure domain code
+### Task 2: Add independently testable Daily score-admission reasons
 
 **Files:**
 - Modify: `src/lib/games/ice-slide/run.ts`
@@ -262,6 +286,21 @@ git commit -m "refactor(ice-slide): centralize Daily competition identity"
 **Interfaces:**
 
 ```ts
+export type IceSlideDailyAdmissionReason =
+    | 'missing-context'
+    | 'context-mode-mismatch'
+    | 'missing-competition-key'
+    | 'malformed-competition-key'
+    | 'missing-game-data'
+    | 'game-data-mode-mismatch'
+    | 'unsolved'
+    | 'run-key-mismatch'
+    | 'generator-version-mismatch'
+    | 'game-data-ruleset-mismatch'
+    | 'context-ruleset-mismatch'
+    | 'invalid-elapsed-seconds'
+    | 'invalid-total-moves'
+
 export function iceSlideDailyAdmissionError(
     context: {
         mode: string
@@ -269,14 +308,14 @@ export function iceSlideDailyAdmissionError(
         rulesetVersion: number
     } | undefined,
     gameData: Record<string, unknown> | undefined
-): string | null
+): { reason: IceSlideDailyAdmissionReason } | null
 ```
 
-The route calls this only for `GameID.ICE_SLIDE`. Invalid semantic Daily claims return the existing HTTP 400 bad-request response and never call `saveGameScoreWithAchievements()`.
+The route maps every non-null result to the same public HTTP 400 body and does not persist.
 
-- [ ] **Step 1: Add pure admission fixtures to `run.test.ts`**
+- [ ] **Step 1: Add one accepted fixture and an exact-reason matrix to `run.test.ts`**
 
-Define one valid payload:
+Define:
 
 ```ts
 const validDailyContext = {
@@ -286,134 +325,220 @@ const validDailyContext = {
 }
 
 const validDailyGameData = {
-    levelsCleared: 5,
-    totalMoves: 31,
-    crystalsCollected: 2,
-    elapsedSeconds: 87,
-    solved: true,
-    perfectLevels: 3,
     mode: 'daily',
+    solved: true,
     runKey: 'ice-slide:daily:2026-08-12:g1:r1',
-    runSchemaVersion: 1,
     generatorVersion: 1,
     rulesetVersion: 1,
-    stagesTotal: 5,
-    starsEarned: 13,
-    falls: 0,
-    resets: 0,
-    stageSignatures: ['a', 'b', 'c', 'd', 'e'],
+    elapsedSeconds: 87,
+    totalMoves: 31,
 }
 ```
 
-Assert the valid claim returns `null`, then cover every domain invariant:
+Assert:
+
+```ts
+expect(
+    iceSlideDailyAdmissionError(validDailyContext, validDailyGameData)
+).toBeNull()
+```
+
+Then add explicit tests whose mutations isolate one reason at a time:
 
 ```ts
 it.each([
-    ['missing context', undefined, validDailyGameData],
-    ['unsolved', validDailyContext, { ...validDailyGameData, solved: false }],
-    ['game-data mode mismatch', validDailyContext, { ...validDailyGameData, mode: 'expedition' }],
-    ['context mode mismatch', { ...validDailyContext, mode: 'expedition' }, validDailyGameData],
-    ['malformed competition key', { ...validDailyContext, competitionKey: 'ice-slide:daily:2026-02-29:g1:r1' }, { ...validDailyGameData, runKey: 'ice-slide:daily:2026-02-29:g1:r1' }],
-    ['run-key mismatch', validDailyContext, { ...validDailyGameData, runKey: 'ice-slide:daily:2026-08-11:g1:r1' }],
-    ['generator mismatch', validDailyContext, { ...validDailyGameData, generatorVersion: 2 }],
-    ['game-data ruleset mismatch', validDailyContext, { ...validDailyGameData, rulesetVersion: 2 }],
-    ['context ruleset mismatch', { ...validDailyContext, rulesetVersion: 2 }, validDailyGameData],
-    ['negative elapsed', validDailyContext, { ...validDailyGameData, elapsedSeconds: -1 }],
-    ['negative moves', validDailyContext, { ...validDailyGameData, totalMoves: -1 }],
-])('rejects Daily admission: %s', (_name, context, gameData) => {
-    expect(iceSlideDailyAdmissionError(context, gameData)).not.toBeNull()
+    ['missing-context', undefined, validDailyGameData, 'missing-context'],
+    [
+        'context-mode-mismatch',
+        { ...validDailyContext, mode: 'expedition' },
+        validDailyGameData,
+        'context-mode-mismatch',
+    ],
+    [
+        'missing-competition-key',
+        { mode: 'daily', rulesetVersion: 1 },
+        validDailyGameData,
+        'missing-competition-key',
+    ],
+    [
+        'malformed-competition-key',
+        { ...validDailyContext, competitionKey: 'ice-slide:daily:2026-02-29:g1:r1' },
+        validDailyGameData,
+        'malformed-competition-key',
+    ],
+    [
+        'missing-game-data',
+        validDailyContext,
+        undefined,
+        'missing-game-data',
+    ],
+    [
+        'game-data-mode-mismatch',
+        validDailyContext,
+        { ...validDailyGameData, mode: 'expedition' },
+        'game-data-mode-mismatch',
+    ],
+    [
+        'unsolved',
+        validDailyContext,
+        { ...validDailyGameData, solved: false },
+        'unsolved',
+    ],
+    [
+        'run-key-mismatch',
+        validDailyContext,
+        { ...validDailyGameData, runKey: 'ice-slide:daily:2026-08-11:g1:r1' },
+        'run-key-mismatch',
+    ],
+    [
+        'generator-version-mismatch',
+        validDailyContext,
+        { ...validDailyGameData, generatorVersion: 2 },
+        'generator-version-mismatch',
+    ],
+    [
+        'game-data-ruleset-mismatch',
+        validDailyContext,
+        { ...validDailyGameData, rulesetVersion: 2 },
+        'game-data-ruleset-mismatch',
+    ],
+    [
+        'context-ruleset-mismatch',
+        { ...validDailyContext, rulesetVersion: 2 },
+        { ...validDailyGameData, rulesetVersion: 2 },
+        'context-ruleset-mismatch',
+    ],
+    [
+        'invalid-elapsed-seconds',
+        validDailyContext,
+        { ...validDailyGameData, elapsedSeconds: -1 },
+        'invalid-elapsed-seconds',
+    ],
+    [
+        'invalid-total-moves',
+        validDailyContext,
+        { ...validDailyGameData, totalMoves: -1 },
+        'invalid-total-moves',
+    ],
+])('returns reason %s', (_name, context, gameData, expected) => {
+    expect(iceSlideDailyAdmissionError(context, gameData)).toEqual({
+        reason: expected,
+    })
 })
 ```
 
-Also cover missing `elapsedSeconds` and `totalMoves` by cloning/deleting those keys before calling the helper.
+Also assert a non-Daily Campaign-like payload and a non-Daily Expedition payload both return `null`.
 
-Finally assert a non-Daily Ice Slide payload such as `{ mode: 'expedition' }` + `{ mode: 'expedition' }` returns `null`; HPA-488 must not accidentally implement Expedition admission.
-
-- [ ] **Step 2: Run the run suite and confirm red**
+- [ ] **Step 2: Run the pure suite and confirm red**
 
 ```bash
 bun run test:run src/lib/games/ice-slide/run.test.ts
 ```
 
-Expected: FAIL because `iceSlideDailyAdmissionError` does not exist.
+Expected: FAIL because the admission helper does not exist.
 
-- [ ] **Step 3: Implement the pure helper next to the parser**
+- [ ] **Step 3: Implement the helper as ordered single-invariant branches**
 
-Use one local integer guard and the parser from Task 1:
+Use one small metric guard:
 
 ```ts
 function isNonNegativeInteger(value: unknown): value is number {
     return typeof value === 'number' && Number.isInteger(value) && value >= 0
 }
+```
 
+Implement in this exact order so each reason remains independently observable:
+
+```ts
 export function iceSlideDailyAdmissionError(
-    context: {
-        mode: string
-        competitionKey?: string
-        rulesetVersion: number
-    } | undefined,
+    context: DailyAdmissionContext | undefined,
     gameData: Record<string, unknown> | undefined
-): string | null {
+): { reason: IceSlideDailyAdmissionReason } | null {
     const claimsDaily =
         context?.mode === 'daily' || gameData?.mode === 'daily'
     if (!claimsDaily) {
         return null
     }
-
-    if (context?.mode !== 'daily' || !context.competitionKey || !gameData) {
-        return 'Invalid Ice Slide Daily score data'
+    if (!context) {
+        return { reason: 'missing-context' }
+    }
+    if (context.mode !== 'daily') {
+        return { reason: 'context-mode-mismatch' }
+    }
+    if (!context.competitionKey) {
+        return { reason: 'missing-competition-key' }
     }
 
     const identity = parseIceSlideDailyRunKey(context.competitionKey)
-    if (
-        !identity ||
-        gameData.mode !== 'daily' ||
-        gameData.solved !== true ||
-        gameData.runKey !== context.competitionKey ||
-        gameData.generatorVersion !== identity.generatorVersion ||
-        gameData.rulesetVersion !== context.rulesetVersion ||
-        context.rulesetVersion !== identity.rulesetVersion ||
-        !isNonNegativeInteger(gameData.elapsedSeconds) ||
-        !isNonNegativeInteger(gameData.totalMoves)
-    ) {
-        return 'Invalid Ice Slide Daily score data'
+    if (!identity) {
+        return { reason: 'malformed-competition-key' }
     }
-
+    if (!gameData) {
+        return { reason: 'missing-game-data' }
+    }
+    if (gameData.mode !== 'daily') {
+        return { reason: 'game-data-mode-mismatch' }
+    }
+    if (gameData.solved !== true) {
+        return { reason: 'unsolved' }
+    }
+    if (gameData.runKey !== context.competitionKey) {
+        return { reason: 'run-key-mismatch' }
+    }
+    if (gameData.generatorVersion !== identity.generatorVersion) {
+        return { reason: 'generator-version-mismatch' }
+    }
+    if (gameData.rulesetVersion !== context.rulesetVersion) {
+        return { reason: 'game-data-ruleset-mismatch' }
+    }
+    if (context.rulesetVersion !== identity.rulesetVersion) {
+        return { reason: 'context-ruleset-mismatch' }
+    }
+    if (!isNonNegativeInteger(gameData.elapsedSeconds)) {
+        return { reason: 'invalid-elapsed-seconds' }
+    }
+    if (!isNonNegativeInteger(gameData.totalMoves)) {
+        return { reason: 'invalid-total-moves' }
+    }
     return null
 }
 ```
 
-Do not import `ScoreSubmissionInput`, `GameID`, server modules, or auth into `run.ts`.
+Do not collapse these checks back into one `||` chain.
 
-- [ ] **Step 4: Add score-route red tests**
+- [ ] **Step 4: Add score-route boundary tests**
 
-In `scores.test.ts`, add an Ice Slide game fixture and a valid request using the same payload. Assert 200 and the existing persistence call shape.
+Use the existing authenticated-session and score persistence mocks. Add one valid Ice Slide Daily POST and representative invalid HTTP cases:
 
-Add representative HTTP 400/no-persist cases for:
+- unsolved Daily;
+- malformed competition key;
+- context/key ruleset mismatch where `gameData.rulesetVersion` matches context but the key is still `r1`;
+- Expedition game data with Daily context.
 
-1. `solved:false`;
-2. malformed but transport-safe `competitionKey='ice-slide:daily:2026-02-29:g1:r1'` with matching `gameData.runKey`;
-3. `context.mode='daily'` with `gameData.mode='expedition'`;
-4. `elapsedSeconds:-1` and `totalMoves:-1` — these are expected to be caught by generic Zod before domain admission, but still must return 400 and skip persistence.
+Each invalid request that passes generic Zod must return 400 and leave `saveGameScoreWithAchievements` uncalled.
 
-Keep or add one non-Ice-Slide contextual score regression proving a generic Tetris scoped submission is still accepted; the route must dispatch Daily semantics only for `GameID.ICE_SLIDE`.
+Negative metric transport remains covered by generic validation tests; the pure helper already freezes its own negative-metric invariants.
 
-- [ ] **Step 5: Wire one route call before `PersistedScoreContext` construction**
+- [ ] **Step 5: Dispatch from `/api/scores` after generic validation**
 
-Import `iceSlideDailyAdmissionError`. After game resolution:
+Import `iceSlideDailyAdmissionError`. After `getGameById()` succeeds and before building `PersistedScoreContext`:
 
 ```ts
 if (validatedGameId === GameID.ICE_SLIDE) {
-    const dailyAdmissionError = iceSlideDailyAdmissionError(context, gameData)
-    if (dailyAdmissionError) {
-        return badRequestResponse(dailyAdmissionError)
+    const admissionError = iceSlideDailyAdmissionError(context, gameData)
+    if (admissionError) {
+        console.warn(
+            '[scores API] Rejected Ice Slide Daily score:',
+            admissionError.reason
+        )
+        return badRequestResponse('Invalid Ice Slide Daily score data')
     }
 }
 ```
 
-Do not add a route-local semantic closure, new error code, stage regeneration, score recomputation, or board inspection.
+Do not log the score payload. Do not add a public admission error-code family.
 
-- [ ] **Step 6: Run score/domain regressions**
+- [ ] **Step 6: Run score regressions**
 
 ```bash
 bun run test:run \
@@ -422,7 +547,7 @@ bun run test:run \
   src/lib/services/scoreService.test.ts
 ```
 
-Expected: PASS.
+Expected: PASS. Existing non-Ice-Slide, Campaign, and generic score behavior remains unchanged.
 
 - [ ] **Step 7: Commit**
 
@@ -434,148 +559,114 @@ git commit -m "feat(ice-slide): admit valid Daily scores only"
 
 ---
 
-### Task 3: Require exact Daily reads and add privacy-safe viewer metadata
+### Task 3: Require exact Daily reads and reuse middleware viewer identity
 
 **Files:**
+- Modify: `src/lib/server/validations.ts`
+- Modify: `src/lib/server/validations.test.ts`
 - Modify: `src/pages/api/leaderboard.ts`
 - Modify: `src/pages/api/leaderboard.test.ts`
 
 **Interfaces:**
 
-- `getScopedGameLeaderboard()` remains:
+- `ScopedLeaderboardQuery` remains unchanged.
+- All scoped API rows gain `isCurrentUser: boolean`.
+- All scoped API responses gain `viewerAuthenticated: boolean`.
+- Unscoped responses remain unchanged.
 
-```ts
-getScopedGameLeaderboard({
-    gameId,
-    mode,
-    competitionKey,
-    limit,
-})
+- [ ] **Step 1: Add the Ice Slide Daily presence rule to `leaderboardQuerySchema` tests**
+
+Add tests for:
+
+```text
+?gameId=ice_slide&mode=daily                            -> invalid
+?gameId=ice_slide&mode=daily&competitionKey=<key>      -> valid
+?gameId=tetris&mode=daily                              -> still valid
 ```
 
-No `rulesetVersion` field is added.
+The valid exact key may use `ice-slide:daily:2026-08-12:g1:r1`; grammar semantics are route-owned, so the validation test only proves presence/transport relationships.
 
-- Every scoped API row gains `isCurrentUser: boolean`.
-- Every scoped API response gains `viewerAuthenticated: boolean`.
-- Unscoped Campaign response shape remains unchanged.
+- [ ] **Step 2: Run validation tests and confirm red**
 
-- [ ] **Step 1: Update test mocks before adding new assertions**
+```bash
+bun run test:run src/lib/server/validations.test.ts
+```
 
-In `leaderboard.test.ts`, extend the mocked `GameID` immediately:
+Expected: FAIL because Ice Slide Daily does not yet require `competitionKey`.
+
+- [ ] **Step 3: Extend `leaderboardQuerySchema.superRefine()`**
+
+After the existing generic relationship rules, add:
+
+```ts
+// Ice Slide Daily additionally requires an exact competition key; the
+// route validates that key's game-domain grammar with parseIceSlideDailyRunKey().
+if (
+    data.gameId === GameID.ICE_SLIDE &&
+    data.mode === 'daily' &&
+    !data.competitionKey
+) {
+    ctx.addIssue({
+        code: 'custom',
+        path: ['competitionKey'],
+        message: 'competitionKey is required for Ice Slide Daily',
+    })
+}
+```
+
+Do not import the Ice Slide parser into generic validation code.
+
+- [ ] **Step 4: Update leaderboard test setup before adding viewer tests**
+
+The file-level game mock must include:
 
 ```ts
 GameID: {
     TETRIS: 'tetris',
     ICE_SLIDE: 'ice_slide',
-},
+}
 ```
 
-Add the file-level auth mock, matching `scores.test.ts`:
+Add an Ice Slide game to `getAllGames()` fixtures.
+
+Do **not** add `vi.mock('@/lib/auth')`; the route will not import auth.
+
+Create a minimal route-context helper:
 
 ```ts
-vi.mock('@/lib/auth', () => ({
-    auth: {
-        api: {
-            getSession: vi.fn(),
-        },
-    },
-}))
+const routeContext = (
+    url: string,
+    user: { id: string } | null = null
+) =>
+    ({
+        url: new URL(url),
+        locals: { user, session: null },
+    }) as never
 ```
 
-Import `auth` for `vi.mocked(auth.api.getSession)` assertions.
+Update every existing direct `GET({ url } as ...)` in this test file to include `locals` through the helper or an equivalent explicit object. No production `undefined` compatibility path is added just for old tests.
 
-Update `beforeEach()` so auth defaults to signed out:
+- [ ] **Step 5: Add exact-key semantic read tests**
+
+Add:
+
+- calendar-invalid key returns 400 and does not call `getScopedGameLeaderboard`;
+- valid key calls the unchanged query with exactly:
 
 ```ts
-vi.mocked(auth.api.getSession).mockResolvedValue(null)
-```
-
-Do this before writing Ice Slide assertions; otherwise importing real `auth.ts` requires secrets and the Tetris-only `GameID` mock makes the Daily branch unreachable.
-
-- [ ] **Step 2: Update the existing scoped Tetris response assertion for additive viewer fields**
-
-The current mode-only Tetris scoped request remains valid. Its response now intentionally contains:
-
-```ts
-expect(body.viewerAuthenticated).toBe(false)
-expect(body.leaderboard).toEqual([
-    {
-        rank: 1,
-        name: 'Player',
-        username: 'player',
-        image: null,
-        score: 500,
-        created_at: '2026-08-01T00:00:00.000Z',
-        mode: 'daily',
-        competitionKey: null,
-        rulesetVersion: 2,
-        elapsedSeconds: 12,
-        totalMoves: 34,
-        isCurrentUser: false,
-    },
-])
-```
-
-This is an additive scoped contract change. Do not weaken the unscoped shape assertions.
-
-- [ ] **Step 3: Add Ice Slide Daily read-admission tests**
-
-Mock an Ice Slide game entry and assert:
-
-```text
-GET /api/leaderboard?gameId=ice_slide&mode=daily
-=> 400, query not called
-```
-
-```text
-GET /api/leaderboard?gameId=ice_slide&mode=daily&competitionKey=ice-slide:daily:2026-02-29:g1:r1
-=> 400, query not called
-```
-
-For a valid key:
-
-```ts
-expect(getScopedGameLeaderboard).toHaveBeenCalledWith({
+{
     gameId: 'ice_slide',
     mode: 'daily',
     competitionKey: 'ice-slide:daily:2026-08-12:g1:r1',
     limit: 10,
-})
-```
-
-Retain the existing generic mode-only Tetris test and assert it still forwards:
-
-```ts
-{
-    gameId: 'tetris',
-    mode: 'daily',
-    competitionKey: undefined,
-    limit: 10,
 }
 ```
 
-- [ ] **Step 4: Add authenticated, signed-out, and auth-failure viewer tests**
+- existing Tetris mode-only scoped request still calls the unchanged query with `competitionKey: undefined`.
 
-The route signature will use `{ url, request }`, so new scoped tests pass a real request:
+- [ ] **Step 6: Add viewer metadata tests from `locals.user`**
 
-```ts
-const url = new URL(
-    'http://localhost/api/leaderboard?gameId=ice_slide&mode=daily&competitionKey=ice-slide%3Adaily%3A2026-08-12%3Ag1%3Ar1'
-)
-const request = new Request(url)
-const response = await GET({ url, request } as never)
-```
-
-For a private row `userId:'u1'`, mock:
-
-```ts
-vi.mocked(auth.api.getSession).mockResolvedValue({
-    user: { id: 'u1' },
-    session: {},
-} as never)
-```
-
-Assert:
+For a scoped row whose private `userId` is `u1`, call with `locals.user = { id: 'u1' }` and assert:
 
 ```ts
 expect(body.viewerAuthenticated).toBe(true)
@@ -586,46 +677,46 @@ expect(body.leaderboard[0]).toMatchObject({
 expect(body.leaderboard[0]).not.toHaveProperty('userId')
 ```
 
-Then cover:
+Call the same scoped query with `locals.user = null` and assert:
 
-- `getSession -> null`: 200, `viewerAuthenticated:false`, all `isCurrentUser:false`;
-- `getSession` rejects: same public 200/false behavior;
-- `GET ?gameId=ice_slide` unscoped: no `viewerAuthenticated`, no `isCurrentUser`, and auth lookup is not required.
+```ts
+expect(body.viewerAuthenticated).toBe(false)
+expect(body.leaderboard[0].isCurrentUser).toBe(false)
+```
 
-- [ ] **Step 5: Run the API suite and confirm red**
+Update the existing scoped Tetris `toEqual` assertion to include `viewerAuthenticated` and `isCurrentUser` because those fields are intentionally additive to all scoped responses.
+
+Assert an unscoped game response does **not** gain either field.
+
+- [ ] **Step 7: Run API tests and confirm new cases red**
 
 ```bash
 bun run test:run src/pages/api/leaderboard.test.ts
 ```
 
-Expected: the new exact-key and viewer-metadata assertions FAIL.
+Expected: exact-key semantic and viewer metadata assertions FAIL before route changes.
 
-- [ ] **Step 6: Implement exact Ice Slide Daily admission without changing the query contract**
+- [ ] **Step 8: Implement route semantics using `locals`**
 
 Change the route signature:
 
 ```ts
-export const GET: APIRoute = async ({ url, request }) => {
+export const GET: APIRoute = async ({ url, locals }) => {
 ```
 
-Import `GameID`, `parseIceSlideDailyRunKey`, and `auth`.
-
-Before the scoped query:
+The schema already guarantees key presence for Ice Slide Daily. In the scoped branch, keep a semantic companion comment and validate grammar:
 
 ```ts
+// leaderboardQuerySchema requires the key's presence for Ice Slide Daily;
+// this route validates the Ice Slide domain grammar/calendar semantics.
 if (gameId === GameID.ICE_SLIDE && mode === 'daily') {
-    if (!competitionKey) {
-        return badRequestResponse(
-            'competitionKey is required for Ice Slide Daily'
-        )
-    }
-    if (!parseIceSlideDailyRunKey(competitionKey)) {
+    if (!competitionKey || !parseIceSlideDailyRunKey(competitionKey)) {
         return badRequestResponse('Invalid Ice Slide Daily competitionKey')
     }
 }
 ```
 
-Keep the existing call shape exactly:
+Call the existing query unchanged:
 
 ```ts
 const scoped = await getScopedGameLeaderboard({
@@ -636,30 +727,10 @@ const scoped = await getScopedGameLeaderboard({
 })
 ```
 
-- [ ] **Step 7: Add best-effort viewer lookup only after a successful scoped query**
-
-Use a helper that tolerates older tests passing no `request`:
+After success:
 
 ```ts
-async function getViewerUserId(
-    request: Request | undefined
-): Promise<string | null> {
-    if (!request) {
-        return null
-    }
-    try {
-        const session = await auth.api.getSession({ headers: request.headers })
-        return session?.user.id ?? null
-    } catch {
-        return null
-    }
-}
-```
-
-After `scoped.success`:
-
-```ts
-const viewerUserId = await getViewerUserId(request)
+const viewerUserId = locals.user?.id ?? null
 const leaderboard = scoped.rows.map((row, index) => ({
     rank: index + 1,
     ...toPublicScopedLeaderboardEntry(row),
@@ -674,29 +745,29 @@ return jsonResponse({
 })
 ```
 
-Do not run auth lookup for unscoped responses and do not expose `userId`.
+Do not import `auth`, do not thread `request`, and do not add `getViewerUserId()`.
 
-- [ ] **Step 8: Run API plus unchanged DB-ranking regressions**
+- [ ] **Step 9: Run validation/API regressions**
 
 ```bash
 bun run test:run \
-  src/pages/api/leaderboard.test.ts \
-  src/lib/server/db/scoped-leaderboard.integration.test.ts \
-  src/lib/server/validations.test.ts
+  src/lib/server/validations.test.ts \
+  src/pages/api/leaderboard.test.ts
 ```
 
-Expected: PASS. The DB file is included only to prove HPA-484's best-per-user/tie-break query remains unchanged and green.
+Expected: PASS, including generic Tetris mode-only behavior and unscoped Campaign response contracts.
 
-- [ ] **Step 9: Commit**
+- [ ] **Step 10: Commit**
 
 ```bash
-git add src/pages/api/leaderboard.ts src/pages/api/leaderboard.test.ts
+git add src/lib/server/validations.ts src/lib/server/validations.test.ts \
+  src/pages/api/leaderboard.ts src/pages/api/leaderboard.test.ts
 git commit -m "feat(ice-slide): scope Daily leaderboard reads"
 ```
 
 ---
 
-### Task 4: Put Daily leaderboard async/render state in a unit-tested game module
+### Task 4: Add a unit-tested Daily leaderboard controller and post-save refresh seam
 
 **Files:**
 - Create: `src/lib/games/ice-slide/daily-leaderboard.ts`
@@ -707,14 +778,6 @@ git commit -m "feat(ice-slide): scope Daily leaderboard reads"
 - Modify: `src/pages/game-board-markup.test.ts`
 
 **Interfaces:**
-
-`IceSlideUICallbacks` gains:
-
-```ts
-onScoreSaved?: (gameData: IceSlideGameData) => void
-```
-
-The new module exports:
 
 ```ts
 export interface DailyLeaderboardEntry {
@@ -737,78 +800,42 @@ export type DailyLeaderboardPanelState =
     | 'unavailable'
     | 'rows'
 
-export interface DailyLeaderboardElements {
-    panel: HTMLElement
-    date: HTMLElement
-    signedOut: HTMLElement
-    loading: HTMLElement
-    empty: HTMLElement
-    unavailable: HTMLElement
-    rows: HTMLElement
-}
+export function buildIceSlideDailyLeaderboardUrl(
+    competitionKey: string
+): string
 
-export interface DailyLeaderboardController {
+export function formatDailyLeaderboardElapsed(
+    seconds: number | null
+): string
+
+export function createDailyLeaderboardRowElement(
+    entry: DailyLeaderboardEntry,
+    document: Document
+): HTMLElement
+
+export function setDailyLeaderboardPanelState(
+    elements: DailyLeaderboardElements,
+    state: DailyLeaderboardPanelState
+): void
+
+export function createDailyLeaderboardController(
+    elements: DailyLeaderboardElements,
+    fetcher?: typeof fetch
+): {
     load: (competitionKey: string) => Promise<void>
     hide: () => void
 }
 ```
 
-Durable page IDs:
-
-```text
-daily-leaderboard
-daily-leaderboard-date
-daily-leaderboard-signed-out
-daily-leaderboard-loading
-daily-leaderboard-empty
-daily-leaderboard-unavailable
-daily-leaderboard-rows
-```
-
-- [ ] **Step 1: Add `init.test.ts` score-saved callback red tests**
-
-Reuse the existing mocked `saveGameScore` and add:
-
-1. current successful Daily save calls `onScoreSaved` once with the submitted `gameData`;
-2. `UNAUTHENTICATED`/other score error never calls it;
-3. if a newer run invalidates the run guard before the old success callback fires, the stale callback never reaches it.
-
-Match at least:
+`IceSlideUICallbacks` gains:
 
 ```ts
-expect(onScoreSaved).toHaveBeenCalledWith(
-    expect.objectContaining({
-        mode: 'daily',
-        solved: true,
-        runKey: 'ice-slide:daily:2026-08-12:g1:r1',
-        rulesetVersion: 1,
-    })
-)
+onScoreSaved?: (gameData: IceSlideGameData) => void
 ```
 
-- [ ] **Step 2: Run `init.test.ts` and confirm red**
+- [ ] **Step 1: Add controller helper tests before implementation**
 
-```bash
-bun run test:run src/lib/games/ice-slide/init.test.ts
-```
-
-Expected: FAIL because the callback does not exist/fire.
-
-- [ ] **Step 3: Add `onScoreSaved` and remove Ice Slide's duplicate formatter**
-
-Import `IceSlideGameData` for the callback type and `formatTime` from `../shared/utils`. Delete the local `formatTime()` implementation from `init.ts`.
-
-In the existing score success callback, after the stale check and achievement dispatch:
-
-```ts
-callbacks.onScoreSaved?.(gameData)
-```
-
-Do not fetch leaderboard data from `init.ts`.
-
-- [ ] **Step 4: Write failing unit tests for `daily-leaderboard.ts`**
-
-Create a jsdom fixture with all seven elements. Tests must cover:
+In `daily-leaderboard.test.ts`, mount the seven required static elements and test:
 
 ```ts
 expect(
@@ -819,23 +846,54 @@ expect(
     '/api/leaderboard?gameId=ice_slide&mode=daily&competitionKey=' +
         'ice-slide%3Adaily%3A2026-08-12%3Ag1%3Ar1&limit=10'
 )
-
-expect(formatDailyLeaderboardElapsed(null)).toBe('—')
-expect(formatDailyLeaderboardElapsed(87)).toBe('1:27')
 ```
 
-For row construction, assert a current-user row contains rank/name/formatted score/elapsed/moves plus literal `YOU`, and a non-current row does not contain `YOU`.
+Elapsed formatting:
 
-For state toggling, assert exactly one of loading/empty/unavailable/rows is visible for each `DailyLeaderboardPanelState`.
+```ts
+expect(formatDailyLeaderboardElapsed(null)).toBe('—')
+expect(formatDailyLeaderboardElapsed(87)).toBe('1:27')
+expect(formatDailyLeaderboardElapsed(3665)).toBe('1:01:05')
+```
 
-For the controller:
+The `3665` assertion belongs to the **new leaderboard formatter only**. Do not assert/change the existing in-run HUD's private `M:SS` formatter.
 
-- a successful empty signed-out response shows panel/date/signed-out + empty state;
-- a 503 shows unavailable without throwing;
-- a delayed response resolved after `hide()` does not append rows or unhide the panel;
-- a delayed older load resolved after a newer load cannot replace the newer date/rows.
+Row rendering must assert rank, player, localized score text, elapsed, moves, and a literal `YOU` badge for `isCurrentUser=true`, using `textContent`/children rather than `innerHTML`.
 
-- [ ] **Step 5: Run the new module suite and confirm red**
+- [ ] **Step 2: Add controller-state tests**
+
+Test `loading`, `empty`, `unavailable`, and `rows` visibility toggles through `setDailyLeaderboardPanelState()`.
+
+Add a successful load using a mocked fetcher and assert:
+
+- panel becomes visible;
+- date is derived from `parseIceSlideDailyRunKey()`;
+- signed-out note follows `viewerAuthenticated`;
+- rows are replaced, not appended across refreshes.
+
+Add an invalid-key load:
+
+```ts
+await controller.load('not-a-daily-key')
+expect(unavailable).not.toHaveClass('hidden')
+expect(rows).toHaveClass('hidden')
+```
+
+This must not silently leave previous ranking rows visible.
+
+- [ ] **Step 3: Add delayed stale-response coverage**
+
+Use two deferred fetch responses:
+
+1. call `load(oldKey)`;
+2. call `load(newKey)` before the first resolves;
+3. resolve the new request with `New Pilot`;
+4. resolve the old request with `Old Pilot`;
+5. assert only `New Pilot` remains.
+
+Then test `hide()` while a request is pending; releasing that request must not reveal the panel or render its row.
+
+- [ ] **Step 4: Run the new module test and confirm red**
 
 ```bash
 bun run test:run src/lib/games/ice-slide/daily-leaderboard.test.ts
@@ -843,24 +901,16 @@ bun run test:run src/lib/games/ice-slide/daily-leaderboard.test.ts
 
 Expected: FAIL because the module does not exist.
 
-- [ ] **Step 6: Implement the focused helper module**
+- [ ] **Step 5: Implement `daily-leaderboard.ts` minimally**
 
-Use `formatTime` from `../shared/utils`, `GameID.ICE_SLIDE`, and `parseIceSlideDailyRunKey`.
-
-URL builder:
+Import:
 
 ```ts
-export function buildIceSlideDailyLeaderboardUrl(
-    competitionKey: string
-): string {
-    return (
-        `/api/leaderboard?gameId=${GameID.ICE_SLIDE}&mode=daily&` +
-        `competitionKey=${encodeURIComponent(competitionKey)}&limit=10`
-    )
-}
+import { formatTime } from '../shared/utils'
+import { parseIceSlideDailyRunKey } from './run'
 ```
 
-Elapsed wrapper:
+`formatDailyLeaderboardElapsed()` is:
 
 ```ts
 export function formatDailyLeaderboardElapsed(
@@ -870,98 +920,35 @@ export function formatDailyLeaderboardElapsed(
 }
 ```
 
-State helper:
+`load()` increments/captures one request token before parsing. If parsing fails, show the panel and set `unavailable`. For valid keys, set the date/loading state, fetch the exact URL, re-check the token after `fetch()` and after `json()`, then render current data only.
+
+`hide()` increments the token before adding `hidden` to the panel.
+
+Do not add `AbortController`, a class hierarchy, a store, or an event bus.
+
+- [ ] **Step 6: Add `onScoreSaved` unit coverage to `init.test.ts`**
+
+Reuse the existing mocked `saveGameScore`. Add:
+
+1. current successful Daily save calls `onScoreSaved` once with game data containing `mode:'daily'`, `solved:true`, and the captured `runKey`;
+2. `UNAUTHENTICATED` and generic score errors never call it;
+3. starting a newer run before an older mocked success callback fires suppresses the stale callback.
+
+- [ ] **Step 7: Implement the callback in `init.ts`**
+
+Import `IceSlideGameData` only for the callback type. In the existing score success callback, after the run-guard stale check and achievement dispatch:
 
 ```ts
-export function setDailyLeaderboardPanelState(
-    elements: DailyLeaderboardElements,
-    state: DailyLeaderboardPanelState
-): void {
-    elements.loading.classList.toggle('hidden', state !== 'loading')
-    elements.empty.classList.toggle('hidden', state !== 'empty')
-    elements.unavailable.classList.toggle('hidden', state !== 'unavailable')
-    elements.rows.classList.toggle('hidden', state !== 'rows')
-}
+callbacks.onScoreSaved?.(gameData)
 ```
 
-`createDailyLeaderboardRowElement()` must use `document.createElement`, `textContent`, and classes only; never `innerHTML`. Format scores with `toLocaleString()`. Render a literal `YOU` badge only for `isCurrentUser`.
+Do not fetch a leaderboard from `init.ts`.
 
-Implement `createDailyLeaderboardController(elements, fetcher = fetch)` as one closure with `let requestToken = 0`:
+Do not remove or replace the existing private `formatTime()`; HPA-488 leaves in-run HUD formatting unchanged.
 
-```ts
-export function createDailyLeaderboardController(
-    elements: DailyLeaderboardElements,
-    fetcher: typeof fetch = fetch
-): DailyLeaderboardController {
-    let requestToken = 0
+- [ ] **Step 8: Add the static Astro card and markup IDs**
 
-    return {
-        async load(competitionKey) {
-            const identity = parseIceSlideDailyRunKey(competitionKey)
-            if (!identity) {
-                return
-            }
-
-            const token = ++requestToken
-            elements.panel.classList.remove('hidden')
-            elements.date.textContent = identity.dateKey
-            elements.signedOut.classList.add('hidden')
-            setDailyLeaderboardPanelState(elements, 'loading')
-
-            try {
-                const response = await fetcher(
-                    buildIceSlideDailyLeaderboardUrl(competitionKey)
-                )
-                if (token !== requestToken) {
-                    return
-                }
-                if (!response.ok) {
-                    setDailyLeaderboardPanelState(elements, 'unavailable')
-                    return
-                }
-
-                const data =
-                    (await response.json()) as DailyLeaderboardResponse
-                if (token !== requestToken) {
-                    return
-                }
-
-                while (elements.rows.firstChild) {
-                    elements.rows.removeChild(elements.rows.firstChild)
-                }
-                for (const entry of data.leaderboard) {
-                    elements.rows.appendChild(
-                        createDailyLeaderboardRowElement(entry, document)
-                    )
-                }
-                elements.signedOut.classList.toggle(
-                    'hidden',
-                    data.viewerAuthenticated
-                )
-                setDailyLeaderboardPanelState(
-                    elements,
-                    data.leaderboard.length > 0 ? 'rows' : 'empty'
-                )
-            } catch {
-                if (token === requestToken) {
-                    setDailyLeaderboardPanelState(elements, 'unavailable')
-                }
-            }
-        },
-
-        hide() {
-            requestToken += 1
-            elements.panel.classList.add('hidden')
-        },
-    }
-}
-```
-
-Do not add `AbortController`, a store, event bus, class hierarchy, or generic leaderboard abstraction.
-
-- [ ] **Step 7: Add the static Astro card and structural markup assertions**
-
-Place below `#daily-meta`:
+Place directly below `#daily-meta`:
 
 ```astro
 <Card id="daily-leaderboard" variant="glass" class="hidden p-4">
@@ -987,159 +974,173 @@ Place below `#daily-meta`:
 </Card>
 ```
 
-Add all seven IDs to `src/pages/game-board-markup.test.ts`. Keep that test structural; behavior belongs in `daily-leaderboard.test.ts` and Playwright.
+Add all seven IDs to `src/pages/game-board-markup.test.ts`. Keep that test structural; do not assert Astro script source text.
 
-- [ ] **Step 8: Make the Astro script wiring-only**
+- [ ] **Step 9: Wire the Astro page to the controller**
 
 Import:
 
 ```ts
-import {
-  createDailyLeaderboardController,
-  type DailyLeaderboardElements,
-} from '@/lib/games/ice-slide/daily-leaderboard'
+import { createDailyLeaderboardController } from '@/lib/games/ice-slide/daily-leaderboard'
 import {
   createIceSlideDailyCompetitionKey,
   toIceSlideUtcDateKey,
 } from '@/lib/games/ice-slide/daily'
 ```
 
-Query the seven elements, build `DailyLeaderboardElements`, and instantiate one controller. Keep page helpers limited to identity handoff:
+Build the `DailyLeaderboardElements` object from the static IDs and construct one controller.
 
-```ts
-const currentUtcDailyKey = () =>
-  createIceSlideDailyCompetitionKey(toIceSlideUtcDateKey(new Date()))
+Use these transitions:
 
-const loadCurrentDailyLeaderboard = () =>
-  dailyLeaderboardController.load(currentUtcDailyKey())
+- after page init, if Daily is selected, `controller.load(currentUtcDailyKey())`;
+- idle radio change to Daily loads current UTC key;
+- idle radio change to Campaign calls `controller.hide()`;
+- after `await gameHandle.start('daily')`, load `gameHandle.getGame()?.getState().runKey`;
+- after Daily `playAgain()`, load the game's still-captured run key;
+- `onScoreSaved(gameData)` loads `gameData.runKey` only when `gameData.mode === 'daily'`;
+- Change Mode hides or loads based on the still-selected radio.
 
-const loadCapturedDailyLeaderboard = () => {
-  const state = gameHandle?.getGame()?.getState()
-  if (state?.mode === 'daily') {
-    void dailyLeaderboardController.load(state.runKey)
-  }
-}
-```
+The page does not duplicate URL construction, parsing, token logic, row creation, or formatting.
 
-Wire exact transitions:
-
-- after initialization, if selected radio is Daily, load today's key;
-- idle radio change to Daily -> load today's key;
-- idle radio change to Campaign -> `hide()`;
-- after successful `await gameHandle.start('daily')` -> load captured `state.runKey`;
-- after successful Daily `playAgain()` -> load captured `state.runKey`;
-- `onScoreSaved(gameData)` -> if `gameData.mode === 'daily'`, load `gameData.runKey`;
-- Change Mode -> return to idle controls; if selected radio is Daily load today's current key, otherwise hide;
-- leaderboard errors remain inside the controller and never touch `#game-error`/`failRun`.
-
-This keeps rollover behavior correct: in-progress/post-save refresh uses captured identity; idle selection uses the current UTC identity.
-
-- [ ] **Step 9: Run focused DOM/client/init suites**
+- [ ] **Step 10: Run Task 4 unit/markup verification**
 
 ```bash
 bun run test:run \
-  src/lib/games/ice-slide/init.test.ts \
   src/lib/games/ice-slide/daily-leaderboard.test.ts \
+  src/lib/games/ice-slide/init.test.ts \
   src/pages/game-board-markup.test.ts
 ```
 
-Expected: PASS, including stale-response tests before browser coverage runs.
+Expected: PASS.
 
-- [ ] **Step 10: Commit**
+**Coverage boundary:** these tests execute the controller, callback, and durable markup. They do **not** execute the inline Astro event wiring from Step 9. Task 5 Playwright is intentionally the first executable proof that the page wiring connects those tested seams correctly.
+
+- [ ] **Step 11: Commit**
 
 ```bash
-git add src/lib/games/ice-slide/init.ts src/lib/games/ice-slide/init.test.ts \
-  src/lib/games/ice-slide/daily-leaderboard.ts \
+git add src/lib/games/ice-slide/daily-leaderboard.ts \
   src/lib/games/ice-slide/daily-leaderboard.test.ts \
+  src/lib/games/ice-slide/init.ts src/lib/games/ice-slide/init.test.ts \
   src/pages/ice-slide/index.astro src/pages/game-board-markup.test.ts
 git commit -m "feat(ice-slide): show Daily leaderboard"
 ```
 
 ---
 
-### Task 5: Lock the frozen Daily playthrough before using it in Playwright
+### Task 5: Share one frozen playthrough fixture, prove page wiring, and run repository gates
 
 **Files:**
+- Modify: `src/lib/games/ice-slide/test-fixtures.ts`
 - Modify: `src/lib/games/ice-slide/daily.test.ts`
 - Modify: `e2e/games/play-coverage.spec.ts`
 
 **Interfaces:**
-- Consumes the exact HPA-487 generator-v1 fixture for `2026-08-12`.
-- No production interface changes.
-
-- [ ] **Step 1: Add a unit replay for the exact five browser sequences**
-
-In `daily.test.ts`, import `IceSlideGame` and `Direction`. Lock the exact directions:
 
 ```ts
-const DAILY_2026_08_12_DIRECTIONS: readonly (readonly Direction[])[] = [
+export const ICE_SLIDE_DAILY_2026_08_12_DIRECTIONS = [
     ['S', 'E', 'S'],
     ['N', 'W', 'N', 'W'],
     ['W', 'N', 'E', 'S', 'W', 'N'],
     ['S', 'W', 'N', 'E', 'S', 'W'],
     ['E', 'S', 'W', 'N', 'E', 'S'],
-]
+] as const satisfies readonly (readonly Direction[])[]
 ```
 
-Replay them through the real game/runtime contract:
+- [ ] **Step 1: Put the direction fixture in `test-fixtures.ts` once**
+
+Import `Direction` as a type and export the constant above.
+
+Do not export browser key strings from the source fixture; it remains game-domain directions only.
+
+- [ ] **Step 2: Unit-replay the shared fixture before Playwright consumes it**
+
+In `daily.test.ts`, import:
 
 ```ts
-it('locks the 2026-08-12 browser playthrough against the materialized Daily', () => {
-    const run = createIceSlideDailyRunDefinition('2026-08-12')
-    const game = new IceSlideGame()
+import { IceSlideGame } from './game'
+import { solveIceSlideBoard } from './solver'
+import { ICE_SLIDE_DAILY_2026_08_12_DIRECTIONS } from './test-fixtures'
+```
 
-    try {
-        game.start(run)
-        for (const [stageIndex, directions] of
-            DAILY_2026_08_12_DIRECTIONS.entries()) {
-            expect(directions).toHaveLength(run.stages[stageIndex].parMoves)
-            for (const direction of directions) {
-                game.move(direction)
-            }
+Add:
+
+```ts
+it('locks the shared 2026-08-12 minimum-move completion fixture', () => {
+    const run = createIceSlideDailyRunDefinition('2026-08-12')
+    expect(ICE_SLIDE_DAILY_2026_08_12_DIRECTIONS).toHaveLength(
+        run.stages.length
+    )
+
+    const game = new IceSlideGame()
+    game.start(run)
+
+    for (const [stageIndex, directions] of
+        ICE_SLIDE_DAILY_2026_08_12_DIRECTIONS.entries()) {
+        const stage = run.stages[stageIndex]
+        const solved = solveIceSlideBoard(stage, {
+            maxStates: ICE_SLIDE_DAILY_SOLVER_MAX_STATES,
+        })
+        expect(solved.truncated).toBe(false)
+        expect(solved.minMoves).toBe(directions.length)
+
+        for (const direction of directions) {
+            game.move(direction)
         }
 
-        expect(game.getState().status).toBe('won')
-        expect(game.getGameData()).toMatchObject({
-            mode: 'daily',
-            runKey: 'ice-slide:daily:2026-08-12:g1:r1',
-            solved: true,
-            levelsCleared: 5,
-        })
-    } finally {
-        game.destroy()
+        if (stageIndex < run.stages.length - 1) {
+            expect(game.getState().levelIndex).toBe(stageIndex + 1)
+            expect(game.getState().status).toBe('playing')
+        }
     }
+
+    expect(game.getState().status).toBe('won')
+    expect(game.getGameData().solved).toBe(true)
+    game.destroy()
 })
 ```
 
-Stages 3 and 4 have `collect_all_crystals` as an optional bonus. The test requires a completed run, not all optional stars; this directly validates the same crystal-mutating runtime that Playwright will drive.
+This validates the exact shared directions and their minimum-move lengths. It does not claim every optional star is earned.
 
-- [ ] **Step 2: Run the unit fixture before adding browser dependence**
+- [ ] **Step 3: Run the unit consumer first**
 
 ```bash
 bun run test:run src/lib/games/ice-slide/daily.test.ts
 ```
 
-Expected: PASS. If any sequence is wrong, correct it here first; do not discover the mistake for the first time in Playwright.
+Expected: PASS before any browser test uses the fixture. If it fails, fix the fixture here rather than debugging an opaque Playwright failure.
 
-- [ ] **Step 3: Add the matching Playwright helper**
+- [ ] **Step 4: Import the same fixture in Playwright and derive keys**
 
-Use the exact arrow-key translation of the unit fixture:
+At the top of `e2e/games/play-coverage.spec.ts`:
 
 ```ts
-const DAILY_2026_08_12_SOLUTIONS = [
-    ['ArrowDown', 'ArrowRight', 'ArrowDown'],
-    ['ArrowUp', 'ArrowLeft', 'ArrowUp', 'ArrowLeft'],
-    ['ArrowLeft', 'ArrowUp', 'ArrowRight', 'ArrowDown', 'ArrowLeft', 'ArrowUp'],
-    ['ArrowDown', 'ArrowLeft', 'ArrowUp', 'ArrowRight', 'ArrowDown', 'ArrowLeft'],
-    ['ArrowRight', 'ArrowDown', 'ArrowLeft', 'ArrowUp', 'ArrowRight', 'ArrowDown'],
-] as const
+import { ICE_SLIDE_DAILY_2026_08_12_DIRECTIONS } from '../../src/lib/games/ice-slide/test-fixtures'
+```
+
+Inside the Ice Slide test section:
+
+```ts
+const DIRECTION_TO_KEY = {
+    N: 'ArrowUp',
+    E: 'ArrowRight',
+    S: 'ArrowDown',
+    W: 'ArrowLeft',
+} as const
 
 async function completeFrozenDaily(page: Page): Promise<void> {
-    for (let stage = 0; stage < DAILY_2026_08_12_SOLUTIONS.length; stage++) {
-        for (const key of DAILY_2026_08_12_SOLUTIONS[stage]) {
-            await page.keyboard.press(key)
+    for (
+        let stage = 0;
+        stage < ICE_SLIDE_DAILY_2026_08_12_DIRECTIONS.length;
+        stage++
+    ) {
+        for (const direction of
+            ICE_SLIDE_DAILY_2026_08_12_DIRECTIONS[stage]) {
+            await page.keyboard.press(DIRECTION_TO_KEY[direction])
         }
-        if (stage < DAILY_2026_08_12_SOLUTIONS.length - 1) {
+        if (
+            stage <
+            ICE_SLIDE_DAILY_2026_08_12_DIRECTIONS.length - 1
+        ) {
             await expect(page.locator('#stage-clear-overlay')).toBeVisible()
             await page.locator('#stage-clear-continue-btn').click()
         }
@@ -1148,11 +1149,13 @@ async function completeFrozenDaily(page: Page): Promise<void> {
 }
 ```
 
-- [ ] **Step 4: Cover signed-out/empty and ranked-current-user rendering**
+Do not hardcode a second arrow-key sequence array.
 
-With fixed time `2026-08-12T20:00:00Z`, intercept `**/api/leaderboard?*`.
+- [ ] **Step 5: Cover signed-out/empty and viewer-row rendering**
 
-Empty signed-out response:
+Fix time to `2026-08-12T20:00:00Z` and route `**/api/leaderboard?*`.
+
+Empty response:
 
 ```json
 {
@@ -1163,9 +1166,13 @@ Empty signed-out response:
 }
 ```
 
-Assert the request contains exact competition key `ice-slide:daily:2026-08-12:g1:r1`, the empty state is visible, and the sign-in note is visible.
+Assert:
 
-Current-user row response:
+- request key equals `ice-slide:daily:2026-08-12:g1:r1`;
+- empty state visible;
+- signed-out note visible.
+
+Viewer response:
 
 ```json
 {
@@ -1183,49 +1190,49 @@ Current-user row response:
 }
 ```
 
-Assert rows show `1`, `Pilot`, `4,321`, `1:27`, `31`, and visible `YOU` text.
+Assert row text includes `1`, `Pilot`, `4,321`, `1:27`, `31`, and visible `YOU`.
 
-- [ ] **Step 5: Cover unavailable ranking without blocking play**
+- [ ] **Step 6: Cover leaderboard unavailable without blocking play**
 
-Return status 503 with the normal scoped-unavailable body. Assert `#daily-leaderboard-unavailable` is visible, then start Daily and verify the Pixi canvas and `#end-btn` remain usable. `#game-error` must stay hidden for a leaderboard-only failure.
+Return 503 for the leaderboard route with the existing coded scoped-unavailable body. Assert `#daily-leaderboard-unavailable` is visible, then Start Daily and verify the Pixi canvas plus `#end-btn` remain usable. The generic `#game-error` surface must stay hidden for a leaderboard-only failure.
 
-- [ ] **Step 6: Cover successful-submit refresh on the captured key**
+- [ ] **Step 7: Cover successful-submit refresh on the captured key**
 
-Mock `/api/scores` with a 200 success body and count leaderboard requests. Start the fixed-date Daily, record the request count, call `completeFrozenDaily(page)`, then assert a later request occurs and its `competitionKey` remains:
+Mock `/api/scores` with a 200 success body and count leaderboard requests. Start fixed-date Daily, record the current request count, call `completeFrozenDaily(page)`, then assert another leaderboard fetch occurs and its exact key remains:
 
 ```text
 ice-slide:daily:2026-08-12:g1:r1
 ```
 
-Inspect the POST once and assert:
+Inspect the POST body once and assert:
 
 ```ts
-context.mode === 'daily'
-context.competitionKey === 'ice-slide:daily:2026-08-12:g1:r1'
-gameData.solved === true
+expect(body.context).toMatchObject({
+    mode: 'daily',
+    competitionKey: 'ice-slide:daily:2026-08-12:g1:r1',
+    rulesetVersion: 1,
+})
+expect(body.gameData.solved).toBe(true)
 ```
 
-This proves `onScoreSaved` refreshes the captured competition rather than recomputing today's identity.
+- [ ] **Step 8: Cover delayed stale-response suppression through real page wiring**
 
-- [ ] **Step 7: Keep one browser integration proof for stale suppression**
-
-Delay one Daily leaderboard response. While pending, switch the idle mode selection to Campaign. Release the old response and assert:
+Delay a Daily leaderboard response. While it is pending, switch idle mode selection to Campaign. Release the delayed response and assert:
 
 - `#daily-leaderboard` remains hidden;
-- delayed row text never appears;
-- Campaign remains selectable/startable.
+- delayed row text never appears.
 
-The detailed request-token semantics are already red/green in `daily-leaderboard.test.ts`; this test proves page wiring invokes invalidation correctly.
+This proves the Astro wiring actually calls the controller's tested invalidation path. Do not add `AbortController` only for this test.
 
-- [ ] **Step 8: Run focused Ice Slide browser coverage**
+- [ ] **Step 9: Run focused Ice Slide browser coverage**
 
 ```bash
 bun run test:e2e -- e2e/games/play-coverage.spec.ts --grep "Ice Slide"
 ```
 
-Expected: all existing HPA-487 cases plus the new leaderboard cases PASS.
+Expected: all existing HPA-487 cases plus new leaderboard cases PASS.
 
-- [ ] **Step 9: Run focused unit/API/integration suites once more**
+- [ ] **Step 10: Run focused unit/API coverage once more**
 
 ```bash
 bun run test:run \
@@ -1233,15 +1240,15 @@ bun run test:run \
   src/lib/games/ice-slide/daily.test.ts \
   src/lib/games/ice-slide/init.test.ts \
   src/lib/games/ice-slide/daily-leaderboard.test.ts \
-  src/lib/server/db/scoped-leaderboard.integration.test.ts \
   src/pages/api/scores.test.ts \
+  src/lib/server/validations.test.ts \
   src/pages/api/leaderboard.test.ts \
   src/pages/game-board-markup.test.ts
 ```
 
 Expected: PASS.
 
-- [ ] **Step 10: Run full repository verification**
+- [ ] **Step 11: Run full repository verification**
 
 ```bash
 bun run test:run
@@ -1258,10 +1265,12 @@ Expected:
 - local coverage does not regress the repository below the configured 95% project target;
 - remote Codecov project and patch checks remain authoritative after push.
 
-- [ ] **Step 11: Commit the deterministic fixture and E2E coverage**
+- [ ] **Step 12: Commit the shared fixture/browser coverage**
 
 ```bash
-git add src/lib/games/ice-slide/daily.test.ts e2e/games/play-coverage.spec.ts
+git add src/lib/games/ice-slide/test-fixtures.ts \
+  src/lib/games/ice-slide/daily.test.ts \
+  e2e/games/play-coverage.spec.ts
 git commit -m "test(ice-slide): cover Daily leaderboard flows"
 ```
 
@@ -1269,10 +1278,12 @@ git commit -m "test(ice-slide): cover Daily leaderboard flows"
 
 ## Plan self-review
 
-- **Spec coverage:** Daily identity/admission, exact-key read isolation, unchanged best-per-user ranking, viewer highlighting, signed-out/loading/empty/unavailable states, successful-save refresh, stale suppression, Campaign compatibility, and failure isolation each map to a concrete task.
-- **Parser consistency:** `assertValidIceSlideRunDefinition`, `init.ts`, score admission, leaderboard admission, and client identity display all consume `parseIceSlideDailyRunKey`; `extractDailyDateKey` is removed.
-- **Query consistency:** no `ScopedLeaderboardQuery.rulesetVersion` field or duplicate ruleset filter is introduced; exact competition key is the Daily scope.
-- **Test seams:** score semantics live in a pure helper; async page behavior lives in `daily-leaderboard.ts`; the frozen browser keypresses are validated by a unit replay before Playwright.
-- **Existing-test compatibility:** the plan explicitly mocks `@/lib/auth`, adds `GameID.ICE_SLIDE`, threads `request`, and updates the existing scoped Tetris response for additive viewer fields.
+- **Spec coverage:** Daily identity, exact semantic admission, exact-key reads, best-per-user reuse, middleware viewer highlighting, signed-out/loading/empty/unavailable states, successful-save refresh, stale suppression, Campaign compatibility, and failure isolation each map to a concrete task.
+- **Reuse:** `getScopedGameLeaderboard()` stays unchanged; `locals.user` avoids a second auth lookup; shared `formatTime()` is used only for the new leaderboard; existing `test-fixtures.ts` owns the frozen playthrough once.
+- **Identity consistency:** `run.ts` owns parse + format grammar. `daily.ts` only supplies current generator/ruleset constants to the formatter. `init.ts`, writes, reads, and client display all parse through the same function.
+- **Admission consistency:** every semantic invariant has a distinct closed-union reason test, while the public API still emits one stable 400 body.
+- **Client test seam:** request-token/render logic is executed under jsdom in Task 4. Task 4 explicitly does not claim to execute Astro event wiring; Task 5 Playwright proves that integration.
+- **HUD compatibility:** HPA-488 does not change the existing Ice Slide in-run `M:SS` formatter; the shared formatter is used only by the new ranking panel.
+- **Fixture consistency:** one direction fixture feeds both the unit replay and browser key translation; Playwright does not own a duplicate sequence.
 - **Placeholder scan:** no TBD/TODO/future implementation step remains.
-- **Scope check:** no schema, endpoint family, shared UI abstraction, replay verifier, historical browser, Expedition ranking, read repair, or current-user rank query has entered the plan.
+- **Scope check:** no schema, endpoint family, ranking query change, auth preflight/lookup, shared UI abstraction, replay verifier, historical browser, Expedition ranking, or current-user rank query has entered the plan.

--- a/docs/superpowers/specs/2026-08-13-ice-slide-daily-leaderboard-design.md
+++ b/docs/superpowers/specs/2026-08-13-ice-slide-daily-leaderboard-design.md
@@ -10,15 +10,15 @@
 
 HPA-488 completes the competitive half of Ice Slide Daily without creating another leaderboard subsystem.
 
-HPA-484 already provides persisted score context plus a scoped best-per-user query. HPA-487 now submits completed Daily runs with `mode='daily'`, the captured run key as `competitionKey`, ruleset version, and full Ice Slide game data. The remaining work is narrow:
+HPA-484 already provides persisted score context plus a scoped best-per-user query. HPA-487 submits completed Daily runs with `mode='daily'`, the captured run key as `competitionKey`, ruleset version, and full Ice Slide game data. The remaining work is narrow:
 
-1. centralize the already-frozen Daily run/competition-key interpretation and remove the weaker `init.ts` date parser;
+1. centralize the frozen Daily run-key grammar and remove the weaker `init.ts` date parser;
 2. reject malformed or mismatched Ice Slide Daily score submissions before persistence;
-3. require an exact Daily competition key for Ice Slide Daily leaderboard reads while reusing HPA-484's query unchanged;
-4. add current-viewer metadata without exposing user IDs;
-5. render and refresh one Ice-Slide-specific Daily leaderboard through a small testable client module.
+3. require an exact Daily competition key for Ice Slide Daily leaderboard reads while leaving HPA-484's ranking query unchanged;
+4. derive current-viewer metadata from the authenticated user the middleware already stored in `Astro.locals`;
+5. render and refresh one Ice-Slide-specific Daily leaderboard through a small unit-tested client module.
 
-No new database table, endpoint family, ranking query, shared leaderboard framework, persistence service, or generic game-mode registry is needed.
+No new database table, endpoint family, ranking query, shared leaderboard framework, persistence service, auth round-trip, or generic game-mode registry is needed.
 
 ## 2. Goals
 
@@ -32,7 +32,8 @@ No new database table, endpoint family, ranking query, shared leaderboard framew
 - Refresh the active Daily ranking after a successful Daily score save.
 - Keep Campaign leaderboard behavior and `/api/leaderboard?gameId=ice_slide` unchanged.
 - Keep local Daily play/completion usable when score saving or leaderboard loading fails.
-- Give the page-local request-token/render behavior unit coverage rather than making Playwright its first proof.
+- Unit-test the page-local request-token/render behavior instead of making Playwright its first proof.
+- Keep one frozen `2026-08-12` direction fixture shared by its unit replay and Playwright consumer.
 
 ## 3. Non-goals
 
@@ -45,13 +46,14 @@ No new database table, endpoint family, ranking query, shared leaderboard framew
 - Cross-seed Expedition ranking.
 - A shared client leaderboard component for other games.
 - Changes to the global leaderboard page.
-- Read-repair or migration of any pre-HPA-488 malformed scoped rows.
+- Read-repair or migration of pre-HPA-488 malformed scoped rows.
+- Refactoring unrelated game time formatters.
 
 ## 4. Approaches considered
 
 ### A. Reuse the scoped query and specialize the existing score/leaderboard routes — selected
 
-Keep `/api/scores` and `/api/leaderboard` as the only network seams. Add Ice Slide Daily semantic checks to score admission, exact-key enforcement to the scoped leaderboard branch, and one Ice-Slide-specific client helper module for testable panel behavior.
+Keep `/api/scores` and `/api/leaderboard` as the only network seams. Add Ice Slide Daily semantic checks to score admission, exact-key enforcement to the existing leaderboard validation/route seam, and one Ice-Slide-specific client helper module for testable panel behavior.
 
 **Why selected:** it reuses every expensive piece already delivered by HPA-484, touches the fewest abstractions, and leaves generic scoped ranking available for future modes.
 
@@ -65,17 +67,17 @@ This would make the Daily contract obvious but duplicate request validation, ran
 
 This would avoid server changes but would allow malformed Daily submissions into persisted/ranked data and would keep the mode-only cross-date query footgun.
 
-**Rejected:** the ticket explicitly owns server admission and competitive isolation.
+**Rejected:** the ticket owns server admission and competitive isolation.
 
 ## 5. Competition identity contract
 
-The existing Daily run key is also the competition key:
+The Daily run key is also the competition key:
 
 ```text
 ice-slide:daily:YYYY-MM-DD:g<generatorVersion>:r<rulesetVersion>
 ```
 
-`run.ts` remains the single owner of that syntax. Export:
+`run.ts` owns both parsing and formatting of that grammar:
 
 ```ts
 export interface IceSlideDailyRunIdentity {
@@ -87,11 +89,15 @@ export interface IceSlideDailyRunIdentity {
 export function parseIceSlideDailyRunKey(
     runKey: string
 ): IceSlideDailyRunIdentity | null
+
+export function formatIceSlideDailyRunKey(
+    identity: IceSlideDailyRunIdentity
+): string
 ```
 
-The parser rejects malformed keys, trailing garbage, zero/non-positive versions, and calendar-invalid dates.
+`formatIceSlideDailyRunKey()` validates the UTC date and positive integer versions before returning the key. The parser rejects malformed keys, trailing garbage, non-positive versions, and calendar-invalid dates. Unit tests cover parse/format round trips.
 
-Every consumer that interprets a Daily key uses this parser:
+Every consumer that interprets a Daily key uses `parseIceSlideDailyRunKey()`:
 
 - `assertValidIceSlideRunDefinition()`;
 - the Ice Slide Daily score-admission helper;
@@ -113,23 +119,48 @@ parseIceSlideDailyRunKey(runKey)?.dateKey ?? null
 
 This prevents HUD and rollover logic from accepting a weaker key grammar than server admission.
 
-`daily.ts` also exports:
+`daily.ts` retains ownership of the current Daily generator version and imports `formatIceSlideDailyRunKey()` to expose the current-version convenience helper:
 
 ```ts
-export function createIceSlideDailyCompetitionKey(dateKey: string): string
+export function createIceSlideDailyCompetitionKey(dateKey: string): string {
+    return formatIceSlideDailyRunKey({
+        dateKey,
+        generatorVersion: ICE_SLIDE_DAILY_GENERATOR_VERSION,
+        rulesetVersion: ICE_SLIDE_RULESET_VERSION,
+    })
+}
 ```
 
-`createIceSlideDailyRunDefinition()` uses this helper for `run.runKey`. The idle Daily page uses the same helper to ask for the current UTC competition before a run starts. A started run still uses its captured `runKey`, so crossing UTC midnight cannot silently move the result to a new board.
+`createIceSlideDailyRunDefinition()` uses that helper for `run.runKey`. The idle Daily page uses the same helper to ask for the current UTC competition before a run starts. A started run still uses its captured `runKey`, so crossing UTC midnight cannot move the result to a new board.
 
-Changing these helpers does not change generator-v1 output; they centralize the already-frozen format.
+This changes no generator-v1 output; it only removes duplicate grammar construction.
 
 ## 6. Score admission
 
-Keep the generic Zod transport schema unchanged. Ice Slide Daily semantics run after generic validation and game-ID resolution in `src/pages/api/scores.ts`.
+Keep the generic Zod score transport schema unchanged. Ice Slide Daily semantics run after generic validation and game-ID resolution in `src/pages/api/scores.ts`.
 
 The domain check is pure and lives beside the Daily-key parser in `run.ts`:
 
 ```ts
+export type IceSlideDailyAdmissionReason =
+    | 'missing-context'
+    | 'context-mode-mismatch'
+    | 'missing-competition-key'
+    | 'malformed-competition-key'
+    | 'missing-game-data'
+    | 'game-data-mode-mismatch'
+    | 'unsolved'
+    | 'run-key-mismatch'
+    | 'generator-version-mismatch'
+    | 'game-data-ruleset-mismatch'
+    | 'context-ruleset-mismatch'
+    | 'invalid-elapsed-seconds'
+    | 'invalid-total-moves'
+
+export interface IceSlideDailyAdmissionError {
+    reason: IceSlideDailyAdmissionReason
+}
+
 export function iceSlideDailyAdmissionError(
     context: {
         mode: string
@@ -137,12 +168,12 @@ export function iceSlideDailyAdmissionError(
         rulesetVersion: number
     } | undefined,
     gameData: Record<string, unknown> | undefined
-): string | null
+): IceSlideDailyAdmissionError | null
 ```
 
-The route calls it only when `validatedGameId === GameID.ICE_SLIDE`. `run.ts` therefore does not import server validation types or the global game registry.
+The route calls it only when `validatedGameId === GameID.ICE_SLIDE`. `run.ts` therefore imports neither server validation types nor the global game registry.
 
-A payload claims Daily identity when either `context?.mode === 'daily'` or `gameData?.mode === 'daily'`. Such a claim is accepted only when all of these are true:
+A payload claims Daily identity when either `context?.mode === 'daily'` or `gameData?.mode === 'daily'`. A non-Daily Ice Slide payload returns `null`. A Daily claim is accepted only when all of these are true:
 
 - context exists and `context.mode === 'daily'`;
 - `context.competitionKey` exists and parses as a valid Ice Slide Daily run key;
@@ -156,13 +187,21 @@ A payload claims Daily identity when either `context?.mode === 'daily'` or `game
 - `gameData.elapsedSeconds` is a non-negative integer;
 - `gameData.totalMoves` is a non-negative integer.
 
-Invalid Daily claims return the existing HTTP 400 bad-request shape and are not persisted. No new public error-code family is required; the existing score client already maps a 400 response to invalid score data.
+The helper returns the first violated closed-union reason in a fixed order. Unit tests assert the exact reason for each invalid fixture, so removing one invariant cannot stay green because another overlapping check rejected the same payload.
 
-The helper unit tests name malformed competition keys and negative elapsed/move metrics explicitly even though generic Zod already rejects negative metrics when context is present. That keeps the domain invariant true independently of route validation order.
+The route maps every reason to the same existing public 400 body:
 
-This deliberately does **not** regenerate the Daily, recompute score, inspect stage rows, or verify move history. That remains outside HPA-488.
+```text
+Invalid Ice Slide Daily score data
+```
 
-Campaign behavior is unchanged because Campaign still submits without competitive context. Future Expedition context is also unaffected unless it incorrectly claims Daily identity.
+and does not call persistence. The server may log only the reason string for development diagnostics; it does not echo score payloads or create a new public error-code family.
+
+The helper unit tests include malformed competition keys and negative elapsed/move metrics even though generic Zod already rejects negative metrics when context is present. That keeps the domain invariant independent of route validation order.
+
+This deliberately does **not** regenerate the Daily, recompute score, inspect stage rows, or verify move history.
+
+Campaign behavior is unchanged because Campaign submits without competitive context. Future Expedition context is unaffected unless it claims Daily identity.
 
 ## 7. Scoped ranking and API contract
 
@@ -192,22 +231,38 @@ Rows written before semantic Daily admission are not a compatibility target. HPA
 /api/leaderboard?gameId=ice_slide&mode=daily&competitionKey=<exact-key>&limit=10
 ```
 
-For `gameId=ice_slide&mode=daily`:
+The existing `leaderboardQuerySchema.superRefine()` owns parameter-presence relationships. Extend it with:
 
-- `competitionKey` is required;
-- it must parse as a valid Ice Slide Daily key;
-- the unchanged scoped query receives `{ gameId, mode, competitionKey, limit }`.
+- when `gameId === GameID.ICE_SLIDE && mode === 'daily'`, `competitionKey` is required.
 
-This prevents the existing generic mode-only query from combining multiple Ice Slide Daily dates or versions. Other games/modes retain HPA-484's generic mode-only behavior.
+This sits beside the existing generic rules that `mode` requires `gameId` and `competitionKey` requires both `gameId` and `mode`.
 
-### 7.3 Viewer metadata
+The validation schema checks presence/transport shape only. It does **not** import Ice Slide domain parsing. A short comment points to the route's semantic companion.
 
-The scoped API branch performs an optional session lookup after a successful ranking query. Public leaderboard access remains public.
+After generic query validation succeeds, the leaderboard route parses the exact key with `parseIceSlideDailyRunKey()` for Ice Slide Daily. Malformed/calendar-invalid keys return the existing bad-request shape. Another short comment points back to the schema presence rule.
 
-`GET` must destructure both `url` and `request`:
+The unchanged scoped query receives exactly:
 
 ```ts
-export const GET: APIRoute = async ({ url, request }) => {
+{ gameId, mode, competitionKey, limit }
+```
+
+This prevents mode-only Ice Slide Daily reads from mixing dates/versions while preserving HPA-484's mode-only behavior for other games/modes.
+
+### 7.3 Viewer metadata from middleware locals
+
+`src/middleware.ts` already calls `auth.api.getSession()` for every request and stores the result in `context.locals.user` / `context.locals.session`. `env.d.ts` types `locals.user` as `User | null`.
+
+The leaderboard route therefore consumes the established request context instead of authenticating a second time:
+
+```ts
+export const GET: APIRoute = async ({ url, locals }) => {
+```
+
+After a successful scoped ranking query:
+
+```ts
+const viewerUserId = locals.user?.id ?? null
 ```
 
 The public scoped row keeps its existing fields and gains:
@@ -222,11 +277,13 @@ Every scoped response gains:
 viewerAuthenticated: boolean
 ```
 
-`isCurrentUser` is computed by comparing the private DB `userId` with the session user ID before combining it with `toPublicScopedLeaderboardEntry(row)`. The raw user ID remains absent from the response.
+`isCurrentUser` is computed by comparing the private DB `userId` with `viewerUserId` before combining it with `toPublicScopedLeaderboardEntry(row)`. The raw user ID remains absent from the response.
 
-An auth lookup failure degrades to an unauthenticated viewer rather than failing an otherwise available public leaderboard. The unscoped Campaign response shape is untouched.
+There is no route-local auth import, no `getViewerUserId()` helper, and no compatibility branch for tests that omit `request`. Route tests pass `locals: { user: null }` or a minimal user object, matching existing API-route test patterns.
 
-Because viewer metadata is additive to **all scoped responses**, existing scoped Tetris API assertions are updated deliberately; only unscoped responses retain byte/shape compatibility.
+The middleware's auth lookup remains the single auth lookup for the request. If it fails, normal middleware error behavior applies; HPA-488 does not add a second best-effort session policy that cannot be reached after middleware failure.
+
+Because viewer metadata is additive to **all scoped responses**, existing scoped Tetris API assertions are updated deliberately. Unscoped Campaign responses retain their current shape.
 
 ## 8. Ice Slide page UX
 
@@ -270,11 +327,13 @@ setDailyLeaderboardPanelState(elements, state)
 createDailyLeaderboardController(elements, fetcher?)
 ```
 
-The controller is a small closure, not a shared store or class hierarchy. It owns one monotonically increasing request token and exposes only the operations the page needs, such as `load(competitionKey)` and `hide()`/invalidation.
+The controller is a small closure, not a shared store or class hierarchy. It owns one monotonically increasing request token and exposes only `load(competitionKey)` and `hide()`.
 
-Unit tests in `daily-leaderboard.test.ts` execute the real loader under jsdom, including a delayed stale response. Playwright remains integration coverage rather than the first proof of token gating.
+Unit tests in `daily-leaderboard.test.ts` execute the real loader under jsdom, including delayed stale responses. Playwright remains integration coverage rather than the first proof of token gating.
 
-For elapsed formatting, reuse the existing `src/lib/games/shared/utils.ts::formatTime`. Remove the duplicate local `formatTime()` from `init.ts` and import the shared helper there too. The leaderboard wrapper maps `null` to `—` before calling the shared formatter.
+For leaderboard elapsed display, `formatDailyLeaderboardElapsed()` maps `null` to `—` and otherwise reuses `src/lib/games/shared/utils.ts::formatTime`.
+
+HPA-488 does **not** replace the existing private `init.ts::formatTime()`. That helper uses unbounded `M:SS`, whereas the shared helper switches to `H:MM:SS` after one hour. Changing the in-run HUD at that boundary is unrelated to Daily ranking and stays out of scope.
 
 ### 8.2 Loading lifecycle
 
@@ -294,15 +353,53 @@ Anonymous completion does not fire this callback because the score was not persi
 
 ### 8.3 Stale requests and failure isolation
 
-`createDailyLeaderboardController()` owns one request token. Every load captures the token and competition key; responses render only when the token remains current. `hide()` invalidates the token before hiding the panel.
+`createDailyLeaderboardController()` owns one request token. Every load increments/captures the token and parses the competition key.
 
-Switching to Campaign or starting/loading a newer Daily invalidates older requests. No `AbortController`, global store, event bus, or shared run guard is added for this one caller.
+If the key cannot be parsed, the controller shows the panel's `unavailable` state instead of silently returning and leaving stale rows visible.
+
+For a valid key, responses render only when the token remains current. `hide()` invalidates the token before hiding the panel.
+
+Switching to Campaign or loading a newer Daily invalidates older requests. No `AbortController`, global store, event bus, or shared run guard is added for this one caller.
 
 A 503/error switches only the leaderboard panel to unavailable. It never calls the game `failRun` path and never hides the local completion overlay.
 
 The Astro script remains wiring only: mode selection, Start, Play Again, Change Mode, captured run-key handoff, and `onScoreSaved` refresh.
 
-## 9. File boundaries
+## 9. Frozen Daily playthrough fixture
+
+The deterministic `2026-08-12` playthrough exists once in the existing test-only fixture module:
+
+```ts
+// src/lib/games/ice-slide/test-fixtures.ts
+export const ICE_SLIDE_DAILY_2026_08_12_DIRECTIONS = [
+    ['S', 'E', 'S'],
+    ['N', 'W', 'N', 'W'],
+    ['W', 'N', 'E', 'S', 'W', 'N'],
+    ['S', 'W', 'N', 'E', 'S', 'W'],
+    ['E', 'S', 'W', 'N', 'E', 'S'],
+] as const satisfies readonly (readonly Direction[])[]
+```
+
+A unit test replays this exact fixture through `IceSlideGame` with `createIceSlideDailyRunDefinition('2026-08-12')`, advancing each non-final stage through the normal game API and asserting the final run reaches `status='won'` with `solved=true`.
+
+For each stage, the test also compares the fixture length with `solveIceSlideBoard(stage, { maxStates: ICE_SLIDE_DAILY_SOLVER_MAX_STATES }).minMoves`. The solver does not produce a path, so this is an optimal-length assertion rather than a second source of directions.
+
+The E2E spec imports the same fixture and derives browser keys through one local map:
+
+```ts
+const DIRECTION_TO_KEY = {
+    N: 'ArrowUp',
+    E: 'ArrowRight',
+    S: 'ArrowDown',
+    W: 'ArrowLeft',
+} as const
+```
+
+No arrow-key sequence is hardcoded separately in Playwright.
+
+Stages with `collect_all_crystals` still treat that objective as optional; the fixture proves deterministic completion and shortest-goal length, not every optional star.
+
+## 10. File boundaries
 
 Expected implementation files:
 
@@ -311,8 +408,11 @@ src/lib/games/ice-slide/run.ts
 src/lib/games/ice-slide/run.test.ts
 src/lib/games/ice-slide/daily.ts
 src/lib/games/ice-slide/daily.test.ts
+src/lib/games/ice-slide/test-fixtures.ts
 src/pages/api/scores.ts
 src/pages/api/scores.test.ts
+src/lib/server/validations.ts
+src/lib/server/validations.test.ts
 src/pages/api/leaderboard.ts
 src/pages/api/leaderboard.test.ts
 src/lib/games/ice-slide/init.ts
@@ -329,53 +429,43 @@ Not modified:
 ```text
 src/lib/server/db/scoped-leaderboard.ts
 src/lib/server/db/scoped-leaderboard.integration.test.ts
+src/middleware.ts
+env.d.ts
 ```
 
 The one new production module is justified by executable unit coverage of the page-local async/render state; it is intentionally game-specific and not a reusable component framework.
 
-## 10. Test strategy
+## 11. Test strategy
 
 ### Pure/unit
 
 - valid and invalid Daily competition-key parsing;
+- parse/format round trip for Daily identity;
 - `assertValidIceSlideRunDefinition()` and every `init.ts` date extraction use the same parser;
-- key construction preserves generator-v1/run-key output;
+- current-version key construction preserves generator-v1 output;
 - pure Daily admission accepts the exact HPA-487 payload;
-- pure Daily admission rejects omitted context, unsolved data, mode mismatch, malformed/mismatched run key, generator mismatch, ruleset mismatch, missing/negative metrics, and Expedition masquerading as Daily;
-- score route returns 400/no-persist for representative semantic failures after generic validation;
+- every invalid Daily admission fixture asserts an exact closed-union reason;
+- malformed keys, omitted context/data, mode mismatch, unsolved runs, run/generator/ruleset mismatch, missing/negative metrics, and Expedition masquerading as Daily are independently pinned;
+- score route maps admission reasons to the same 400/no-persist behavior;
 - `onScoreSaved` fires once after a current successful save and never on stale/error/unauthenticated paths;
 - Daily leaderboard URL/state/row/elapsed helpers run in jsdom;
-- controller tests prove loading/empty/unavailable/signed-out rendering and stale-response suppression.
+- controller tests prove loading/empty/unavailable/signed-out rendering, invalid-key behavior, and stale-response suppression;
+- the single frozen direction fixture replays to a solved Daily and matches each stage's solver minimum-move count.
 
-### Database/API
+### API
 
-- HPA-484's unchanged real-LibSQL best-per-user/tie-break suite remains green;
-- Ice Slide Daily leaderboard requests require and validate the exact `competitionKey`;
+- `leaderboardQuerySchema` requires `competitionKey` specifically for `ice_slide + daily` while preserving generic mode-only forms for other games;
+- malformed/calendar-invalid exact Ice Slide Daily keys are rejected semantically by the route;
 - the scoped query is called with only `{ gameId, mode, competitionKey, limit }`;
-- current-viewer rows gain `isCurrentUser=true` without exposing `userId`;
-- signed-out and auth-failure scoped responses return `viewerAuthenticated=false`;
+- current-viewer rows gain `isCurrentUser=true` from `locals.user` without exposing `userId`;
+- signed-out scoped responses use `locals.user=null` and return `viewerAuthenticated=false`;
+- no leaderboard API test imports or mocks `@/lib/auth` for HPA-488;
 - existing scoped Tetris response assertions are updated for the additive viewer fields;
 - Campaign/unscoped API tests keep their current response shape.
 
-### Deterministic Daily playthrough fixture
-
-Before Playwright depends on hard-coded keypresses, a unit test replays the exact five `2026-08-12` sequences through `IceSlideGame` using `createIceSlideDailyRunDefinition('2026-08-12')` and asserts the run reaches `status='won'` with `solved=true`.
-
-The known shortest goal sequences are:
-
-```text
-S E S
-N W N W
-W N E S W N
-S W N E S W
-E S W N E S
-```
-
-Stages 3 and 4 have `collect_all_crystals` as an optional bonus objective; these sequences are allowed to miss that bonus and still clear the run. The unit replay exists to prove the browser fixture clears the materialized boards, not to require every optional star.
-
 ### Browser
 
-Use the existing Ice Slide Playwright section. Add deterministic route-backed assertions for:
+Use the existing Ice Slide Playwright section. Add route-backed assertions for:
 
 - Daily selection loads the exact active key and renders empty/signed-out states;
 - ranked rows render all required metrics and the `YOU` marker;
@@ -383,23 +473,28 @@ Use the existing Ice Slide Playwright section. Add deterministic route-backed as
 - a successful current-run save triggers a second fetch for the same captured key;
 - a delayed stale leaderboard response cannot reappear after switching to Campaign/newer identity.
 
-Existing HPA-487 rollover/Play Again tests remain the source of truth for captured Daily identity.
+The browser completion helper imports `ICE_SLIDE_DAILY_2026_08_12_DIRECTIONS` and derives keys from `DIRECTION_TO_KEY`; it never owns a second copy of the sequence.
 
-## 11. Acceptance mapping
+## 12. Acceptance mapping
 
-- **Different dates/generator/ruleset versions do not mix:** exact competition key is mandatory for Ice Slide Daily reads and is validated by the one parser; accepted writes must match that key's encoded identity.
-- **One row per user / better retries:** reused HPA-484 partitioned query unchanged.
-- **Tie-break order:** reused HPA-484 SQL and deterministic DB tests unchanged.
-- **Incomplete/mismatched/malformed/Expedition submissions cannot rank:** rejected before persistence by the pure Ice Slide Daily admission helper.
+- **Different dates/generator/ruleset versions do not mix:** exact key required; one parser/formatter owns identity grammar; unchanged query filters exact key.
+- **One row per user / better retries:** reused HPA-484 partitioned query.
+- **Tie-break order:** reused HPA-484 SQL and deterministic DB tests.
+- **Incomplete/mismatched/malformed/Expedition submissions cannot rank:** rejected before persistence with independently tested reasons.
 - **Campaign compatibility:** Campaign writes and unscoped read branch remain unchanged.
-- **Local play survives failures:** leaderboard errors stay inside the Daily leaderboard controller; score errors retain HPA-487 behavior.
-- **Authenticated/anonymous/empty/failure/success coverage:** split across API, init, jsdom controller, and Playwright tests.
+- **Viewer highlighting:** uses existing middleware-authenticated `locals.user`; private `userId` never enters the public DTO.
+- **Local play survives failures:** leaderboard errors are controller-local; score errors retain HPA-487 behavior.
+- **Authenticated/anonymous/empty/failure/success coverage:** split across API, init/controller, markup, and Playwright tests.
+- **Deterministic completion fixture:** one directions source is unit-replayed before Playwright consumes it.
 
-## 12. Self-review
+## 13. Self-review
 
 - No placeholder requirement remains.
-- There is one Daily-key parser and one current-version key constructor.
-- The existing scoped ranking query is reused without a redundant identity field.
-- Semantic admission is pure domain logic rather than a large route-local closure.
-- The single new client module is game-specific and exists to make async/token/render behavior directly testable.
-- No database schema, endpoint, shared UI abstraction, replay verifier, historical browser, Expedition ranking, or current-user rank-beyond-top-N query is added.
+- The design adds no schema, endpoint, ranking query, auth request, or shared UI framework.
+- `run.ts` owns Daily key grammar in both directions; `daily.ts` supplies only current version constants.
+- `getScopedGameLeaderboard()` remains unchanged.
+- Middleware auth is reused instead of repeated.
+- Admission reasons independently freeze semantic invariants while preserving one public 400 response.
+- The new leaderboard uses shared time formatting without changing existing Ice Slide HUD behavior.
+- The async panel logic is unit-testable; Astro remains structure/wiring.
+- Historical navigation, anti-cheat, Expedition ranking, and current-user rank-beyond-top-N remain out of scope.

--- a/docs/superpowers/specs/2026-08-13-ice-slide-daily-leaderboard-design.md
+++ b/docs/superpowers/specs/2026-08-13-ice-slide-daily-leaderboard-design.md
@@ -1,0 +1,305 @@
+# Ice Slide Daily Leaderboard — Design
+
+- **Date:** 2026-08-13
+- **Linear:** HPA-488 — Add the per-day Ice Slide leaderboard and best-per-player ranking
+- **Repository:** `cwchanap/cetus`
+- **Dependencies:** HPA-484 complete; HPA-487 merged in PR #61 on 2026-08-13
+- **Status:** Implementation design
+
+## 1. Summary
+
+HPA-488 completes the competitive half of Ice Slide Daily without creating another leaderboard subsystem.
+
+HPA-484 already provides persisted score context plus a scoped best-per-user query. HPA-487 now submits completed Daily runs with `mode='daily'`, the captured run key as `competitionKey`, ruleset version, and full Ice Slide game data. The remaining work is therefore narrow:
+
+1. reject malformed or mismatched Ice Slide Daily score submissions before persistence;
+2. require an exact Daily competition key for Ice Slide Daily leaderboard reads;
+3. reuse the existing scoped query while constraining it to the ruleset encoded by that key;
+4. add current-viewer metadata without exposing user IDs;
+5. render a page-local Daily leaderboard panel and refresh it only after a successful completed submission.
+
+No new database table, endpoint family, shared leaderboard framework, persistence service, or generic game-mode registry is needed.
+
+## 2. Goals
+
+- Rank only completed, internally consistent Ice Slide Daily submissions.
+- Keep each UTC date/generator/ruleset combination isolated by exact competition key.
+- Keep one best displayed result per player while retaining all attempts in history.
+- Preserve the existing ranking order: score descending, elapsed seconds ascending, total moves ascending, submission time ascending.
+- Show rank, player, score, elapsed time, and total moves on the Ice Slide page.
+- Highlight the authenticated viewer's row when it is present in the returned top results.
+- Show clear loading, empty, signed-out, and unavailable states.
+- Refresh the active Daily ranking after a successful Daily score save.
+- Keep Campaign leaderboard behavior and `/api/leaderboard?gameId=ice_slide` unchanged.
+- Keep local Daily play/completion usable when score saving or leaderboard loading fails.
+
+## 3. Non-goals
+
+- Historical Daily calendar/navigation.
+- A second Ice Slide-specific leaderboard endpoint.
+- A materialized best-score table or cache.
+- A current-user rank query when the user is outside the returned top-N rows.
+- One-attempt-only Daily restrictions.
+- Server replay verification, score recomputation, or broader anti-cheat.
+- Cross-seed Expedition ranking.
+- A shared client leaderboard component for other games.
+- Changes to the global leaderboard page.
+
+## 4. Approaches considered
+
+### A. Reuse the scoped query and specialize the existing score/leaderboard routes — selected
+
+Keep `/api/scores` and `/api/leaderboard` as the only network seams. Add Ice Slide Daily semantic checks to score admission, exact-key enforcement to the scoped leaderboard branch, and a small page-local renderer.
+
+**Why selected:** it reuses every expensive piece already delivered by HPA-484, touches the fewest abstractions, and leaves generic scoped ranking available for future modes.
+
+### B. Add `/api/ice-slide/daily-leaderboard`
+
+This would make the Daily contract obvious but duplicate request validation, ranking DTO assembly, unavailable handling, and tests already present in `/api/leaderboard`.
+
+**Rejected:** more surface area with no product capability gain.
+
+### C. Fetch generic scoped rows and filter/validate them only in the browser
+
+This would avoid server changes but would allow malformed Daily submissions into persisted/ranked data and would keep the mode-only cross-date query footgun.
+
+**Rejected:** the ticket explicitly owns server admission and competitive isolation.
+
+## 5. Competition identity contract
+
+The existing Daily run key is also the competition key:
+
+```text
+ice-slide:daily:YYYY-MM-DD:g<generatorVersion>:r<rulesetVersion>
+```
+
+`run.ts` remains the owner of that syntax. Export a small parser:
+
+```ts
+export interface IceSlideDailyRunIdentity {
+    dateKey: string
+    generatorVersion: number
+    rulesetVersion: number
+}
+
+export function parseIceSlideDailyRunKey(
+    runKey: string
+): IceSlideDailyRunIdentity | null
+```
+
+The parser must reject malformed keys and calendar-invalid dates. `assertValidIceSlideRunDefinition()` should reuse it rather than maintaining a second interpretation of the same format.
+
+`daily.ts` also exports:
+
+```ts
+export function createIceSlideDailyCompetitionKey(dateKey: string): string
+```
+
+`createIceSlideDailyRunDefinition()` uses this helper for `run.runKey`. The browser uses the same helper to ask for the currently selectable Daily leaderboard before a run starts. This prevents duplicated string construction while preserving the captured run key for a Daily started before UTC rollover.
+
+Changing this helper does not change generator-v1 output; it only centralizes the already-frozen string format.
+
+## 6. Score admission
+
+Keep the generic Zod transport schema unchanged. Ice Slide Daily semantics belong after generic validation and game-ID resolution in `src/pages/api/scores.ts`.
+
+A score is treated as an Ice Slide Daily claim when `gameId === ice_slide` and either the submitted context or game data claims `mode='daily'`. Such a claim is accepted only when all of these are true:
+
+- context exists and `context.mode === 'daily'`;
+- `context.competitionKey` exists and parses as a valid Ice Slide Daily run key;
+- `gameData` exists;
+- `gameData.mode === 'daily'`;
+- `gameData.solved === true`;
+- `gameData.runKey === context.competitionKey`;
+- `gameData.generatorVersion` equals the generator version encoded in the competition key;
+- `gameData.rulesetVersion === context.rulesetVersion`;
+- `context.rulesetVersion` equals the ruleset version encoded in the competition key;
+- `gameData.elapsedSeconds` is a non-negative integer;
+- `gameData.totalMoves` is a non-negative integer.
+
+Invalid Daily claims return the existing HTTP 400 bad-request shape and are not persisted. No new public error-code family is required; the existing score client already maps a 400 response to invalid score data.
+
+This deliberately does **not** recompute scores, regenerate stages, or verify move history. That remains outside HPA-488.
+
+Campaign behavior is unchanged because Campaign still submits without competitive context. Future Expedition context is also unaffected unless it incorrectly claims Daily identity.
+
+## 7. Scoped ranking and API contract
+
+### 7.1 Query reuse
+
+`getScopedGameLeaderboard()` remains the only best-per-user ranking implementation. Add one optional field to its query contract:
+
+```ts
+rulesetVersion?: number
+```
+
+When supplied, the SQL filters `game_scores.ruleset_version` to that exact version; when omitted, existing generic behavior remains unchanged.
+
+The existing window-function order is retained:
+
+1. score descending;
+2. elapsed seconds ascending, valid values before missing values;
+3. total moves ascending, valid values before missing values;
+4. `created_at` ascending;
+5. row ID ascending only as an internal deterministic fallback when all documented fields tie exactly.
+
+HPA-484 already has deterministic database coverage for the four documented tie-break levels. HPA-488 adds only the exact-ruleset isolation regression rather than rewriting that ranking test suite.
+
+### 7.2 Ice Slide Daily read admission
+
+`GET /api/leaderboard` keeps all existing forms, except the Ice Slide Daily combination becomes stricter:
+
+```text
+/api/leaderboard?gameId=ice_slide&mode=daily&competitionKey=<exact-key>&limit=10
+```
+
+For `gameId=ice_slide&mode=daily`:
+
+- `competitionKey` is required;
+- it must parse as a valid Ice Slide Daily key;
+- the parsed ruleset version is passed to `getScopedGameLeaderboard()`.
+
+This prevents the existing generic mode-only query from combining multiple Ice Slide Daily dates or versions. Other games/modes retain HPA-484's generic mode-only behavior.
+
+### 7.3 Viewer metadata
+
+The scoped API branch performs an optional session lookup after the ranking query. Public leaderboard access remains public.
+
+The public row keeps its existing fields and gains:
+
+```ts
+isCurrentUser: boolean
+```
+
+The scoped response gains:
+
+```ts
+viewerAuthenticated: boolean
+```
+
+`isCurrentUser` is computed by comparing the private DB `userId` with the session user ID before calling/combining the public DTO. The raw user ID remains absent from the response.
+
+An auth lookup failure degrades to an unauthenticated viewer rather than failing an otherwise available public leaderboard.
+
+The unscoped Campaign response shape is untouched.
+
+## 8. Ice Slide page UX
+
+Add one `Card` below the existing Daily metadata in `src/pages/ice-slide/index.astro`. Astro owns all durable structure and state containers; client TypeScript only toggles visibility/text and creates row children, matching the repository DOM ownership rule.
+
+The panel contains:
+
+- heading and active competition date;
+- signed-out note: the player may view rankings but must sign in to submit;
+- loading state;
+- empty state;
+- unavailable state;
+- ranked row list.
+
+Each ranked row shows:
+
+```text
+#rank  Player [YOU]
+score  elapsed  moves
+```
+
+The viewer row receives both a visible `YOU` label and a visual border/background treatment, so identity is not communicated by color alone.
+
+No avatar/profile-link system is pulled into this game-local panel; the ticket only requires player identity plus ranking metrics.
+
+### 8.1 Loading lifecycle
+
+Before a run starts, selecting Daily loads the key produced from the current UTC date.
+
+When a Daily starts, the page reloads using the run's captured `runKey`. This matters around UTC rollover: a run started at 23:59:59 remains attached to the old competition even if it finishes after midnight.
+
+`initializeIceSlide()` gains one optional UI-only callback:
+
+```ts
+onScoreSaved?: (gameData: IceSlideGameData) => void
+```
+
+It fires only after `saveGameScore()` reports success and the run guard says the response is still current. The page refreshes the leaderboard using `gameData.runKey` only when `gameData.mode === 'daily'`.
+
+Anonymous completion does not fire this callback because the score was not persisted; the local result remains intact and the signed-out leaderboard note stays visible.
+
+### 8.2 Stale requests
+
+The page owns one monotonically increasing leaderboard request token. Every load captures the token and competition key; responses render only when both are still current.
+
+Switching to Campaign or starting a newer Daily invalidates older requests. No `AbortController`, global store, event bus, or shared run guard is added for this one page-local fetch.
+
+A 503/error switches only the leaderboard panel to unavailable. It never calls the game `failRun` path and never hides the local completion overlay.
+
+## 9. File boundaries
+
+Expected implementation files:
+
+```text
+src/lib/games/ice-slide/run.ts
+src/lib/games/ice-slide/run.test.ts
+src/lib/games/ice-slide/daily.ts
+src/lib/games/ice-slide/daily.test.ts
+src/pages/api/scores.ts
+src/pages/api/scores.test.ts
+src/lib/server/db/scoped-leaderboard.ts
+src/lib/server/db/scoped-leaderboard.integration.test.ts
+src/pages/api/leaderboard.ts
+src/pages/api/leaderboard.test.ts
+src/lib/games/ice-slide/init.ts
+src/lib/games/ice-slide/init.test.ts
+src/pages/ice-slide/index.astro
+src/pages/game-board-markup.test.ts
+e2e/games/play-coverage.spec.ts
+```
+
+No production file is created for HPA-488.
+
+## 10. Test strategy
+
+### Pure/unit
+
+- valid and invalid Daily competition-key parsing;
+- key construction preserves generator-v1/run-key output;
+- score admission accepts the exact HPA-487 payload;
+- score admission rejects omitted context, unsolved data, mode mismatch, run-key mismatch, generator mismatch, ruleset mismatch, missing metrics, and Expedition masquerading as Daily;
+- `onScoreSaved` fires once after a current successful save and never on stale/error/unauthenticated paths.
+
+### Database/API
+
+- exact `rulesetVersion` filtering excludes a mismatched persisted row;
+- existing score/elapsed/moves/time ranking tests continue to pass;
+- Ice Slide Daily leaderboard requests require and validate `competitionKey`;
+- current-viewer rows gain `isCurrentUser=true` without exposing `userId`;
+- signed-out scoped responses return `viewerAuthenticated=false`;
+- Campaign/unscoped API tests keep their current response shape.
+
+### Browser
+
+Use the existing Ice Slide Playwright section. Add deterministic route-backed assertions for:
+
+- Daily selection loads the exact active key and renders empty/signed-out states;
+- ranked rows render all required metrics and the `YOU` marker;
+- a leaderboard 503 shows unavailable while Start/Daily play remains usable;
+- a successful current-run save triggers a second fetch for the same captured key;
+- a delayed stale leaderboard response cannot reappear after switching to Campaign/newer identity.
+
+Existing HPA-487 rollover/Play Again tests remain the source of truth for captured Daily identity.
+
+## 11. Acceptance mapping
+
+- **Different dates/generator/ruleset versions do not mix:** exact key required; key parser validates generator/ruleset identity; query also filters exact ruleset.
+- **One row per user / better retries:** reused HPA-484 partitioned query.
+- **Tie-break order:** reused HPA-484 SQL and deterministic DB tests.
+- **Incomplete/mismatched/malformed/Expedition submissions cannot rank:** rejected before persistence by Ice Slide Daily admission.
+- **Campaign compatibility:** Campaign writes and unscoped read branch remain unchanged.
+- **Local play survives failures:** leaderboard errors are page-local; score errors retain HPA-487 behavior.
+- **Authenticated/anonymous/empty/failure/success coverage:** split across API, init/page, and Playwright tests as described above.
+
+## 12. Self-review
+
+- No placeholder requirement remains.
+- The design adds no new database schema or endpoint.
+- The generic scoped query stays generic; Ice Slide-specific semantics stay at the API/game boundary.
+- The UI adds no reusable component before a second consumer exists.
+- Historical navigation, anti-cheat, Expedition ranking, and current-user rank-beyond-top-N remain explicitly out of scope.

--- a/docs/superpowers/specs/2026-08-13-ice-slide-daily-leaderboard-design.md
+++ b/docs/superpowers/specs/2026-08-13-ice-slide-daily-leaderboard-design.md
@@ -10,15 +10,15 @@
 
 HPA-488 completes the competitive half of Ice Slide Daily without creating another leaderboard subsystem.
 
-HPA-484 already provides persisted score context plus a scoped best-per-user query. HPA-487 now submits completed Daily runs with `mode='daily'`, the captured run key as `competitionKey`, ruleset version, and full Ice Slide game data. The remaining work is therefore narrow:
+HPA-484 already provides persisted score context plus a scoped best-per-user query. HPA-487 now submits completed Daily runs with `mode='daily'`, the captured run key as `competitionKey`, ruleset version, and full Ice Slide game data. The remaining work is narrow:
 
-1. reject malformed or mismatched Ice Slide Daily score submissions before persistence;
-2. require an exact Daily competition key for Ice Slide Daily leaderboard reads;
-3. reuse the existing scoped query while constraining it to the ruleset encoded by that key;
+1. centralize the already-frozen Daily run/competition-key interpretation and remove the weaker `init.ts` date parser;
+2. reject malformed or mismatched Ice Slide Daily score submissions before persistence;
+3. require an exact Daily competition key for Ice Slide Daily leaderboard reads while reusing HPA-484's query unchanged;
 4. add current-viewer metadata without exposing user IDs;
-5. render a page-local Daily leaderboard panel and refresh it only after a successful completed submission.
+5. render and refresh one Ice-Slide-specific Daily leaderboard through a small testable client module.
 
-No new database table, endpoint family, shared leaderboard framework, persistence service, or generic game-mode registry is needed.
+No new database table, endpoint family, ranking query, shared leaderboard framework, persistence service, or generic game-mode registry is needed.
 
 ## 2. Goals
 
@@ -32,6 +32,7 @@ No new database table, endpoint family, shared leaderboard framework, persistenc
 - Refresh the active Daily ranking after a successful Daily score save.
 - Keep Campaign leaderboard behavior and `/api/leaderboard?gameId=ice_slide` unchanged.
 - Keep local Daily play/completion usable when score saving or leaderboard loading fails.
+- Give the page-local request-token/render behavior unit coverage rather than making Playwright its first proof.
 
 ## 3. Non-goals
 
@@ -44,12 +45,13 @@ No new database table, endpoint family, shared leaderboard framework, persistenc
 - Cross-seed Expedition ranking.
 - A shared client leaderboard component for other games.
 - Changes to the global leaderboard page.
+- Read-repair or migration of any pre-HPA-488 malformed scoped rows.
 
 ## 4. Approaches considered
 
 ### A. Reuse the scoped query and specialize the existing score/leaderboard routes — selected
 
-Keep `/api/scores` and `/api/leaderboard` as the only network seams. Add Ice Slide Daily semantic checks to score admission, exact-key enforcement to the scoped leaderboard branch, and a small page-local renderer.
+Keep `/api/scores` and `/api/leaderboard` as the only network seams. Add Ice Slide Daily semantic checks to score admission, exact-key enforcement to the scoped leaderboard branch, and one Ice-Slide-specific client helper module for testable panel behavior.
 
 **Why selected:** it reuses every expensive piece already delivered by HPA-484, touches the fewest abstractions, and leaves generic scoped ranking available for future modes.
 
@@ -73,7 +75,7 @@ The existing Daily run key is also the competition key:
 ice-slide:daily:YYYY-MM-DD:g<generatorVersion>:r<rulesetVersion>
 ```
 
-`run.ts` remains the owner of that syntax. Export a small parser:
+`run.ts` remains the single owner of that syntax. Export:
 
 ```ts
 export interface IceSlideDailyRunIdentity {
@@ -87,7 +89,29 @@ export function parseIceSlideDailyRunKey(
 ): IceSlideDailyRunIdentity | null
 ```
 
-The parser must reject malformed keys and calendar-invalid dates. `assertValidIceSlideRunDefinition()` should reuse it rather than maintaining a second interpretation of the same format.
+The parser rejects malformed keys, trailing garbage, zero/non-positive versions, and calendar-invalid dates.
+
+Every consumer that interprets a Daily key uses this parser:
+
+- `assertValidIceSlideRunDefinition()`;
+- the Ice Slide Daily score-admission helper;
+- Ice Slide Daily leaderboard request admission;
+- `init.ts` HUD/Play-Again date extraction;
+- the Daily leaderboard client module.
+
+The current `init.ts` helper:
+
+```ts
+function extractDailyDateKey(runKey: string): string | null
+```
+
+is removed. Its callers use:
+
+```ts
+parseIceSlideDailyRunKey(runKey)?.dateKey ?? null
+```
+
+This prevents HUD and rollover logic from accepting a weaker key grammar than server admission.
 
 `daily.ts` also exports:
 
@@ -95,15 +119,30 @@ The parser must reject malformed keys and calendar-invalid dates. `assertValidIc
 export function createIceSlideDailyCompetitionKey(dateKey: string): string
 ```
 
-`createIceSlideDailyRunDefinition()` uses this helper for `run.runKey`. The browser uses the same helper to ask for the currently selectable Daily leaderboard before a run starts. This prevents duplicated string construction while preserving the captured run key for a Daily started before UTC rollover.
+`createIceSlideDailyRunDefinition()` uses this helper for `run.runKey`. The idle Daily page uses the same helper to ask for the current UTC competition before a run starts. A started run still uses its captured `runKey`, so crossing UTC midnight cannot silently move the result to a new board.
 
-Changing this helper does not change generator-v1 output; it only centralizes the already-frozen string format.
+Changing these helpers does not change generator-v1 output; they centralize the already-frozen format.
 
 ## 6. Score admission
 
-Keep the generic Zod transport schema unchanged. Ice Slide Daily semantics belong after generic validation and game-ID resolution in `src/pages/api/scores.ts`.
+Keep the generic Zod transport schema unchanged. Ice Slide Daily semantics run after generic validation and game-ID resolution in `src/pages/api/scores.ts`.
 
-A score is treated as an Ice Slide Daily claim when `gameId === ice_slide` and either the submitted context or game data claims `mode='daily'`. Such a claim is accepted only when all of these are true:
+The domain check is pure and lives beside the Daily-key parser in `run.ts`:
+
+```ts
+export function iceSlideDailyAdmissionError(
+    context: {
+        mode: string
+        competitionKey?: string
+        rulesetVersion: number
+    } | undefined,
+    gameData: Record<string, unknown> | undefined
+): string | null
+```
+
+The route calls it only when `validatedGameId === GameID.ICE_SLIDE`. `run.ts` therefore does not import server validation types or the global game registry.
+
+A payload claims Daily identity when either `context?.mode === 'daily'` or `gameData?.mode === 'daily'`. Such a claim is accepted only when all of these are true:
 
 - context exists and `context.mode === 'daily'`;
 - `context.competitionKey` exists and parses as a valid Ice Slide Daily run key;
@@ -119,7 +158,9 @@ A score is treated as an Ice Slide Daily claim when `gameId === ice_slide` and e
 
 Invalid Daily claims return the existing HTTP 400 bad-request shape and are not persisted. No new public error-code family is required; the existing score client already maps a 400 response to invalid score data.
 
-This deliberately does **not** recompute scores, regenerate stages, or verify move history. That remains outside HPA-488.
+The helper unit tests name malformed competition keys and negative elapsed/move metrics explicitly even though generic Zod already rejects negative metrics when context is present. That keeps the domain invariant true independently of route validation order.
+
+This deliberately does **not** regenerate the Daily, recompute score, inspect stage rows, or verify move history. That remains outside HPA-488.
 
 Campaign behavior is unchanged because Campaign still submits without competitive context. Future Expedition context is also unaffected unless it incorrectly claims Daily identity.
 
@@ -127,15 +168,11 @@ Campaign behavior is unchanged because Campaign still submits without competitiv
 
 ### 7.1 Query reuse
 
-`getScopedGameLeaderboard()` remains the only best-per-user ranking implementation. Add one optional field to its query contract:
+`getScopedGameLeaderboard()` remains the only best-per-user ranking implementation and is not modified by HPA-488.
 
-```ts
-rulesetVersion?: number
-```
+The exact competition key already encodes date, generator version, and ruleset version. After score admission, a newly persisted Ice Slide Daily row cannot have a competition key whose encoded identity disagrees with its stored context/game data. HPA-488 therefore does **not** add a second `rulesetVersion` filter to `ScopedLeaderboardQuery`.
 
-When supplied, the SQL filters `game_scores.ruleset_version` to that exact version; when omitted, existing generic behavior remains unchanged.
-
-The existing window-function order is retained:
+The existing query continues to require `ruleset_version IS NOT NULL` and retains its window-function order:
 
 1. score descending;
 2. elapsed seconds ascending, valid values before missing values;
@@ -143,7 +180,9 @@ The existing window-function order is retained:
 4. `created_at` ascending;
 5. row ID ascending only as an internal deterministic fallback when all documented fields tie exactly.
 
-HPA-484 already has deterministic database coverage for the four documented tie-break levels. HPA-488 adds only the exact-ruleset isolation regression rather than rewriting that ranking test suite.
+HPA-484's database integration suite remains authoritative for best-per-user selection and all tie-break levels. HPA-488 does not duplicate or rewrite it.
+
+Rows written before semantic Daily admission are not a compatibility target. HPA-488 adds no read-repair or alternate identity channel for them.
 
 ### 7.2 Ice Slide Daily read admission
 
@@ -157,35 +196,41 @@ For `gameId=ice_slide&mode=daily`:
 
 - `competitionKey` is required;
 - it must parse as a valid Ice Slide Daily key;
-- the parsed ruleset version is passed to `getScopedGameLeaderboard()`.
+- the unchanged scoped query receives `{ gameId, mode, competitionKey, limit }`.
 
 This prevents the existing generic mode-only query from combining multiple Ice Slide Daily dates or versions. Other games/modes retain HPA-484's generic mode-only behavior.
 
 ### 7.3 Viewer metadata
 
-The scoped API branch performs an optional session lookup after the ranking query. Public leaderboard access remains public.
+The scoped API branch performs an optional session lookup after a successful ranking query. Public leaderboard access remains public.
 
-The public row keeps its existing fields and gains:
+`GET` must destructure both `url` and `request`:
+
+```ts
+export const GET: APIRoute = async ({ url, request }) => {
+```
+
+The public scoped row keeps its existing fields and gains:
 
 ```ts
 isCurrentUser: boolean
 ```
 
-The scoped response gains:
+Every scoped response gains:
 
 ```ts
 viewerAuthenticated: boolean
 ```
 
-`isCurrentUser` is computed by comparing the private DB `userId` with the session user ID before calling/combining the public DTO. The raw user ID remains absent from the response.
+`isCurrentUser` is computed by comparing the private DB `userId` with the session user ID before combining it with `toPublicScopedLeaderboardEntry(row)`. The raw user ID remains absent from the response.
 
-An auth lookup failure degrades to an unauthenticated viewer rather than failing an otherwise available public leaderboard.
+An auth lookup failure degrades to an unauthenticated viewer rather than failing an otherwise available public leaderboard. The unscoped Campaign response shape is untouched.
 
-The unscoped Campaign response shape is untouched.
+Because viewer metadata is additive to **all scoped responses**, existing scoped Tetris API assertions are updated deliberately; only unscoped responses retain byte/shape compatibility.
 
 ## 8. Ice Slide page UX
 
-Add one `Card` below the existing Daily metadata in `src/pages/ice-slide/index.astro`. Astro owns all durable structure and state containers; client TypeScript only toggles visibility/text and creates row children, matching the repository DOM ownership rule.
+Add one `Card` below the existing Daily metadata in `src/pages/ice-slide/index.astro`. Astro owns all durable structure and state containers.
 
 The panel contains:
 
@@ -207,7 +252,31 @@ The viewer row receives both a visible `YOU` label and a visual border/backgroun
 
 No avatar/profile-link system is pulled into this game-local panel; the ticket only requires player identity plus ranking metrics.
 
-### 8.1 Loading lifecycle
+### 8.1 Testable Daily leaderboard module
+
+The client fetch/render/token logic does not live as a large inline Astro-script block. Add one game-specific module:
+
+```text
+src/lib/games/ice-slide/daily-leaderboard.ts
+```
+
+It owns only the Ice Slide Daily panel behavior:
+
+```ts
+buildIceSlideDailyLeaderboardUrl(competitionKey)
+formatDailyLeaderboardElapsed(seconds)
+createDailyLeaderboardRowElement(entry, document)
+setDailyLeaderboardPanelState(elements, state)
+createDailyLeaderboardController(elements, fetcher?)
+```
+
+The controller is a small closure, not a shared store or class hierarchy. It owns one monotonically increasing request token and exposes only the operations the page needs, such as `load(competitionKey)` and `hide()`/invalidation.
+
+Unit tests in `daily-leaderboard.test.ts` execute the real loader under jsdom, including a delayed stale response. Playwright remains integration coverage rather than the first proof of token gating.
+
+For elapsed formatting, reuse the existing `src/lib/games/shared/utils.ts::formatTime`. Remove the duplicate local `formatTime()` from `init.ts` and import the shared helper there too. The leaderboard wrapper maps `null` to `—` before calling the shared formatter.
+
+### 8.2 Loading lifecycle
 
 Before a run starts, selecting Daily loads the key produced from the current UTC date.
 
@@ -223,13 +292,15 @@ It fires only after `saveGameScore()` reports success and the run guard says the
 
 Anonymous completion does not fire this callback because the score was not persisted; the local result remains intact and the signed-out leaderboard note stays visible.
 
-### 8.2 Stale requests
+### 8.3 Stale requests and failure isolation
 
-The page owns one monotonically increasing leaderboard request token. Every load captures the token and competition key; responses render only when both are still current.
+`createDailyLeaderboardController()` owns one request token. Every load captures the token and competition key; responses render only when the token remains current. `hide()` invalidates the token before hiding the panel.
 
-Switching to Campaign or starting a newer Daily invalidates older requests. No `AbortController`, global store, event bus, or shared run guard is added for this one page-local fetch.
+Switching to Campaign or starting/loading a newer Daily invalidates older requests. No `AbortController`, global store, event bus, or shared run guard is added for this one caller.
 
 A 503/error switches only the leaderboard panel to unavailable. It never calls the game `failRun` path and never hides the local completion overlay.
+
+The Astro script remains wiring only: mode selection, Start, Play Again, Change Mode, captured run-key handoff, and `onScoreSaved` refresh.
 
 ## 9. File boundaries
 
@@ -242,37 +313,65 @@ src/lib/games/ice-slide/daily.ts
 src/lib/games/ice-slide/daily.test.ts
 src/pages/api/scores.ts
 src/pages/api/scores.test.ts
-src/lib/server/db/scoped-leaderboard.ts
-src/lib/server/db/scoped-leaderboard.integration.test.ts
 src/pages/api/leaderboard.ts
 src/pages/api/leaderboard.test.ts
 src/lib/games/ice-slide/init.ts
 src/lib/games/ice-slide/init.test.ts
+src/lib/games/ice-slide/daily-leaderboard.ts
+src/lib/games/ice-slide/daily-leaderboard.test.ts
 src/pages/ice-slide/index.astro
 src/pages/game-board-markup.test.ts
 e2e/games/play-coverage.spec.ts
 ```
 
-No production file is created for HPA-488.
+Not modified:
+
+```text
+src/lib/server/db/scoped-leaderboard.ts
+src/lib/server/db/scoped-leaderboard.integration.test.ts
+```
+
+The one new production module is justified by executable unit coverage of the page-local async/render state; it is intentionally game-specific and not a reusable component framework.
 
 ## 10. Test strategy
 
 ### Pure/unit
 
 - valid and invalid Daily competition-key parsing;
+- `assertValidIceSlideRunDefinition()` and every `init.ts` date extraction use the same parser;
 - key construction preserves generator-v1/run-key output;
-- score admission accepts the exact HPA-487 payload;
-- score admission rejects omitted context, unsolved data, mode mismatch, run-key mismatch, generator mismatch, ruleset mismatch, missing metrics, and Expedition masquerading as Daily;
-- `onScoreSaved` fires once after a current successful save and never on stale/error/unauthenticated paths.
+- pure Daily admission accepts the exact HPA-487 payload;
+- pure Daily admission rejects omitted context, unsolved data, mode mismatch, malformed/mismatched run key, generator mismatch, ruleset mismatch, missing/negative metrics, and Expedition masquerading as Daily;
+- score route returns 400/no-persist for representative semantic failures after generic validation;
+- `onScoreSaved` fires once after a current successful save and never on stale/error/unauthenticated paths;
+- Daily leaderboard URL/state/row/elapsed helpers run in jsdom;
+- controller tests prove loading/empty/unavailable/signed-out rendering and stale-response suppression.
 
 ### Database/API
 
-- exact `rulesetVersion` filtering excludes a mismatched persisted row;
-- existing score/elapsed/moves/time ranking tests continue to pass;
-- Ice Slide Daily leaderboard requests require and validate `competitionKey`;
+- HPA-484's unchanged real-LibSQL best-per-user/tie-break suite remains green;
+- Ice Slide Daily leaderboard requests require and validate the exact `competitionKey`;
+- the scoped query is called with only `{ gameId, mode, competitionKey, limit }`;
 - current-viewer rows gain `isCurrentUser=true` without exposing `userId`;
-- signed-out scoped responses return `viewerAuthenticated=false`;
+- signed-out and auth-failure scoped responses return `viewerAuthenticated=false`;
+- existing scoped Tetris response assertions are updated for the additive viewer fields;
 - Campaign/unscoped API tests keep their current response shape.
+
+### Deterministic Daily playthrough fixture
+
+Before Playwright depends on hard-coded keypresses, a unit test replays the exact five `2026-08-12` sequences through `IceSlideGame` using `createIceSlideDailyRunDefinition('2026-08-12')` and asserts the run reaches `status='won'` with `solved=true`.
+
+The known shortest goal sequences are:
+
+```text
+S E S
+N W N W
+W N E S W N
+S W N E S W
+E S W N E S
+```
+
+Stages 3 and 4 have `collect_all_crystals` as an optional bonus objective; these sequences are allowed to miss that bonus and still clear the run. The unit replay exists to prove the browser fixture clears the materialized boards, not to require every optional star.
 
 ### Browser
 
@@ -288,18 +387,19 @@ Existing HPA-487 rollover/Play Again tests remain the source of truth for captur
 
 ## 11. Acceptance mapping
 
-- **Different dates/generator/ruleset versions do not mix:** exact key required; key parser validates generator/ruleset identity; query also filters exact ruleset.
-- **One row per user / better retries:** reused HPA-484 partitioned query.
-- **Tie-break order:** reused HPA-484 SQL and deterministic DB tests.
-- **Incomplete/mismatched/malformed/Expedition submissions cannot rank:** rejected before persistence by Ice Slide Daily admission.
+- **Different dates/generator/ruleset versions do not mix:** exact competition key is mandatory for Ice Slide Daily reads and is validated by the one parser; accepted writes must match that key's encoded identity.
+- **One row per user / better retries:** reused HPA-484 partitioned query unchanged.
+- **Tie-break order:** reused HPA-484 SQL and deterministic DB tests unchanged.
+- **Incomplete/mismatched/malformed/Expedition submissions cannot rank:** rejected before persistence by the pure Ice Slide Daily admission helper.
 - **Campaign compatibility:** Campaign writes and unscoped read branch remain unchanged.
-- **Local play survives failures:** leaderboard errors are page-local; score errors retain HPA-487 behavior.
-- **Authenticated/anonymous/empty/failure/success coverage:** split across API, init/page, and Playwright tests as described above.
+- **Local play survives failures:** leaderboard errors stay inside the Daily leaderboard controller; score errors retain HPA-487 behavior.
+- **Authenticated/anonymous/empty/failure/success coverage:** split across API, init, jsdom controller, and Playwright tests.
 
 ## 12. Self-review
 
 - No placeholder requirement remains.
-- The design adds no new database schema or endpoint.
-- The generic scoped query stays generic; Ice Slide-specific semantics stay at the API/game boundary.
-- The UI adds no reusable component before a second consumer exists.
-- Historical navigation, anti-cheat, Expedition ranking, and current-user rank-beyond-top-N remain explicitly out of scope.
+- There is one Daily-key parser and one current-version key constructor.
+- The existing scoped ranking query is reused without a redundant identity field.
+- Semantic admission is pure domain logic rather than a large route-local closure.
+- The single new client module is game-specific and exists to make async/token/render behavior directly testable.
+- No database schema, endpoint, shared UI abstraction, replay verifier, historical browser, Expedition ranking, or current-user rank-beyond-top-N query is added.

--- a/e2e/games/play-coverage.spec.ts
+++ b/e2e/games/play-coverage.spec.ts
@@ -642,6 +642,7 @@ test.describe('Ice Slide', () => {
         })
 
         await page.goto('/ice-slide?mode=daily')
+        await expect.poll(() => resolveDaily, { timeout: 10_000 }).toBeDefined()
         await page.locator('input[value="campaign"]').check()
 
         await expect(page.locator('#daily-leaderboard')).toHaveClass(/hidden/)

--- a/e2e/games/play-coverage.spec.ts
+++ b/e2e/games/play-coverage.spec.ts
@@ -599,14 +599,25 @@ test.describe('Ice Slide', () => {
         await page.goto('/ice-slide?mode=daily')
         await expect(page.locator('#daily-leaderboard-empty')).toBeVisible()
 
-        const before = leaderboardRequests.length
+        // Init has already fired one leaderboard request (Daily selected at
+        // load). The Start handler fires a second one for the captured runKey
+        // once the run begins, so wait for that Start-triggered request to
+        // land before capturing the pre-submit baseline. Otherwise the
+        // final count assertion could pass on the Start request alone, even
+        // if onScoreSaved stopped refreshing the leaderboard.
+        const afterStart = leaderboardRequests.length
         await startGameWhenReady(page)
         await expectVisibleGameSurface(page, '#game-canvas-container canvas')
+        await expect
+            .poll(() => leaderboardRequests.length, { timeout: 10_000 })
+            .toBeGreaterThan(afterStart)
+
+        const beforeSubmit = leaderboardRequests.length
         await completeFrozenDaily(page)
 
         await expect
             .poll(() => leaderboardRequests.length, { timeout: 10_000 })
-            .toBeGreaterThan(before)
+            .toBeGreaterThan(beforeSubmit)
         expect(leaderboardRequests[leaderboardRequests.length - 1]).toContain(
             'competitionKey=ice-slide%3Adaily%3A2026-08-12%3Ag1%3Ar1'
         )

--- a/e2e/games/play-coverage.spec.ts
+++ b/e2e/games/play-coverage.spec.ts
@@ -1,4 +1,5 @@
 import { test, expect, type Page } from '@playwright/test'
+import { ICE_SLIDE_DAILY_2026_08_12_DIRECTIONS } from '../../src/lib/games/ice-slide/test-fixtures'
 
 /**
  * One happy-path play test per game. Each game's "Start" listener attaches
@@ -335,6 +336,32 @@ test.describe('Satellite Sync', () => {
 })
 
 test.describe('Ice Slide', () => {
+    const DIRECTION_TO_KEY = {
+        N: 'ArrowUp',
+        E: 'ArrowRight',
+        S: 'ArrowDown',
+        W: 'ArrowLeft',
+    } as const
+
+    async function completeFrozenDaily(page: Page): Promise<void> {
+        for (
+            let stage = 0;
+            stage < ICE_SLIDE_DAILY_2026_08_12_DIRECTIONS.length;
+            stage++
+        ) {
+            for (const direction of ICE_SLIDE_DAILY_2026_08_12_DIRECTIONS[
+                stage
+            ]) {
+                await page.keyboard.press(DIRECTION_TO_KEY[direction])
+            }
+            if (stage < ICE_SLIDE_DAILY_2026_08_12_DIRECTIONS.length - 1) {
+                await expect(page.locator('#stage-clear-overlay')).toBeVisible()
+                await page.locator('#stage-clear-continue-btn').click()
+            }
+        }
+        await expect(page.locator('#game-over-overlay')).toBeVisible()
+    }
+
     test('renders, starts, accepts a move, and can be ended', async ({
         page,
     }) => {
@@ -447,4 +474,179 @@ test.describe('Ice Slide', () => {
             await expect(page.locator('#end-btn')).toHaveCSS('display', 'none')
         })
     }
+
+    test('loads the active Daily ranking and renders the empty + signed-out states', async ({
+        page,
+    }) => {
+        await page.clock.setFixedTime(new Date('2026-08-12T20:00:00Z'))
+        await page.route('**/api/leaderboard?*', async route => {
+            expect(route.request().url()).toContain(
+                'competitionKey=ice-slide%3Adaily%3A2026-08-12%3Ag1%3Ar1'
+            )
+            await route.fulfill({
+                status: 200,
+                contentType: 'application/json',
+                body: JSON.stringify({
+                    gameId: 'ice_slide',
+                    gameName: 'Ice Slide',
+                    viewerAuthenticated: false,
+                    leaderboard: [],
+                }),
+            })
+        })
+
+        await page.goto('/ice-slide?mode=daily')
+
+        await expect(page.locator('#daily-leaderboard-empty')).toBeVisible()
+        await expect(
+            page.locator('#daily-leaderboard-signed-out')
+        ).toBeVisible()
+    })
+
+    test('renders a ranked Daily row and highlights the viewer', async ({
+        page,
+    }) => {
+        await page.clock.setFixedTime(new Date('2026-08-12T20:00:00Z'))
+        await page.route('**/api/leaderboard?*', async route => {
+            await route.fulfill({
+                status: 200,
+                contentType: 'application/json',
+                body: JSON.stringify({
+                    gameId: 'ice_slide',
+                    gameName: 'Ice Slide',
+                    viewerAuthenticated: true,
+                    leaderboard: [
+                        {
+                            rank: 1,
+                            name: 'Pilot',
+                            score: 4321,
+                            elapsedSeconds: 87,
+                            totalMoves: 31,
+                            isCurrentUser: true,
+                        },
+                    ],
+                }),
+            })
+        })
+
+        await page.goto('/ice-slide?mode=daily')
+
+        const rows = page.locator('#daily-leaderboard-rows')
+        await expect(rows).toBeVisible()
+        const rowText = (await rows.textContent()) ?? ''
+        expect(rowText).toContain('#1')
+        expect(rowText).toContain('Pilot')
+        expect(rowText).toContain('4,321')
+        expect(rowText).toContain('1:27')
+        expect(rowText).toContain('31')
+        expect(rowText).toContain('YOU')
+    })
+
+    test('shows unavailable for a leaderboard failure without blocking Daily play', async ({
+        page,
+    }) => {
+        await page.clock.setFixedTime(new Date('2026-08-12T20:00:00Z'))
+        await page.route('**/api/leaderboard?*', route =>
+            route.fulfill({
+                status: 503,
+                contentType: 'application/json',
+                body: JSON.stringify({
+                    error: 'Scoped leaderboard is unavailable',
+                    code: 'SCOPED_LEADERBOARD_UNAVAILABLE',
+                }),
+            })
+        )
+
+        await page.goto('/ice-slide?mode=daily')
+
+        await expect(
+            page.locator('#daily-leaderboard-unavailable')
+        ).toBeVisible()
+        await startGameWhenReady(page)
+        await expectVisibleGameSurface(page, '#game-canvas-container canvas')
+        await expect(page.locator('#end-btn')).toBeVisible()
+        await expect(page.locator('#game-error')).toHaveClass(/hidden/)
+    })
+
+    test('refreshes the Daily ranking on a successful submit using the captured key', async ({
+        page,
+    }) => {
+        await page.clock.setFixedTime(new Date('2026-08-12T20:00:00Z'))
+        const leaderboardRequests: string[] = []
+        await page.route('**/api/leaderboard?*', route => {
+            leaderboardRequests.push(route.request().url())
+            return route.fulfill({
+                status: 200,
+                contentType: 'application/json',
+                body: JSON.stringify({
+                    gameId: 'ice_slide',
+                    gameName: 'Ice Slide',
+                    viewerAuthenticated: false,
+                    leaderboard: [],
+                }),
+            })
+        })
+        let scoresBody: Record<string, unknown> = {}
+        await page.route('**/api/scores', async route => {
+            scoresBody = JSON.parse(route.request().postData() ?? '{}')
+            await route.fulfill({
+                status: 200,
+                contentType: 'application/json',
+                body: JSON.stringify({ success: true, newAchievements: [] }),
+            })
+        })
+
+        await page.goto('/ice-slide?mode=daily')
+        await expect(page.locator('#daily-leaderboard-empty')).toBeVisible()
+
+        const before = leaderboardRequests.length
+        await startGameWhenReady(page)
+        await expectVisibleGameSurface(page, '#game-canvas-container canvas')
+        await completeFrozenDaily(page)
+
+        await expect
+            .poll(() => leaderboardRequests.length, { timeout: 10_000 })
+            .toBeGreaterThan(before)
+        expect(leaderboardRequests[leaderboardRequests.length - 1]).toContain(
+            'competitionKey=ice-slide%3Adaily%3A2026-08-12%3Ag1%3Ar1'
+        )
+        expect(scoresBody).toMatchObject({
+            context: {
+                mode: 'daily',
+                competitionKey: 'ice-slide:daily:2026-08-12:g1:r1',
+                rulesetVersion: 1,
+            },
+        })
+        expect((scoresBody.gameData as { solved?: boolean }).solved).toBe(true)
+    })
+
+    test('suppresses a delayed leaderboard response after switching to Campaign', async ({
+        page,
+    }) => {
+        await page.clock.setFixedTime(new Date('2026-08-12T20:00:00Z'))
+        let resolveDaily: (() => void) | undefined
+        await page.route('**/api/leaderboard?*', async route => {
+            await new Promise<void>(resolve => {
+                resolveDaily = resolve
+            })
+            await route.fulfill({
+                status: 200,
+                contentType: 'application/json',
+                body: JSON.stringify({
+                    gameId: 'ice_slide',
+                    gameName: 'Ice Slide',
+                    viewerAuthenticated: false,
+                    leaderboard: [],
+                }),
+            })
+        })
+
+        await page.goto('/ice-slide?mode=daily')
+        await page.locator('input[value="campaign"]').check()
+
+        await expect(page.locator('#daily-leaderboard')).toHaveClass(/hidden/)
+        resolveDaily?.()
+        await expect(page.locator('#daily-leaderboard')).toHaveClass(/hidden/)
+        await expect(page.locator('#daily-leaderboard-rows')).toBeEmpty()
+    })
 })

--- a/src/lib/games/ice-slide/daily-leaderboard.test.ts
+++ b/src/lib/games/ice-slide/daily-leaderboard.test.ts
@@ -1,0 +1,239 @@
+import { beforeEach, describe, expect, it, vi } from 'vitest'
+import {
+    buildIceSlideDailyLeaderboardUrl,
+    createDailyLeaderboardController,
+    createDailyLeaderboardRowElement,
+    formatDailyLeaderboardElapsed,
+    setDailyLeaderboardPanelState,
+    type DailyLeaderboardElements,
+    type DailyLeaderboardEntry,
+} from './daily-leaderboard'
+
+function mountElements(): DailyLeaderboardElements {
+    const make = (id: string) => {
+        const el = document.createElement('div')
+        el.id = id
+        el.classList.add('hidden')
+        document.body.appendChild(el)
+        return el
+    }
+    return {
+        panel: make('daily-leaderboard'),
+        date: make('daily-leaderboard-date'),
+        signedOut: make('daily-leaderboard-signed-out'),
+        loading: make('daily-leaderboard-loading'),
+        empty: make('daily-leaderboard-empty'),
+        unavailable: make('daily-leaderboard-unavailable'),
+        rows: make('daily-leaderboard-rows'),
+    }
+}
+
+function makeResponse(body: unknown): Response {
+    return {
+        ok: true,
+        status: 200,
+        json: async () => body,
+    } as unknown as Response
+}
+
+const baseEntry = (
+    overrides: Partial<DailyLeaderboardEntry> = {}
+): DailyLeaderboardEntry => ({
+    rank: 1,
+    name: 'Pilot',
+    score: 4321,
+    elapsedSeconds: 87,
+    totalMoves: 31,
+    isCurrentUser: true,
+    ...overrides,
+})
+
+describe('Ice Slide Daily leaderboard helpers', () => {
+    it('builds the scoped Daily leaderboard URL with an encoded key', () => {
+        expect(
+            buildIceSlideDailyLeaderboardUrl('ice-slide:daily:2026-08-12:g1:r1')
+        ).toBe(
+            '/api/leaderboard?gameId=ice_slide&mode=daily&competitionKey=' +
+                'ice-slide%3Adaily%3A2026-08-12%3Ag1%3Ar1&limit=10'
+        )
+    })
+
+    it('formats elapsed seconds for the leaderboard', () => {
+        expect(formatDailyLeaderboardElapsed(null)).toBe('—')
+        expect(formatDailyLeaderboardElapsed(87)).toBe('1:27')
+        expect(formatDailyLeaderboardElapsed(3665)).toBe('1:01:05')
+    })
+
+    it('renders a ranked leaderboard row without innerHTML', () => {
+        const row = createDailyLeaderboardRowElement(baseEntry(), document)
+
+        const text = row.textContent ?? ''
+        expect(text).toContain('1')
+        expect(text).toContain('Pilot')
+        expect(text).toContain('4,321')
+        expect(text).toContain('1:27')
+        expect(text).toContain('31')
+        expect(text).toContain('YOU')
+    })
+
+    it('omits the YOU badge for other users', () => {
+        const row = createDailyLeaderboardRowElement(
+            baseEntry({ rank: 2, name: 'Rival', isCurrentUser: false }),
+            document
+        )
+        expect(row.textContent ?? '').not.toContain('YOU')
+    })
+
+    it('toggles the four panel states', () => {
+        const elements = mountElements()
+
+        setDailyLeaderboardPanelState(elements, 'loading')
+        expect(elements.loading.classList.contains('hidden')).toBe(false)
+        expect(elements.empty.classList.contains('hidden')).toBe(true)
+        expect(elements.unavailable.classList.contains('hidden')).toBe(true)
+        expect(elements.rows.classList.contains('hidden')).toBe(true)
+
+        setDailyLeaderboardPanelState(elements, 'empty')
+        expect(elements.empty.classList.contains('hidden')).toBe(false)
+        expect(elements.loading.classList.contains('hidden')).toBe(true)
+
+        setDailyLeaderboardPanelState(elements, 'unavailable')
+        expect(elements.unavailable.classList.contains('hidden')).toBe(false)
+
+        setDailyLeaderboardPanelState(elements, 'rows')
+        expect(elements.rows.classList.contains('hidden')).toBe(false)
+    })
+})
+
+describe('Ice Slide Daily leaderboard controller', () => {
+    let elements: DailyLeaderboardElements
+    let resolvers: ((response: Response) => void)[]
+    let deferredFetcher: ReturnType<typeof vi.fn>
+
+    beforeEach(() => {
+        document.body.innerHTML = ''
+        elements = mountElements()
+        resolvers = []
+        deferredFetcher = vi.fn(
+            () =>
+                new Promise<Response>(resolve => {
+                    resolvers.push(resolve)
+                })
+        )
+    })
+
+    const okFetcher = (body: unknown) => () =>
+        Promise.resolve(makeResponse(body))
+
+    it('renders a successful load and replaces rows across refreshes', async () => {
+        const controller = createDailyLeaderboardController(
+            elements,
+            okFetcher({
+                viewerAuthenticated: true,
+                leaderboard: [baseEntry()],
+            })
+        )
+
+        await controller.load('ice-slide:daily:2026-08-12:g1:r1')
+
+        expect(elements.panel.classList.contains('hidden')).toBe(false)
+        expect(elements.date.textContent).toBe('2026-08-12')
+        expect(elements.signedOut.classList.contains('hidden')).toBe(true)
+        expect(elements.rows.classList.contains('hidden')).toBe(false)
+        expect(elements.rows.children).toHaveLength(1)
+
+        await controller.load('ice-slide:daily:2026-08-12:g1:r1')
+        expect(elements.rows.children).toHaveLength(1)
+    })
+
+    it('shows the signed-out note when the viewer is unauthenticated', async () => {
+        const controller = createDailyLeaderboardController(
+            elements,
+            okFetcher({
+                viewerAuthenticated: false,
+                leaderboard: [baseEntry()],
+            })
+        )
+
+        await controller.load('ice-slide:daily:2026-08-12:g1:r1')
+
+        expect(elements.signedOut.classList.contains('hidden')).toBe(false)
+    })
+
+    it('shows the empty state when the leaderboard has no rows', async () => {
+        const controller = createDailyLeaderboardController(
+            elements,
+            okFetcher({ viewerAuthenticated: false, leaderboard: [] })
+        )
+
+        await controller.load('ice-slide:daily:2026-08-12:g1:r1')
+
+        expect(elements.empty.classList.contains('hidden')).toBe(false)
+        expect(elements.rows.classList.contains('hidden')).toBe(true)
+        expect(elements.rows.children).toHaveLength(0)
+    })
+
+    it('shows unavailable for an invalid Daily key and hides rows', async () => {
+        const controller = createDailyLeaderboardController(
+            elements,
+            deferredFetcher
+        )
+
+        await controller.load('not-a-daily-key')
+
+        expect(elements.panel.classList.contains('hidden')).toBe(false)
+        expect(elements.unavailable.classList.contains('hidden')).toBe(false)
+        expect(elements.rows.classList.contains('hidden')).toBe(true)
+        expect(deferredFetcher).not.toHaveBeenCalled()
+    })
+
+    it('suppresses a stale response in favor of a newer Daily key', async () => {
+        const controller = createDailyLeaderboardController(
+            elements,
+            deferredFetcher
+        )
+
+        const oldPromise = controller.load('ice-slide:daily:2026-08-11:g1:r1')
+        const newPromise = controller.load('ice-slide:daily:2026-08-12:g1:r1')
+
+        resolvers[1](
+            makeResponse({
+                viewerAuthenticated: true,
+                leaderboard: [baseEntry({ name: 'New Pilot' })],
+            })
+        )
+        resolvers[0](
+            makeResponse({
+                viewerAuthenticated: true,
+                leaderboard: [baseEntry({ name: 'Old Pilot' })],
+            })
+        )
+        await Promise.all([oldPromise, newPromise])
+
+        expect(elements.rows.textContent).toContain('New Pilot')
+        expect(elements.rows.textContent).not.toContain('Old Pilot')
+    })
+
+    it('does not reveal the panel after hide() while a request is pending', async () => {
+        const controller = createDailyLeaderboardController(
+            elements,
+            deferredFetcher
+        )
+
+        const pending = controller.load('ice-slide:daily:2026-08-12:g1:r1')
+        controller.hide()
+
+        expect(elements.panel.classList.contains('hidden')).toBe(true)
+
+        resolvers[0](
+            makeResponse({
+                viewerAuthenticated: true,
+                leaderboard: [baseEntry({ name: 'Late Pilot' })],
+            })
+        )
+        await pending
+
+        expect(elements.panel.classList.contains('hidden')).toBe(true)
+        expect(elements.rows.children).toHaveLength(0)
+    })
+})

--- a/src/lib/games/ice-slide/daily-leaderboard.test.ts
+++ b/src/lib/games/ice-slide/daily-leaderboard.test.ts
@@ -236,4 +236,45 @@ describe('Ice Slide Daily leaderboard controller', () => {
         expect(elements.panel.classList.contains('hidden')).toBe(true)
         expect(elements.rows.children).toHaveLength(0)
     })
+
+    it('shows unavailable when the leaderboard fetch rejects', async () => {
+        const controller = createDailyLeaderboardController(elements, () =>
+            Promise.reject(new Error('network error'))
+        )
+
+        await controller.load('ice-slide:daily:2026-08-12:g1:r1')
+
+        expect(elements.unavailable.classList.contains('hidden')).toBe(false)
+        expect(elements.rows.classList.contains('hidden')).toBe(true)
+    })
+
+    it('shows unavailable when the leaderboard response is not ok', async () => {
+        const controller = createDailyLeaderboardController(elements, () =>
+            Promise.resolve({
+                ok: false,
+                status: 503,
+                json: async () => ({}),
+            } as unknown as Response)
+        )
+
+        await controller.load('ice-slide:daily:2026-08-12:g1:r1')
+
+        expect(elements.unavailable.classList.contains('hidden')).toBe(false)
+    })
+
+    it('shows unavailable when the leaderboard body fails to parse', async () => {
+        const controller = createDailyLeaderboardController(elements, () =>
+            Promise.resolve({
+                ok: true,
+                status: 200,
+                json: async () => {
+                    throw new Error('bad json')
+                },
+            } as unknown as Response)
+        )
+
+        await controller.load('ice-slide:daily:2026-08-12:g1:r1')
+
+        expect(elements.unavailable.classList.contains('hidden')).toBe(false)
+    })
 })

--- a/src/lib/games/ice-slide/daily-leaderboard.ts
+++ b/src/lib/games/ice-slide/daily-leaderboard.ts
@@ -1,0 +1,222 @@
+import { formatNumber, formatTime } from '../shared/utils'
+import { parseIceSlideDailyRunKey } from './run'
+
+export interface DailyLeaderboardEntry {
+    rank: number
+    name: string
+    score: number
+    elapsedSeconds: number | null
+    totalMoves: number | null
+    isCurrentUser: boolean
+}
+
+export interface DailyLeaderboardResponse {
+    viewerAuthenticated: boolean
+    leaderboard: DailyLeaderboardEntry[]
+}
+
+export type DailyLeaderboardPanelState =
+    | 'loading'
+    | 'empty'
+    | 'unavailable'
+    | 'rows'
+
+export interface DailyLeaderboardElements {
+    panel: HTMLElement
+    date: HTMLElement
+    signedOut: HTMLElement
+    loading: HTMLElement
+    empty: HTMLElement
+    unavailable: HTMLElement
+    rows: HTMLElement
+}
+
+/**
+ * Build the exact scoped `/api/leaderboard` URL for an Ice Slide Daily
+ * competition key. The key is URL-encoded so its colons survive transport.
+ */
+export function buildIceSlideDailyLeaderboardUrl(
+    competitionKey: string
+): string {
+    const params = new URLSearchParams({
+        gameId: 'ice_slide',
+        mode: 'daily',
+        competitionKey,
+        limit: '10',
+    })
+    return `/api/leaderboard?${params.toString()}`
+}
+
+/**
+ * Format an elapsed-seconds value for the Daily leaderboard. `null` (missing
+ * metric) renders as an em dash; otherwise the shared H:MM:SS / M:SS formatter
+ * is reused. The existing in-run Ice Slide HUD formatter is intentionally left
+ * untouched.
+ */
+export function formatDailyLeaderboardElapsed(seconds: number | null): string {
+    return seconds === null ? '—' : formatTime(seconds)
+}
+
+/**
+ * Create one leaderboard row using the DOM API only (no innerHTML). The viewer
+ * row gets a literal `YOU` badge plus a distinct class so identity is not
+ * communicated by color alone.
+ */
+export function createDailyLeaderboardRowElement(
+    entry: DailyLeaderboardEntry,
+    document: Document
+): HTMLElement {
+    const row = document.createElement('div')
+    row.className =
+        'flex items-center justify-between gap-2 rounded-md border border-cetus-hairline/50 bg-cetus-surface/60 px-3 py-2 text-sm'
+
+    const left = document.createElement('div')
+    left.className = 'flex items-center gap-2'
+
+    const rank = document.createElement('span')
+    rank.className = 'font-mono text-cetus-ink-muted'
+    rank.textContent = `#${entry.rank}`
+
+    const name = document.createElement('span')
+    name.className = 'text-cetus-ink'
+    name.textContent = entry.name
+
+    left.append(rank, name)
+
+    if (entry.isCurrentUser) {
+        row.classList.add('border-cetus-accent/70', 'bg-cetus-accent/10')
+        const badge = document.createElement('span')
+        badge.className =
+            'rounded border border-cetus-accent px-1 text-xs font-bold text-cetus-accent'
+        badge.textContent = 'YOU'
+        left.appendChild(badge)
+    }
+
+    const right = document.createElement('div')
+    right.className =
+        'flex items-center gap-3 font-mono text-xs text-cetus-ink-muted'
+
+    const score = document.createElement('span')
+    score.textContent = formatNumber(entry.score)
+
+    const elapsed = document.createElement('span')
+    elapsed.textContent = formatDailyLeaderboardElapsed(entry.elapsedSeconds)
+
+    const moves = document.createElement('span')
+    moves.textContent = entry.totalMoves === null ? '—' : `${entry.totalMoves}`
+
+    right.append(score, elapsed, moves)
+    row.append(left, right)
+    return row
+}
+
+/**
+ * Toggle the four mutually-exclusive panel sub-states. The panel container's
+ * own visibility is managed by the controller (`load` shows it, `hide` hides
+ * it); this only selects which sub-message / row list is visible.
+ */
+export function setDailyLeaderboardPanelState(
+    elements: DailyLeaderboardElements,
+    state: DailyLeaderboardPanelState
+): void {
+    elements.loading.classList.toggle('hidden', state !== 'loading')
+    elements.empty.classList.toggle('hidden', state !== 'empty')
+    elements.unavailable.classList.toggle('hidden', state !== 'unavailable')
+    elements.rows.classList.toggle('hidden', state !== 'rows')
+}
+
+function clearRows(rows: HTMLElement): void {
+    while (rows.firstChild) {
+        rows.removeChild(rows.firstChild)
+    }
+}
+
+/**
+ * Create a small closure-based controller for the Ice Slide Daily leaderboard
+ * panel. One monotonically-increasing request token invalidates stale fetches
+ * and hides; no AbortController, store, or event bus.
+ */
+export function createDailyLeaderboardController(
+    elements: DailyLeaderboardElements,
+    fetcher: typeof fetch = fetch
+): {
+    load: (competitionKey: string) => Promise<void>
+    hide: () => void
+} {
+    let token = 0
+
+    const render = (data: DailyLeaderboardResponse): void => {
+        clearRows(elements.rows)
+        elements.signedOut.classList.toggle('hidden', data.viewerAuthenticated)
+        if (data.leaderboard.length === 0) {
+            setDailyLeaderboardPanelState(elements, 'empty')
+            return
+        }
+        for (const entry of data.leaderboard) {
+            elements.rows.appendChild(
+                createDailyLeaderboardRowElement(entry, document)
+            )
+        }
+        setDailyLeaderboardPanelState(elements, 'rows')
+    }
+
+    const showUnavailable = (): void => {
+        setDailyLeaderboardPanelState(elements, 'unavailable')
+    }
+
+    const load = async (competitionKey: string): Promise<void> => {
+        const current = ++token
+
+        const identity = parseIceSlideDailyRunKey(competitionKey)
+        if (!identity) {
+            elements.panel.classList.remove('hidden')
+            showUnavailable()
+            return
+        }
+
+        elements.panel.classList.remove('hidden')
+        elements.date.textContent = identity.dateKey
+        setDailyLeaderboardPanelState(elements, 'loading')
+
+        let response: Response
+        try {
+            response = await fetcher(
+                buildIceSlideDailyLeaderboardUrl(competitionKey)
+            )
+        } catch {
+            if (current === token) {
+                showUnavailable()
+            }
+            return
+        }
+        if (current !== token) {
+            return
+        }
+        if (!response.ok) {
+            showUnavailable()
+            return
+        }
+
+        let data: DailyLeaderboardResponse
+        try {
+            data = (await response.json()) as DailyLeaderboardResponse
+        } catch {
+            if (current === token) {
+                showUnavailable()
+            }
+            return
+        }
+        if (current !== token) {
+            return
+        }
+
+        render(data)
+    }
+
+    const hide = (): void => {
+        token++
+        elements.panel.classList.add('hidden')
+    }
+
+    return { load, hide }
+}

--- a/src/lib/games/ice-slide/daily.test.ts
+++ b/src/lib/games/ice-slide/daily.test.ts
@@ -2,6 +2,7 @@ import { describe, expect, it } from 'vitest'
 import { serializeBoardRows } from './transforms'
 import { assertValidIceSlideRunDefinition } from './run'
 import {
+    createIceSlideDailyCompetitionKey,
     createIceSlideDailyRunDefinition,
     ICE_SLIDE_DAILY_GENERATOR_VERSION,
     ICE_SLIDE_DAILY_SOLVER_MAX_STATES,
@@ -190,5 +191,13 @@ describe('Ice Slide Daily generator v1', () => {
                 new Set(run.stages.map(stage => stage.templateId)).size
             ).toBe(run.stages.length)
         }
+    })
+})
+
+describe('Ice Slide Daily competition key constructor', () => {
+    it('builds the frozen generator-v1 Daily competition key', () => {
+        expect(createIceSlideDailyCompetitionKey('2026-08-12')).toBe(
+            'ice-slide:daily:2026-08-12:g1:r1'
+        )
     })
 })

--- a/src/lib/games/ice-slide/daily.test.ts
+++ b/src/lib/games/ice-slide/daily.test.ts
@@ -1,6 +1,8 @@
 import { describe, expect, it } from 'vitest'
 import { serializeBoardRows } from './transforms'
 import { assertValidIceSlideRunDefinition } from './run'
+import { IceSlideGame } from './game'
+import { solveIceSlideBoard } from './solver'
 import {
     createIceSlideDailyCompetitionKey,
     createIceSlideDailyRunDefinition,
@@ -9,6 +11,7 @@ import {
     ICE_SLIDE_DAILY_STAGE_POOLS,
     toIceSlideUtcDateKey,
 } from './daily'
+import { ICE_SLIDE_DAILY_2026_08_12_DIRECTIONS } from './test-fixtures'
 
 describe('Ice Slide Daily date keys', () => {
     it('formats a Date in UTC', () => {
@@ -199,5 +202,42 @@ describe('Ice Slide Daily competition key constructor', () => {
         expect(createIceSlideDailyCompetitionKey('2026-08-12')).toBe(
             'ice-slide:daily:2026-08-12:g1:r1'
         )
+    })
+})
+
+describe('Ice Slide Daily frozen 2026-08-12 playthrough', () => {
+    it('locks the shared 2026-08-12 minimum-move completion fixture', () => {
+        const run = createIceSlideDailyRunDefinition('2026-08-12')
+        expect(ICE_SLIDE_DAILY_2026_08_12_DIRECTIONS).toHaveLength(
+            run.stages.length
+        )
+
+        const game = new IceSlideGame()
+        game.start(run)
+
+        for (const [
+            stageIndex,
+            directions,
+        ] of ICE_SLIDE_DAILY_2026_08_12_DIRECTIONS.entries()) {
+            const stage = run.stages[stageIndex]
+            const solved = solveIceSlideBoard(stage, {
+                maxStates: ICE_SLIDE_DAILY_SOLVER_MAX_STATES,
+            })
+            expect(solved.truncated).toBe(false)
+            expect(solved.minMoves).toBe(directions.length)
+
+            for (const direction of directions) {
+                game.move(direction)
+            }
+
+            if (stageIndex < run.stages.length - 1) {
+                expect(game.getState().levelIndex).toBe(stageIndex + 1)
+                expect(game.getState().status).toBe('playing')
+            }
+        }
+
+        expect(game.getState().status).toBe('won')
+        expect(game.getGameData().solved).toBe(true)
+        game.destroy()
     })
 })

--- a/src/lib/games/ice-slide/daily.test.ts
+++ b/src/lib/games/ice-slide/daily.test.ts
@@ -213,31 +213,34 @@ describe('Ice Slide Daily frozen 2026-08-12 playthrough', () => {
         )
 
         const game = new IceSlideGame()
-        game.start(run)
+        try {
+            game.start(run)
 
-        for (const [
-            stageIndex,
-            directions,
-        ] of ICE_SLIDE_DAILY_2026_08_12_DIRECTIONS.entries()) {
-            const stage = run.stages[stageIndex]
-            const solved = solveIceSlideBoard(stage, {
-                maxStates: ICE_SLIDE_DAILY_SOLVER_MAX_STATES,
-            })
-            expect(solved.truncated).toBe(false)
-            expect(solved.minMoves).toBe(directions.length)
+            for (const [
+                stageIndex,
+                directions,
+            ] of ICE_SLIDE_DAILY_2026_08_12_DIRECTIONS.entries()) {
+                const stage = run.stages[stageIndex]
+                const solved = solveIceSlideBoard(stage, {
+                    maxStates: ICE_SLIDE_DAILY_SOLVER_MAX_STATES,
+                })
+                expect(solved.truncated).toBe(false)
+                expect(solved.minMoves).toBe(directions.length)
 
-            for (const direction of directions) {
-                game.move(direction)
+                for (const direction of directions) {
+                    game.move(direction)
+                }
+
+                if (stageIndex < run.stages.length - 1) {
+                    expect(game.getState().levelIndex).toBe(stageIndex + 1)
+                    expect(game.getState().status).toBe('playing')
+                }
             }
 
-            if (stageIndex < run.stages.length - 1) {
-                expect(game.getState().levelIndex).toBe(stageIndex + 1)
-                expect(game.getState().status).toBe('playing')
-            }
+            expect(game.getState().status).toBe('won')
+            expect(game.getGameData().solved).toBe(true)
+        } finally {
+            game.destroy()
         }
-
-        expect(game.getState().status).toBe('won')
-        expect(game.getGameData().solved).toBe(true)
-        game.destroy()
     })
 })

--- a/src/lib/games/ice-slide/daily.ts
+++ b/src/lib/games/ice-slide/daily.ts
@@ -5,6 +5,7 @@ import {
     assertValidIceSlideRunDefinition,
     assertValidIceSlideUtcDateKey,
     createIceSlideStageSignature,
+    formatIceSlideDailyRunKey,
     ICE_SLIDE_RULESET_VERSION,
     ICE_SLIDE_RUN_SCHEMA_VERSION,
     CAMPAIGN_STAGE_DIFFICULTIES,
@@ -50,6 +51,14 @@ export function toIceSlideUtcDateKey(date: Date): string {
     ].join('-')
     assertValidIceSlideUtcDateKey(dateKey)
     return dateKey
+}
+
+export function createIceSlideDailyCompetitionKey(dateKey: string): string {
+    return formatIceSlideDailyRunKey({
+        dateKey,
+        generatorVersion: ICE_SLIDE_DAILY_GENERATOR_VERSION,
+        rulesetVersion: ICE_SLIDE_RULESET_VERSION,
+    })
 }
 
 export function createIceSlideDailyRunDefinition(
@@ -187,7 +196,7 @@ export function createIceSlideDailyRunDefinition(
         generatorVersion: ICE_SLIDE_DAILY_GENERATOR_VERSION,
         rulesetVersion: ICE_SLIDE_RULESET_VERSION,
         mode: 'daily',
-        runKey: `ice-slide:daily:${dateKey}:g${ICE_SLIDE_DAILY_GENERATOR_VERSION}:r${ICE_SLIDE_RULESET_VERSION}`,
+        runKey: createIceSlideDailyCompetitionKey(dateKey),
         seed,
         stages,
     }

--- a/src/lib/games/ice-slide/init.test.ts
+++ b/src/lib/games/ice-slide/init.test.ts
@@ -110,6 +110,7 @@ const baseCallbacks = () => ({
     onTimeUpdate: vi.fn(),
     onWin: vi.fn(),
     onError: vi.fn(),
+    onScoreSaved: vi.fn(),
 })
 
 function findSolution(
@@ -797,6 +798,102 @@ describe('initializeIceSlide', () => {
 
         expect(saveGameScore).toHaveBeenCalledTimes(1)
         expect(callbacks.onError).not.toHaveBeenCalled()
+        handle.cleanup()
+    })
+
+    it('fires onScoreSaved after a current successful Daily save', async () => {
+        const callbacks = baseCallbacks()
+        const container = mountDom()
+        const handle = await initializeIceSlide(container, callbacks)
+        await handle.start('daily')
+
+        vi.mocked(saveGameScore).mockImplementation(
+            (_id, _score, onSuccess) => {
+                onSuccess?.({ success: true, newAchievements: [] } as never)
+                return Promise.resolve()
+            }
+        )
+
+        for (let stage = 1; stage <= 5; stage++) {
+            solveCurrentStage(handle)
+            if (stage < 5) {
+                document.getElementById('stage-clear-continue-btn')?.click()
+            }
+        }
+
+        expect(callbacks.onScoreSaved).toHaveBeenCalledTimes(1)
+        const saved = callbacks.onScoreSaved.mock.calls[0][0]
+        expect(saved.mode).toBe('daily')
+        expect(saved.solved).toBe(true)
+        const runKey = handle.getGame()?.getState().runKey
+        expect(saved.runKey).toBe(runKey)
+        handle.cleanup()
+    })
+
+    it('does not fire onScoreSaved on an unauthenticated Daily score error', async () => {
+        const callbacks = baseCallbacks()
+        const container = mountDom()
+        const handle = await initializeIceSlide(container, callbacks)
+        await handle.start('daily')
+
+        vi.mocked(saveGameScore).mockImplementation(
+            (_id, _score, _onSuccess, onErrorCb) => {
+                onErrorCb?.('You must be logged in to save scores', {
+                    success: false,
+                    code: 'UNAUTHENTICATED',
+                })
+                return Promise.resolve()
+            }
+        )
+
+        for (let stage = 1; stage <= 5; stage++) {
+            solveCurrentStage(handle)
+            if (stage < 5) {
+                document.getElementById('stage-clear-continue-btn')?.click()
+            }
+        }
+
+        expect(callbacks.onScoreSaved).not.toHaveBeenCalled()
+        handle.cleanup()
+    })
+
+    it('does not fire onScoreSaved on a generic score error', async () => {
+        const callbacks = baseCallbacks()
+        const container = mountDom()
+        const handle = await initializeIceSlide(container, callbacks)
+        await handle.start()
+        handle.getGame()?.move('S')
+
+        vi.mocked(saveGameScore).mockImplementation(
+            (_id, _score, _onSuccess, onErrorCb) => {
+                onErrorCb?.('nope')
+                return Promise.resolve()
+            }
+        )
+
+        handle.stop()
+        expect(callbacks.onScoreSaved).not.toHaveBeenCalled()
+        handle.cleanup()
+    })
+
+    it('suppresses onScoreSaved when a newer run starts first', async () => {
+        const callbacks = baseCallbacks()
+        let onSuccess: ((result: unknown) => void) | undefined
+        const container = mountDom()
+        const handle = await initializeIceSlide(container, callbacks)
+        await handle.start()
+        handle.getGame()?.move('S')
+
+        vi.mocked(saveGameScore).mockImplementation((_id, _score, success) => {
+            onSuccess = success as ((result: unknown) => void) | undefined
+            return Promise.resolve()
+        })
+
+        handle.stop()
+        await handle.start()
+
+        onSuccess?.({ success: true, newAchievements: [] })
+        expect(callbacks.onScoreSaved).not.toHaveBeenCalled()
         handle.cleanup()
     })
 

--- a/src/lib/games/ice-slide/init.ts
+++ b/src/lib/games/ice-slide/init.ts
@@ -11,7 +11,7 @@ import { saveGameScore } from '@/lib/services/scoreService'
 import { GameID } from '@/lib/games'
 import { createRunGuard } from '@/lib/games/core'
 import { createIceSlideDailyRunDefinition, toIceSlideUtcDateKey } from './daily'
-import { cloneIceSlideRunDefinition } from './run'
+import { cloneIceSlideRunDefinition, parseIceSlideDailyRunKey } from './run'
 import { ICE_SLIDE_OBJECTIVE_LABELS } from './objectives'
 import type {
     IceSlideCallbacks,
@@ -72,10 +72,6 @@ function formatTime(seconds: number): string {
     const m = Math.floor(seconds / 60)
     const s = seconds % 60
     return `${m}:${s.toString().padStart(2, '0')}`
-}
-
-function extractDailyDateKey(runKey: string): string | null {
-    return /^ice-slide:daily:(\d{4}-\d{2}-\d{2}):/.exec(runKey)?.[1] ?? null
 }
 
 function nextUtcDateKey(dateKey: string): string {
@@ -217,7 +213,9 @@ export async function initializeIceSlide(
         }
 
         const capturedDateKey =
-            dailyDateKey ?? extractDailyDateKey(state.runKey) ?? ''
+            dailyDateKey ??
+            parseIceSlideDailyRunKey(state.runKey)?.dateKey ??
+            ''
         setText('daily-date', capturedDateKey)
         if (capturedDateKey) {
             setText(
@@ -403,8 +401,7 @@ export async function initializeIceSlide(
         setVisible('game-over-overlay', false)
         if (run?.mode === 'daily') {
             currentMode = 'daily'
-            dailyDateKey =
-                dailyDateKey ?? extractDailyDateKey(run.runKey) ?? null
+            dailyDateKey = parseIceSlideDailyRunKey(run.runKey)?.dateKey ?? null
         } else {
             currentMode = 'campaign'
         }
@@ -488,7 +485,8 @@ export async function initializeIceSlide(
         playAgain: async () => {
             if (currentMode === 'daily' && retryDailyRun) {
                 const run = cloneIceSlideRunDefinition(retryDailyRun)
-                dailyDateKey = extractDailyDateKey(run.runKey)
+                dailyDateKey =
+                    parseIceSlideDailyRunKey(run.runKey)?.dateKey ?? null
                 await startRun(run)
                 return
             }

--- a/src/lib/games/ice-slide/init.ts
+++ b/src/lib/games/ice-slide/init.ts
@@ -15,6 +15,7 @@ import { cloneIceSlideRunDefinition, parseIceSlideDailyRunKey } from './run'
 import { ICE_SLIDE_OBJECTIVE_LABELS } from './objectives'
 import type {
     IceSlideCallbacks,
+    IceSlideGameData,
     IceSlidePlayableMode,
     IceSlideRunDefinition,
     IceSlideStageClearResult,
@@ -26,6 +27,7 @@ export const CELL_SIZE = 48
 
 export interface IceSlideUICallbacks extends IceSlideCallbacks {
     onError?: (title: string, message: string) => void
+    onScoreSaved?: (gameData: IceSlideGameData) => void
 }
 
 export interface IceSlideHandle {
@@ -300,6 +302,7 @@ export async function initializeIceSlide(
                         })
                     )
                 }
+                callbacks.onScoreSaved?.(gameData)
             },
             (error, result) => {
                 if (isStale()) {

--- a/src/lib/games/ice-slide/run.test.ts
+++ b/src/lib/games/ice-slide/run.test.ts
@@ -609,10 +609,24 @@ describe('Ice Slide Daily competition key grammar', () => {
         expect(parseIceSlideDailyRunKey(key)).toEqual(identity)
     })
 
+    it('accepts the maximum positive signed-int versions (0x7fffffff)', () => {
+        expect(
+            parseIceSlideDailyRunKey(
+                'ice-slide:daily:2026-08-12:g2147483647:r2147483647'
+            )
+        ).toEqual({
+            dateKey: '2026-08-12',
+            generatorVersion: 2147483647,
+            rulesetVersion: 2147483647,
+        })
+    })
+
     it.each([
         'ice-slide:daily:2026-02-29:g1:r1',
         'ice-slide:daily:2026-08-12:g0:r1',
         'ice-slide:daily:2026-08-12:g1:r0',
+        'ice-slide:daily:2026-08-12:g2147483648:r1',
+        'ice-slide:daily:2026-08-12:g1:r2147483648',
         'ice-slide:daily:2026-08-12:g1',
         'ice-slide:daily:2026-08-12:g1:r1:extra',
         'daily:2026-08-12:g1:r1',

--- a/src/lib/games/ice-slide/run.test.ts
+++ b/src/lib/games/ice-slide/run.test.ts
@@ -732,6 +732,24 @@ describe('Ice Slide Daily score admission', () => {
             { ...validDailyGameData, totalMoves: -1 },
             'invalid-total-moves',
         ],
+        [
+            'invalid-elapsed-seconds-above-max-safe-integer',
+            validDailyContext,
+            {
+                ...validDailyGameData,
+                elapsedSeconds: Number.MAX_SAFE_INTEGER + 1,
+            },
+            'invalid-elapsed-seconds',
+        ],
+        [
+            'invalid-total-moves-above-max-safe-integer',
+            validDailyContext,
+            {
+                ...validDailyGameData,
+                totalMoves: Number.MAX_SAFE_INTEGER + 1,
+            },
+            'invalid-total-moves',
+        ],
     ])('returns reason %s', (_name, context, gameData, expected) => {
         expect(iceSlideDailyAdmissionError(context, gameData)).toEqual({
             reason: expected,

--- a/src/lib/games/ice-slide/run.test.ts
+++ b/src/lib/games/ice-slide/run.test.ts
@@ -13,6 +13,7 @@ import {
     createIceSlideStageSignature,
     parseIceSlideDailyRunKey,
     formatIceSlideDailyRunKey,
+    iceSlideDailyAdmissionError,
 } from './run'
 import type { IceSlideObjectiveId, IceSlideRunDefinition } from './types'
 
@@ -625,5 +626,137 @@ describe('Ice Slide Daily competition key grammar', () => {
         [{ dateKey: '2026-08-12', generatorVersion: 1, rulesetVersion: 0 }],
     ])('rejects invalid formatted identity %j', identity => {
         expect(() => formatIceSlideDailyRunKey(identity)).toThrow()
+    })
+})
+
+describe('Ice Slide Daily score admission', () => {
+    const validDailyContext = {
+        mode: 'daily',
+        competitionKey: 'ice-slide:daily:2026-08-12:g1:r1',
+        rulesetVersion: 1,
+    }
+
+    const validDailyGameData = {
+        mode: 'daily',
+        solved: true,
+        runKey: 'ice-slide:daily:2026-08-12:g1:r1',
+        generatorVersion: 1,
+        rulesetVersion: 1,
+        elapsedSeconds: 87,
+        totalMoves: 31,
+    }
+
+    it('admits a valid Daily payload', () => {
+        expect(
+            iceSlideDailyAdmissionError(validDailyContext, validDailyGameData)
+        ).toBeNull()
+    })
+
+    it.each([
+        ['missing-context', undefined, validDailyGameData, 'missing-context'],
+        [
+            'context-mode-mismatch',
+            { ...validDailyContext, mode: 'expedition' },
+            validDailyGameData,
+            'context-mode-mismatch',
+        ],
+        [
+            'missing-competition-key',
+            { mode: 'daily', rulesetVersion: 1 },
+            validDailyGameData,
+            'missing-competition-key',
+        ],
+        [
+            'malformed-competition-key',
+            {
+                ...validDailyContext,
+                competitionKey: 'ice-slide:daily:2026-02-29:g1:r1',
+            },
+            validDailyGameData,
+            'malformed-competition-key',
+        ],
+        [
+            'missing-game-data',
+            validDailyContext,
+            undefined,
+            'missing-game-data',
+        ],
+        [
+            'game-data-mode-mismatch',
+            validDailyContext,
+            { ...validDailyGameData, mode: 'expedition' },
+            'game-data-mode-mismatch',
+        ],
+        [
+            'unsolved',
+            validDailyContext,
+            { ...validDailyGameData, solved: false },
+            'unsolved',
+        ],
+        [
+            'run-key-mismatch',
+            validDailyContext,
+            {
+                ...validDailyGameData,
+                runKey: 'ice-slide:daily:2026-08-11:g1:r1',
+            },
+            'run-key-mismatch',
+        ],
+        [
+            'generator-version-mismatch',
+            validDailyContext,
+            { ...validDailyGameData, generatorVersion: 2 },
+            'generator-version-mismatch',
+        ],
+        [
+            'game-data-ruleset-mismatch',
+            validDailyContext,
+            { ...validDailyGameData, rulesetVersion: 2 },
+            'game-data-ruleset-mismatch',
+        ],
+        [
+            'context-ruleset-mismatch',
+            { ...validDailyContext, rulesetVersion: 2 },
+            { ...validDailyGameData, rulesetVersion: 2 },
+            'context-ruleset-mismatch',
+        ],
+        [
+            'invalid-elapsed-seconds',
+            validDailyContext,
+            { ...validDailyGameData, elapsedSeconds: -1 },
+            'invalid-elapsed-seconds',
+        ],
+        [
+            'invalid-total-moves',
+            validDailyContext,
+            { ...validDailyGameData, totalMoves: -1 },
+            'invalid-total-moves',
+        ],
+    ])('returns reason %s', (_name, context, gameData, expected) => {
+        expect(iceSlideDailyAdmissionError(context, gameData)).toEqual({
+            reason: expected,
+        })
+    })
+
+    it('returns null for a non-Daily Campaign-like payload', () => {
+        expect(
+            iceSlideDailyAdmissionError(undefined, {
+                mode: 'campaign',
+                solved: true,
+            })
+        ).toBeNull()
+    })
+
+    it('returns null for a non-Daily Expedition payload', () => {
+        expect(
+            iceSlideDailyAdmissionError(
+                {
+                    mode: 'expedition',
+                    competitionKey: 'ice-slide:expedition:abcd1234:g1:r1',
+                    rulesetVersion: 1,
+                },
+                { mode: 'expedition', solved: true }
+            )
+        ).toBeNull()
     })
 })

--- a/src/lib/games/ice-slide/run.test.ts
+++ b/src/lib/games/ice-slide/run.test.ts
@@ -11,6 +11,8 @@ import {
     cloneIceSlideRunDefinition,
     createCampaignRunDefinition,
     createIceSlideStageSignature,
+    parseIceSlideDailyRunKey,
+    formatIceSlideDailyRunKey,
 } from './run'
 import type { IceSlideObjectiveId, IceSlideRunDefinition } from './types'
 
@@ -517,7 +519,7 @@ describe('Daily run key validation', () => {
                 run.runKey = 'ice-slide:daily:2026-02-30:g3:r2'
                 run.seed = 'ice-slide:daily:3:2:2026-02-30'
             },
-            'daily runKey date must be a calendar-valid YYYY-MM-DD date',
+            'daily runKey must match the daily key format',
         ],
     ] as const)('rejects %s', (_name, mutate, message) => {
         const run = makeDailyRun()
@@ -581,5 +583,47 @@ describe('Expedition run key validation', () => {
         const run = makeExpeditionRun()
         mutate(run)
         expect(() => assertValidIceSlideRunDefinition(run)).toThrow(message)
+    })
+})
+
+describe('Ice Slide Daily competition key grammar', () => {
+    it('parses an exact Daily competition identity', () => {
+        expect(
+            parseIceSlideDailyRunKey('ice-slide:daily:2026-08-12:g3:r2')
+        ).toEqual({
+            dateKey: '2026-08-12',
+            generatorVersion: 3,
+            rulesetVersion: 2,
+        })
+    })
+
+    it('formats and round-trips a Daily competition identity', () => {
+        const identity = {
+            dateKey: '2026-08-12',
+            generatorVersion: 3,
+            rulesetVersion: 2,
+        }
+        const key = formatIceSlideDailyRunKey(identity)
+        expect(key).toBe('ice-slide:daily:2026-08-12:g3:r2')
+        expect(parseIceSlideDailyRunKey(key)).toEqual(identity)
+    })
+
+    it.each([
+        'ice-slide:daily:2026-02-29:g1:r1',
+        'ice-slide:daily:2026-08-12:g0:r1',
+        'ice-slide:daily:2026-08-12:g1:r0',
+        'ice-slide:daily:2026-08-12:g1',
+        'ice-slide:daily:2026-08-12:g1:r1:extra',
+        'daily:2026-08-12:g1:r1',
+    ])('rejects invalid Daily competition key %s', runKey => {
+        expect(parseIceSlideDailyRunKey(runKey)).toBeNull()
+    })
+
+    it.each([
+        [{ dateKey: '2026-02-29', generatorVersion: 1, rulesetVersion: 1 }],
+        [{ dateKey: '2026-08-12', generatorVersion: 0, rulesetVersion: 1 }],
+        [{ dateKey: '2026-08-12', generatorVersion: 1, rulesetVersion: 0 }],
+    ])('rejects invalid formatted identity %j', identity => {
+        expect(() => formatIceSlideDailyRunKey(identity)).toThrow()
     })
 })

--- a/src/lib/games/ice-slide/run.ts
+++ b/src/lib/games/ice-slide/run.ts
@@ -382,6 +382,83 @@ export function formatIceSlideDailyRunKey(
     )
 }
 
+export type IceSlideDailyAdmissionReason =
+    | 'missing-context'
+    | 'context-mode-mismatch'
+    | 'missing-competition-key'
+    | 'malformed-competition-key'
+    | 'missing-game-data'
+    | 'game-data-mode-mismatch'
+    | 'unsolved'
+    | 'run-key-mismatch'
+    | 'generator-version-mismatch'
+    | 'game-data-ruleset-mismatch'
+    | 'context-ruleset-mismatch'
+    | 'invalid-elapsed-seconds'
+    | 'invalid-total-moves'
+
+interface DailyAdmissionContext {
+    mode: string
+    competitionKey?: string
+    rulesetVersion: number
+}
+
+function isNonNegativeInteger(value: unknown): value is number {
+    return typeof value === 'number' && Number.isInteger(value) && value >= 0
+}
+
+export function iceSlideDailyAdmissionError(
+    context: DailyAdmissionContext | undefined,
+    gameData: Record<string, unknown> | undefined
+): { reason: IceSlideDailyAdmissionReason } | null {
+    const claimsDaily = context?.mode === 'daily' || gameData?.mode === 'daily'
+    if (!claimsDaily) {
+        return null
+    }
+    if (!context) {
+        return { reason: 'missing-context' }
+    }
+    if (context.mode !== 'daily') {
+        return { reason: 'context-mode-mismatch' }
+    }
+    if (!context.competitionKey) {
+        return { reason: 'missing-competition-key' }
+    }
+
+    const identity = parseIceSlideDailyRunKey(context.competitionKey)
+    if (!identity) {
+        return { reason: 'malformed-competition-key' }
+    }
+    if (!gameData) {
+        return { reason: 'missing-game-data' }
+    }
+    if (gameData.mode !== 'daily') {
+        return { reason: 'game-data-mode-mismatch' }
+    }
+    if (gameData.solved !== true) {
+        return { reason: 'unsolved' }
+    }
+    if (gameData.runKey !== context.competitionKey) {
+        return { reason: 'run-key-mismatch' }
+    }
+    if (gameData.generatorVersion !== identity.generatorVersion) {
+        return { reason: 'generator-version-mismatch' }
+    }
+    if (gameData.rulesetVersion !== context.rulesetVersion) {
+        return { reason: 'game-data-ruleset-mismatch' }
+    }
+    if (context.rulesetVersion !== identity.rulesetVersion) {
+        return { reason: 'context-ruleset-mismatch' }
+    }
+    if (!isNonNegativeInteger(gameData.elapsedSeconds)) {
+        return { reason: 'invalid-elapsed-seconds' }
+    }
+    if (!isNonNegativeInteger(gameData.totalMoves)) {
+        return { reason: 'invalid-total-moves' }
+    }
+    return null
+}
+
 export function cloneIceSlideRunDefinition(
     run: IceSlideRunDefinition
 ): IceSlideRunDefinition {

--- a/src/lib/games/ice-slide/run.ts
+++ b/src/lib/games/ice-slide/run.ts
@@ -204,23 +204,19 @@ export function assertValidIceSlideRunDefinition(
             throw new RangeError('campaign seed must be null')
         }
     } else if (run.mode === 'daily') {
-        const match = DAILY_KEY_PATTERN.exec(run.runKey)
-        if (!match) {
+        const identity = parseIceSlideDailyRunKey(run.runKey)
+        if (!identity) {
             throw new RangeError('daily runKey must match the daily key format')
         }
-        const dateSegment = match[1]
-        assertValidIceSlideUtcDateKey(dateSegment)
-        const generatorVersion = Number(match[2])
-        const rulesetVersion = Number(match[3])
-        if (run.generatorVersion !== generatorVersion) {
+        if (run.generatorVersion !== identity.generatorVersion) {
             throw new RangeError('daily generatorVersion must match the runKey')
         }
-        if (run.rulesetVersion !== rulesetVersion) {
+        if (run.rulesetVersion !== identity.rulesetVersion) {
             throw new RangeError('daily rulesetVersion must match the runKey')
         }
         const expectedSeed =
-            `ice-slide:daily:${generatorVersion}:` +
-            `${rulesetVersion}:${match[1]}`
+            `ice-slide:daily:${identity.generatorVersion}:` +
+            `${identity.rulesetVersion}:${identity.dateKey}`
         if (run.seed !== expectedSeed) {
             throw new RangeError(
                 'daily seed must match the runKey date and versions'
@@ -334,6 +330,56 @@ export function assertValidIceSlideRunDefinition(
             )
         }
     }
+}
+
+export interface IceSlideDailyRunIdentity {
+    dateKey: string
+    generatorVersion: number
+    rulesetVersion: number
+}
+
+export function parseIceSlideDailyRunKey(
+    runKey: string
+): IceSlideDailyRunIdentity | null {
+    const match = DAILY_KEY_PATTERN.exec(runKey)
+    if (!match) {
+        return null
+    }
+
+    try {
+        assertValidIceSlideUtcDateKey(match[1])
+    } catch {
+        return null
+    }
+
+    const generatorVersion = Number(match[2])
+    const rulesetVersion = Number(match[3])
+    if (
+        !Number.isSafeInteger(generatorVersion) ||
+        generatorVersion < 1 ||
+        !Number.isSafeInteger(rulesetVersion) ||
+        rulesetVersion < 1
+    ) {
+        return null
+    }
+
+    return {
+        dateKey: match[1],
+        generatorVersion,
+        rulesetVersion,
+    }
+}
+
+export function formatIceSlideDailyRunKey(
+    identity: IceSlideDailyRunIdentity
+): string {
+    assertValidIceSlideUtcDateKey(identity.dateKey)
+    assertPositiveInt(identity.generatorVersion, 'generatorVersion')
+    assertPositiveInt(identity.rulesetVersion, 'rulesetVersion')
+    return (
+        `ice-slide:daily:${identity.dateKey}:` +
+        `g${identity.generatorVersion}:r${identity.rulesetVersion}`
+    )
 }
 
 export function cloneIceSlideRunDefinition(

--- a/src/lib/games/ice-slide/run.ts
+++ b/src/lib/games/ice-slide/run.ts
@@ -147,8 +147,12 @@ export function assertValidIceSlideUtcDateKey(dateKey: string): void {
     }
 }
 
+function isPositiveInt(value: number): boolean {
+    return Number.isInteger(value) && value >= 1 && value <= 0x7fffffff
+}
+
 function assertPositiveInt(value: number, field: string): void {
-    if (!Number.isInteger(value) || value < 1 || value > 0x7fffffff) {
+    if (!isPositiveInt(value)) {
         throw new RangeError(`${field} must be a positive signed integer`)
     }
 }
@@ -354,12 +358,7 @@ export function parseIceSlideDailyRunKey(
 
     const generatorVersion = Number(match[2])
     const rulesetVersion = Number(match[3])
-    if (
-        !Number.isSafeInteger(generatorVersion) ||
-        generatorVersion < 1 ||
-        !Number.isSafeInteger(rulesetVersion) ||
-        rulesetVersion < 1
-    ) {
+    if (!isPositiveInt(generatorVersion) || !isPositiveInt(rulesetVersion)) {
         return null
     }
 

--- a/src/lib/games/ice-slide/run.ts
+++ b/src/lib/games/ice-slide/run.ts
@@ -404,7 +404,9 @@ interface DailyAdmissionContext {
 }
 
 function isNonNegativeInteger(value: unknown): value is number {
-    return typeof value === 'number' && Number.isInteger(value) && value >= 0
+    return (
+        typeof value === 'number' && Number.isSafeInteger(value) && value >= 0
+    )
 }
 
 export function iceSlideDailyAdmissionError(

--- a/src/lib/games/ice-slide/test-fixtures.ts
+++ b/src/lib/games/ice-slide/test-fixtures.ts
@@ -7,7 +7,11 @@ import {
     ICE_SLIDE_RULESET_VERSION,
     ICE_SLIDE_RUN_SCHEMA_VERSION,
 } from './run'
-import type { IceSlideRunDefinition, IceSlideStageDefinition } from './types'
+import type {
+    Direction,
+    IceSlideRunDefinition,
+    IceSlideStageDefinition,
+} from './types'
 
 export function createTestStage(
     overrides: Partial<IceSlideStageDefinition> = {}
@@ -117,3 +121,17 @@ export function createTestDailyRun(
     assertValidIceSlideRunDefinition(run)
     return run
 }
+
+/**
+ * Frozen minimum-move direction sequence that completes the deterministic
+ * generator-v1 2026-08-12 Daily. Shared by the unit replay (daily.test.ts) and
+ * the Playwright Ice Slide coverage; the latter derives arrow keys from it via
+ * a local map so no second copy of the sequence exists.
+ */
+export const ICE_SLIDE_DAILY_2026_08_12_DIRECTIONS = [
+    ['S', 'E', 'S'],
+    ['N', 'W', 'N', 'W'],
+    ['W', 'N', 'E', 'S', 'W', 'N'],
+    ['S', 'W', 'N', 'E', 'S', 'W'],
+    ['E', 'S', 'W', 'N', 'E', 'S'],
+] as const satisfies readonly (readonly Direction[])[]

--- a/src/lib/server/validations.test.ts
+++ b/src/lib/server/validations.test.ts
@@ -273,6 +273,30 @@ describe('server validations', () => {
             expect(leaderboardQuerySchema.safeParse(params).success).toBe(false)
         })
 
+        it('requires competitionKey for Ice Slide Daily while keeping mode-only valid for other games', () => {
+            expect(
+                leaderboardQuerySchema.safeParse({
+                    gameId: GameID.ICE_SLIDE,
+                    mode: 'daily',
+                }).success
+            ).toBe(false)
+
+            expect(
+                leaderboardQuerySchema.safeParse({
+                    gameId: GameID.ICE_SLIDE,
+                    mode: 'daily',
+                    competitionKey: 'ice-slide:daily:2026-08-12:g1:r1',
+                }).success
+            ).toBe(true)
+
+            expect(
+                leaderboardQuerySchema.safeParse({
+                    gameId: GameID.TETRIS,
+                    mode: 'daily',
+                }).success
+            ).toBe(true)
+        })
+
         it('applies default limit and parses numeric limit', () => {
             const withDefault = leaderboardQuerySchema.safeParse({
                 gameId: GameID.TETRIS,

--- a/src/lib/server/validations.ts
+++ b/src/lib/server/validations.ts
@@ -181,6 +181,21 @@ export const leaderboardQuerySchema = z
                 message: 'competitionKey requires gameId and mode',
             })
         }
+
+        // Ice Slide Daily additionally requires an exact competition key; the
+        // route validates that key's game-domain grammar with
+        // parseIceSlideDailyRunKey().
+        if (
+            data.gameId === GameID.ICE_SLIDE &&
+            data.mode === 'daily' &&
+            !data.competitionKey
+        ) {
+            ctx.addIssue({
+                code: 'custom',
+                path: ['competitionKey'],
+                message: 'competitionKey is required for Ice Slide Daily',
+            })
+        }
     })
 
 export type LeaderboardQueryInput = z.infer<typeof leaderboardQuerySchema>

--- a/src/pages/api/leaderboard.test.ts
+++ b/src/pages/api/leaderboard.test.ts
@@ -21,6 +21,7 @@ vi.mock('@/lib/games', () => ({
     getAllGames: vi.fn(),
     GameID: {
         TETRIS: 'tetris',
+        ICE_SLIDE: 'ice_slide',
     },
 }))
 
@@ -35,6 +36,22 @@ describe('GET /api/leaderboard', () => {
         isActive: true,
     }
 
+    const iceSlideGame = {
+        id: 'ice_slide' as GameID,
+        name: 'Ice Slide',
+        description: 'Slide across slippery ice',
+        category: 'puzzle' as const,
+        difficulty: 'medium' as const,
+        tags: ['ice', 'slide'],
+        isActive: true,
+    }
+
+    const routeContext = (url: string, user: { id: string } | null = null) =>
+        ({
+            url: new URL(url),
+            locals: { user, session: null },
+        }) as never
+
     const mockLeaderboardEntry = {
         name: 'Test Player',
         username: 'testplayer',
@@ -45,14 +62,17 @@ describe('GET /api/leaderboard', () => {
 
     beforeEach(() => {
         vi.clearAllMocks()
-        vi.mocked(getAllGames).mockReturnValue([mockGame])
+        vi.mocked(getAllGames).mockReturnValue([mockGame, iceSlideGame])
         vi.mocked(getGameLeaderboard).mockResolvedValue([mockLeaderboardEntry])
     })
 
     describe('without gameId parameter', () => {
         it('should return leaderboards for all games', async () => {
             const url = new URL('http://localhost/api/leaderboard')
-            const response = await GET({ url } as any)
+            const response = await GET({
+                url,
+                locals: { user: null, session: null },
+            } as any)
 
             expect(response.status).toBe(200)
 
@@ -70,14 +90,14 @@ describe('GET /api/leaderboard', () => {
 
         it('should use default limit of 10', async () => {
             const url = new URL('http://localhost/api/leaderboard')
-            await GET({ url } as any)
+            await GET({ url, locals: { user: null, session: null } } as any)
 
             expect(getGameLeaderboard).toHaveBeenCalledWith('tetris', 10)
         })
 
         it('should use custom limit when provided', async () => {
             const url = new URL('http://localhost/api/leaderboard?limit=5')
-            await GET({ url } as any)
+            await GET({ url, locals: { user: null, session: null } } as any)
 
             expect(getGameLeaderboard).toHaveBeenCalledWith('tetris', 5)
         })
@@ -86,7 +106,10 @@ describe('GET /api/leaderboard', () => {
             const url = new URL(
                 'http://localhost/api/leaderboard?limit=invalid'
             )
-            const response = await GET({ url } as any)
+            const response = await GET({
+                url,
+                locals: { user: null, session: null },
+            } as any)
 
             expect(response.status).toBe(400)
 
@@ -100,7 +123,10 @@ describe('GET /api/leaderboard', () => {
 
         it('should return 400 for negative limit', async () => {
             const url = new URL('http://localhost/api/leaderboard?limit=-5')
-            const response = await GET({ url } as any)
+            const response = await GET({
+                url,
+                locals: { user: null, session: null },
+            } as any)
 
             expect(response.status).toBe(400)
 
@@ -114,7 +140,10 @@ describe('GET /api/leaderboard', () => {
 
         it('should return 400 for limit exceeding maximum', async () => {
             const url = new URL('http://localhost/api/leaderboard?limit=101')
-            const response = await GET({ url } as any)
+            const response = await GET({
+                url,
+                locals: { user: null, session: null },
+            } as any)
 
             expect(response.status).toBe(400)
 
@@ -132,7 +161,10 @@ describe('GET /api/leaderboard', () => {
             })
 
             const url = new URL('http://localhost/api/leaderboard')
-            const response = await GET({ url } as any)
+            const response = await GET({
+                url,
+                locals: { user: null, session: null },
+            } as any)
 
             expect(response.status).toBe(503)
 
@@ -149,7 +181,10 @@ describe('GET /api/leaderboard', () => {
             const url = new URL(
                 'http://localhost/api/leaderboard?gameId=tetris'
             )
-            const response = await GET({ url } as any)
+            const response = await GET({
+                url,
+                locals: { user: null, session: null },
+            } as any)
 
             expect(response.status).toBe(200)
 
@@ -172,7 +207,10 @@ describe('GET /api/leaderboard', () => {
             const url = new URL(
                 'http://localhost/api/leaderboard?gameId=invalid'
             )
-            const response = await GET({ url } as any)
+            const response = await GET({
+                url,
+                locals: { user: null, session: null },
+            } as any)
 
             expect(response.status).toBe(400)
 
@@ -209,7 +247,10 @@ describe('GET /api/leaderboard', () => {
             const url = new URL(
                 'http://localhost/api/leaderboard?gameId=tetris'
             )
-            const response = await GET({ url } as any)
+            const response = await GET({
+                url,
+                locals: { user: null, session: null },
+            } as any)
 
             const data = await response.json()
             expect(data.leaderboard).toHaveLength(3)
@@ -224,7 +265,10 @@ describe('GET /api/leaderboard', () => {
             const url = new URL(
                 'http://localhost/api/leaderboard?gameId=tetris'
             )
-            const response = await GET({ url } as any)
+            const response = await GET({
+                url,
+                locals: { user: null, session: null },
+            } as any)
 
             expect(response.status).toBe(200)
 
@@ -241,7 +285,10 @@ describe('GET /api/leaderboard', () => {
             const url = new URL(
                 'http://localhost/api/leaderboard?gameId=tetris'
             )
-            const response = await GET({ url } as any)
+            const response = await GET({
+                url,
+                locals: { user: null, session: null },
+            } as any)
 
             expect(response.status).toBe(503)
 
@@ -262,7 +309,10 @@ describe('GET /api/leaderboard', () => {
             const url = new URL(
                 'http://localhost/api/leaderboard?gameId=tetris'
             )
-            const response = await GET({ url } as any)
+            const response = await GET({
+                url,
+                locals: { user: null, session: null },
+            } as any)
 
             expect(response.status).toBe(500)
 
@@ -276,7 +326,10 @@ describe('GET /api/leaderboard', () => {
             })
 
             const url = new URL('http://localhost/api/leaderboard')
-            const response = await GET({ url } as any)
+            const response = await GET({
+                url,
+                locals: { user: null, session: null },
+            } as any)
 
             expect(response.status).toBe(500)
 
@@ -290,7 +343,10 @@ describe('GET /api/leaderboard', () => {
             const url = new URL(
                 'http://localhost/api/leaderboard?gameId=tetris'
             )
-            const response = await GET({ url } as any)
+            const response = await GET({
+                url,
+                locals: { user: null, session: null },
+            } as any)
 
             expect(response.headers.get('Content-Type')).toBe(
                 'application/json'
@@ -301,7 +357,10 @@ describe('GET /api/leaderboard', () => {
             const url = new URL(
                 'http://localhost/api/leaderboard?gameId=tetris'
             )
-            const response = await GET({ url } as any)
+            const response = await GET({
+                url,
+                locals: { user: null, session: null },
+            } as any)
 
             const data = await response.json()
             const entry = data.leaderboard[0]
@@ -342,6 +401,7 @@ describe('GET /api/leaderboard', () => {
                 url: new URL(
                     'http://localhost/api/leaderboard?gameId=tetris&mode=daily'
                 ),
+                locals: { user: null, session: null },
             } as never)
 
             expect(response.status).toBe(200)
@@ -353,6 +413,7 @@ describe('GET /api/leaderboard', () => {
             })
 
             const body = await response.json()
+            expect(body.viewerAuthenticated).toBe(false)
             expect(body.leaderboard).toEqual([
                 {
                     rank: 1,
@@ -366,6 +427,7 @@ describe('GET /api/leaderboard', () => {
                     rulesetVersion: 2,
                     elapsedSeconds: 12,
                     totalMoves: 34,
+                    isCurrentUser: false,
                 },
             ])
             expect(body.leaderboard[0]).not.toHaveProperty('userId')
@@ -382,6 +444,7 @@ describe('GET /api/leaderboard', () => {
                     'http://localhost/api/leaderboard' +
                         '?gameId=tetris&mode=daily&competitionKey=daily%3A1'
                 ),
+                locals: { user: null, session: null },
             } as never)
 
             expect(getScopedGameLeaderboard).toHaveBeenCalledWith({
@@ -397,7 +460,10 @@ describe('GET /api/leaderboard', () => {
             'http://localhost/api/leaderboard?competitionKey=daily%3A1',
             'http://localhost/api/leaderboard?gameId=tetris&competitionKey=daily%3A1',
         ])('rejects invalid scoped parameter combinations: %s', async url => {
-            const response = await GET({ url: new URL(url) } as never)
+            const response = await GET({
+                url: new URL(url),
+                locals: { user: null, session: null },
+            } as never)
             expect(response.status).toBe(400)
             expect(getScopedGameLeaderboard).not.toHaveBeenCalled()
         })
@@ -412,6 +478,7 @@ describe('GET /api/leaderboard', () => {
                 url: new URL(
                     'http://localhost/api/leaderboard?gameId=tetris&mode=daily'
                 ),
+                locals: { user: null, session: null },
             } as never)
 
             expect(response.status).toBe(503)
@@ -442,10 +509,131 @@ describe('GET /api/leaderboard', () => {
             const url = new URL(
                 'http://localhost/api/leaderboard?gameId=tetris'
             )
-            const response = await GET({ url } as never)
+            const response = await GET({
+                url,
+                locals: { user: null, session: null },
+            } as never)
 
             const data = await response.json()
             expect(data.leaderboard).toHaveLength(2)
+        })
+
+        it('rejects a calendar-invalid Ice Slide Daily competition key', async () => {
+            const response = await GET(
+                routeContext(
+                    'http://localhost/api/leaderboard' +
+                        '?gameId=ice_slide&mode=daily' +
+                        '&competitionKey=ice-slide%3Adaily%3A2026-02-29%3Ag1%3Ar1'
+                )
+            )
+
+            expect(response.status).toBe(400)
+            expect(getScopedGameLeaderboard).not.toHaveBeenCalled()
+        })
+
+        it('reads the Ice Slide Daily leaderboard by exact competition key', async () => {
+            vi.mocked(getScopedGameLeaderboard).mockResolvedValue({
+                success: true,
+                rows: [],
+            })
+
+            const response = await GET(
+                routeContext(
+                    'http://localhost/api/leaderboard' +
+                        '?gameId=ice_slide&mode=daily' +
+                        '&competitionKey=ice-slide%3Adaily%3A2026-08-12%3Ag1%3Ar1'
+                )
+            )
+
+            expect(response.status).toBe(200)
+            expect(getScopedGameLeaderboard).toHaveBeenCalledWith({
+                gameId: 'ice_slide',
+                mode: 'daily',
+                competitionKey: 'ice-slide:daily:2026-08-12:g1:r1',
+                limit: 10,
+            })
+        })
+
+        it('marks the viewer row as current from locals.user', async () => {
+            vi.mocked(getScopedGameLeaderboard).mockResolvedValue({
+                success: true,
+                rows: [
+                    {
+                        userId: 'u1',
+                        name: 'Pilot',
+                        username: 'pilot',
+                        image: null,
+                        score: 4321,
+                        created_at: '2026-08-12T00:00:00.000Z',
+                        mode: 'daily',
+                        competitionKey: 'ice-slide:daily:2026-08-12:g1:r1',
+                        rulesetVersion: 1,
+                        elapsedSeconds: 87,
+                        totalMoves: 31,
+                    },
+                ],
+            })
+
+            const response = await GET(
+                routeContext(
+                    'http://localhost/api/leaderboard' +
+                        '?gameId=ice_slide&mode=daily' +
+                        '&competitionKey=ice-slide%3Adaily%3A2026-08-12%3Ag1%3Ar1',
+                    { id: 'u1' }
+                )
+            )
+
+            const body = await response.json()
+            expect(body.viewerAuthenticated).toBe(true)
+            expect(body.leaderboard[0]).toMatchObject({
+                rank: 1,
+                isCurrentUser: true,
+            })
+            expect(body.leaderboard[0]).not.toHaveProperty('userId')
+        })
+
+        it('reports viewerAuthenticated false for a signed-out scoped read', async () => {
+            vi.mocked(getScopedGameLeaderboard).mockResolvedValue({
+                success: true,
+                rows: [
+                    {
+                        userId: 'u1',
+                        name: 'Pilot',
+                        username: 'pilot',
+                        image: null,
+                        score: 4321,
+                        created_at: '2026-08-12T00:00:00.000Z',
+                        mode: 'daily',
+                        competitionKey: 'ice-slide:daily:2026-08-12:g1:r1',
+                        rulesetVersion: 1,
+                        elapsedSeconds: 87,
+                        totalMoves: 31,
+                    },
+                ],
+            })
+
+            const response = await GET(
+                routeContext(
+                    'http://localhost/api/leaderboard' +
+                        '?gameId=ice_slide&mode=daily' +
+                        '&competitionKey=ice-slide%3Adaily%3A2026-08-12%3Ag1%3Ar1',
+                    null
+                )
+            )
+
+            const body = await response.json()
+            expect(body.viewerAuthenticated).toBe(false)
+            expect(body.leaderboard[0].isCurrentUser).toBe(false)
+        })
+
+        it('does not add viewer metadata to an unscoped game response', async () => {
+            const response = await GET(
+                routeContext('http://localhost/api/leaderboard?gameId=tetris')
+            )
+
+            const body = await response.json()
+            expect(body).not.toHaveProperty('viewerAuthenticated')
+            expect(body.leaderboard[0]).not.toHaveProperty('isCurrentUser')
         })
     })
 })

--- a/src/pages/api/leaderboard.ts
+++ b/src/pages/api/leaderboard.ts
@@ -6,7 +6,8 @@ import {
     toPublicScopedLeaderboardEntry,
     type GameLeaderboardEntry,
 } from '@/lib/server/db/queries'
-import { getAllGames } from '@/lib/games'
+import { getAllGames, GameID } from '@/lib/games'
+import { parseIceSlideDailyRunKey } from '@/lib/games/ice-slide/run'
 import {
     jsonResponse,
     badRequestResponse,
@@ -15,7 +16,7 @@ import {
 } from '@/lib/server/api-utils'
 import { leaderboardQuerySchema, validateQuery } from '@/lib/server/validations'
 
-export const GET: APIRoute = async ({ url }) => {
+export const GET: APIRoute = async ({ url, locals }) => {
     try {
         const parsed = validateQuery(url, leaderboardQuerySchema)
         if (!parsed.success) {
@@ -78,6 +79,20 @@ export const GET: APIRoute = async ({ url }) => {
 
         // Scoped branch: mode present → best-per-user via scoped query
         if (mode) {
+            // leaderboardQuerySchema requires the key's presence for Ice Slide
+            // Daily; this route validates the Ice Slide domain grammar and
+            // calendar semantics.
+            if (gameId === GameID.ICE_SLIDE && mode === 'daily') {
+                if (
+                    !competitionKey ||
+                    !parseIceSlideDailyRunKey(competitionKey)
+                ) {
+                    return badRequestResponse(
+                        'Invalid Ice Slide Daily competitionKey'
+                    )
+                }
+            }
+
             const scoped = await getScopedGameLeaderboard({
                 gameId,
                 mode,
@@ -93,14 +108,18 @@ export const GET: APIRoute = async ({ url }) => {
                 )
             }
 
+            const viewerUserId = locals.user?.id ?? null
             const leaderboard = scoped.rows.map((row, index) => ({
                 rank: index + 1,
                 ...toPublicScopedLeaderboardEntry(row),
+                isCurrentUser:
+                    viewerUserId !== null && row.userId === viewerUserId,
             }))
 
             return jsonResponse({
                 gameId,
                 gameName: game.name,
+                viewerAuthenticated: viewerUserId !== null,
                 leaderboard,
             })
         }

--- a/src/pages/api/scores.test.ts
+++ b/src/pages/api/scores.test.ts
@@ -541,4 +541,131 @@ describe('POST /api/scores', () => {
         expect(response.status).toBe(500)
         expect(updateChallengeProgress).not.toHaveBeenCalled()
     })
+
+    describe('Ice Slide Daily score admission', () => {
+        const iceSlideGame: Game = {
+            id: GameID.ICE_SLIDE,
+            name: 'Ice Slide',
+            description: 'Slide across slippery ice',
+            category: 'puzzle',
+            difficulty: 'medium',
+            tags: [],
+            isActive: true,
+        }
+
+        const validDailyBody = {
+            gameId: 'ice_slide',
+            score: 4321,
+            gameData: {
+                mode: 'daily',
+                solved: true,
+                runKey: 'ice-slide:daily:2026-08-12:g1:r1',
+                generatorVersion: 1,
+                rulesetVersion: 1,
+                elapsedSeconds: 87,
+                totalMoves: 31,
+            },
+            context: {
+                mode: 'daily',
+                competitionKey: 'ice-slide:daily:2026-08-12:g1:r1',
+                rulesetVersion: 1,
+            },
+        }
+
+        const postBody = (body: unknown) =>
+            new Request('http://localhost/api/scores', {
+                method: 'POST',
+                headers: { 'Content-Type': 'application/json' },
+                body: JSON.stringify(body),
+            })
+
+        beforeEach(() => {
+            vi.mocked(auth.api.getSession).mockResolvedValue(
+                mockSession as never
+            )
+            vi.mocked(getGameById).mockReturnValue(iceSlideGame)
+        })
+
+        it('accepts and persists a valid Ice Slide Daily score', async () => {
+            vi.mocked(saveGameScoreWithAchievements).mockResolvedValue({
+                success: true,
+                newAchievements: [],
+            })
+
+            const response = await POST({
+                request: postBody(validDailyBody),
+            } as never)
+
+            expect(response.status).toBe(200)
+            expect(saveGameScoreWithAchievements).toHaveBeenCalledTimes(1)
+            expect(saveGameScoreWithAchievements).toHaveBeenCalledWith(
+                'user-123',
+                'ice_slide',
+                4321,
+                expect.objectContaining({
+                    mode: 'daily',
+                    solved: true,
+                    runKey: 'ice-slide:daily:2026-08-12:g1:r1',
+                }),
+                expect.objectContaining({
+                    mode: 'daily',
+                    competitionKey: 'ice-slide:daily:2026-08-12:g1:r1',
+                    rulesetVersion: 1,
+                })
+            )
+        })
+
+        it.each([
+            [
+                'unsolved Daily',
+                {
+                    ...validDailyBody,
+                    gameData: {
+                        ...validDailyBody.gameData,
+                        solved: false,
+                    },
+                },
+            ],
+            [
+                'malformed competition key',
+                {
+                    ...validDailyBody,
+                    context: {
+                        ...validDailyBody.context,
+                        competitionKey: 'ice-slide:daily:2026-02-29:g1:r1',
+                    },
+                },
+            ],
+            [
+                'context/key ruleset mismatch',
+                {
+                    ...validDailyBody,
+                    context: { ...validDailyBody.context, rulesetVersion: 2 },
+                    gameData: {
+                        ...validDailyBody.gameData,
+                        rulesetVersion: 2,
+                    },
+                },
+            ],
+            [
+                'Expedition game data with Daily context',
+                {
+                    ...validDailyBody,
+                    gameData: {
+                        ...validDailyBody.gameData,
+                        mode: 'expedition',
+                    },
+                },
+            ],
+        ])('rejects %s with 400 and does not persist', async (_name, body) => {
+            const response = await POST({
+                request: postBody(body),
+            } as never)
+
+            expect(response.status).toBe(400)
+            const result = await response.json()
+            expect(result.error).toBe('Invalid Ice Slide Daily score data')
+            expect(saveGameScoreWithAchievements).not.toHaveBeenCalled()
+        })
+    })
 })

--- a/src/pages/api/scores.ts
+++ b/src/pages/api/scores.ts
@@ -1,6 +1,7 @@
 import type { APIRoute } from 'astro'
 import { saveGameScoreWithAchievements } from '@/lib/server/db/queries'
 import { getGameById, GameID } from '@/lib/games'
+import { iceSlideDailyAdmissionError } from '@/lib/games/ice-slide/run'
 import { auth } from '@/lib/auth'
 import { getAchievementNotifications } from '@/lib/services/achievementService'
 import { updateChallengeProgress } from '@/lib/services/challengeService'
@@ -43,6 +44,20 @@ export const POST: APIRoute = async ({ request }) => {
         const game = getGameById(validatedGameId)
         if (!game) {
             return badRequestResponse('Invalid game ID')
+        }
+
+        if (validatedGameId === GameID.ICE_SLIDE) {
+            const admissionError = iceSlideDailyAdmissionError(
+                context,
+                gameData
+            )
+            if (admissionError) {
+                console.warn(
+                    '[scores API] Rejected Ice Slide Daily score:',
+                    admissionError.reason
+                )
+                return badRequestResponse('Invalid Ice Slide Daily score data')
+            }
         }
 
         const persistedContext: PersistedScoreContext | undefined = context

--- a/src/pages/game-board-markup.test.ts
+++ b/src/pages/game-board-markup.test.ts
@@ -81,6 +81,13 @@ describe('Ice Slide Daily challenge markup', () => {
         expect(iceSlideMarkup).toContain('id="stage-clear-continue-btn"')
         expect(iceSlideMarkup).toContain('id="daily-final-stage-result"')
         expect(iceSlideMarkup).toContain('id="change-mode-btn"')
+        expect(iceSlideMarkup).toContain('id="daily-leaderboard"')
+        expect(iceSlideMarkup).toContain('id="daily-leaderboard-date"')
+        expect(iceSlideMarkup).toContain('id="daily-leaderboard-signed-out"')
+        expect(iceSlideMarkup).toContain('id="daily-leaderboard-loading"')
+        expect(iceSlideMarkup).toContain('id="daily-leaderboard-empty"')
+        expect(iceSlideMarkup).toContain('id="daily-leaderboard-unavailable"')
+        expect(iceSlideMarkup).toContain('id="daily-leaderboard-rows"')
     })
 })
 

--- a/src/pages/ice-slide/index.astro
+++ b/src/pages/ice-slide/index.astro
@@ -134,6 +134,42 @@ import Button from '@/components/ui/Button.astro'
           <span id="daily-objective-bonus">Bonus: —</span>
         </div>
       </Card>
+
+      <Card id="daily-leaderboard" variant="glass" class="hidden p-4">
+        <div class="flex items-baseline justify-between gap-3">
+          <h3 class="font-mono text-sm tracking-wide text-cetus-accent">
+            ▸ DAILY RANKING
+          </h3>
+          <span id="daily-leaderboard-date" class="text-xs text-cetus-ink-muted"
+            >—</span
+          >
+        </div>
+        <p
+          id="daily-leaderboard-signed-out"
+          class="hidden mt-2 text-xs text-cetus-ink-muted"
+        >
+          Sign in to submit a ranked result. You can still view today's ranking.
+        </p>
+        <p
+          id="daily-leaderboard-loading"
+          class="mt-3 text-sm text-cetus-ink-muted"
+        >
+          Loading ranking…
+        </p>
+        <p
+          id="daily-leaderboard-empty"
+          class="hidden mt-3 text-sm text-cetus-ink-muted"
+        >
+          No ranked finishes yet.
+        </p>
+        <p
+          id="daily-leaderboard-unavailable"
+          class="hidden mt-3 text-sm text-cetus-ink-muted"
+        >
+          Ranking is temporarily unavailable.
+        </p>
+        <div id="daily-leaderboard-rows" class="hidden mt-3 space-y-2"></div>
+      </Card>
     </div>
   </div>
 
@@ -239,6 +275,11 @@ import Button from '@/components/ui/Button.astro'
 
 <script>
   import { initializeIceSlide } from '@/lib/games/ice-slide/init'
+  import {
+    createIceSlideDailyCompetitionKey,
+    toIceSlideUtcDateKey,
+  } from '@/lib/games/ice-slide/daily'
+  import { createDailyLeaderboardController } from '@/lib/games/ice-slide/daily-leaderboard'
   import type { IceSlidePlayableMode } from '@/lib/games/ice-slide/types'
 
   const requestedMode = new URLSearchParams(window.location.search).get('mode')
@@ -265,6 +306,19 @@ import Button from '@/components/ui/Button.astro'
     )
     const dailyFinalResult = document.getElementById('daily-final-stage-result')
     const changeModeBtn = document.getElementById('change-mode-btn')
+    const leaderboardPanel = document.getElementById('daily-leaderboard')
+    const leaderboardDate = document.getElementById('daily-leaderboard-date')
+    const leaderboardSignedOut = document.getElementById(
+      'daily-leaderboard-signed-out'
+    )
+    const leaderboardLoading = document.getElementById(
+      'daily-leaderboard-loading'
+    )
+    const leaderboardEmpty = document.getElementById('daily-leaderboard-empty')
+    const leaderboardUnavailable = document.getElementById(
+      'daily-leaderboard-unavailable'
+    )
+    const leaderboardRows = document.getElementById('daily-leaderboard-rows')
     if (
       !container ||
       !statusEl ||
@@ -277,10 +331,30 @@ import Button from '@/components/ui/Button.astro'
       modeRadios.length === 0 ||
       !dailyMeta ||
       !dailyFinalResult ||
-      !changeModeBtn
+      !changeModeBtn ||
+      !leaderboardPanel ||
+      !leaderboardDate ||
+      !leaderboardSignedOut ||
+      !leaderboardLoading ||
+      !leaderboardEmpty ||
+      !leaderboardUnavailable ||
+      !leaderboardRows
     ) {
       return
     }
+
+    const leaderboardController = createDailyLeaderboardController({
+      panel: leaderboardPanel,
+      date: leaderboardDate,
+      signedOut: leaderboardSignedOut,
+      loading: leaderboardLoading,
+      empty: leaderboardEmpty,
+      unavailable: leaderboardUnavailable,
+      rows: leaderboardRows,
+    })
+
+    const currentUtcDailyKey = () =>
+      createIceSlideDailyCompetitionKey(toIceSlideUtcDateKey(new Date()))
 
     modeRadios.forEach(radio => {
       radio.checked = radio.value === selectedMode
@@ -343,6 +417,11 @@ import Button from '@/components/ui/Button.astro'
           errorEl.classList.remove('hidden')
           restoreIdleModeControlsIfNoResult()
         },
+        onScoreSaved: gameData => {
+          if (gameData.mode === 'daily') {
+            leaderboardController.load(gameData.runKey)
+          }
+        },
       })
     } catch (error) {
       errorEl.textContent =
@@ -351,12 +430,26 @@ import Button from '@/components/ui/Button.astro'
       return
     }
 
+    if (readSelectedMode() === 'daily') {
+      leaderboardController.load(currentUtcDailyKey())
+    } else {
+      leaderboardController.hide()
+    }
+
     startBtn.addEventListener('click', async () => {
       const mode = readSelectedMode()
       startBtn.style.display = 'none'
       setModeControlsDisabled(true)
       try {
         await gameHandle?.start(mode)
+        if (mode === 'daily') {
+          const runKey = gameHandle?.getGame()?.getState().runKey
+          if (runKey) {
+            leaderboardController.load(runKey)
+          }
+        } else {
+          leaderboardController.hide()
+        }
       } catch (error) {
         errorEl.textContent =
           error instanceof Error ? error.message : 'Failed to start'
@@ -382,6 +475,14 @@ import Button from '@/components/ui/Button.astro'
       setModeControlsDisabled(true)
       try {
         await gameHandle?.playAgain()
+        if (gameHandle?.getGame()?.getState().mode === 'daily') {
+          const runKey = gameHandle.getGame()?.getState().runKey
+          if (runKey) {
+            leaderboardController.load(runKey)
+          }
+        } else {
+          leaderboardController.hide()
+        }
       } catch (error) {
         errorEl.textContent =
           error instanceof Error ? error.message : 'Failed to restart'
@@ -400,6 +501,21 @@ import Button from '@/components/ui/Button.astro'
       resetButtonState()
       setModeControlsDisabled(false)
       focusIdleControl()
+      if (readSelectedMode() === 'daily') {
+        leaderboardController.load(currentUtcDailyKey())
+      } else {
+        leaderboardController.hide()
+      }
+    })
+
+    modeRadios.forEach(radio => {
+      radio.addEventListener('change', () => {
+        if (readSelectedMode() === 'daily') {
+          leaderboardController.load(currentUtcDailyKey())
+        } else {
+          leaderboardController.hide()
+        }
+      })
     })
   }
 

--- a/src/pages/ice-slide/index.astro
+++ b/src/pages/ice-slide/index.astro
@@ -150,24 +150,26 @@ import Button from '@/components/ui/Button.astro'
         >
           Sign in to submit a ranked result. You can still view today's ranking.
         </p>
-        <p
-          id="daily-leaderboard-loading"
-          class="mt-3 text-sm text-cetus-ink-muted"
-        >
-          Loading ranking…
-        </p>
-        <p
-          id="daily-leaderboard-empty"
-          class="hidden mt-3 text-sm text-cetus-ink-muted"
-        >
-          No ranked finishes yet.
-        </p>
-        <p
-          id="daily-leaderboard-unavailable"
-          class="hidden mt-3 text-sm text-cetus-ink-muted"
-        >
-          Ranking is temporarily unavailable.
-        </p>
+        <div aria-live="polite" aria-atomic="true">
+          <p
+            id="daily-leaderboard-loading"
+            class="mt-3 text-sm text-cetus-ink-muted"
+          >
+            Loading ranking…
+          </p>
+          <p
+            id="daily-leaderboard-empty"
+            class="hidden mt-3 text-sm text-cetus-ink-muted"
+          >
+            No ranked finishes yet.
+          </p>
+          <p
+            id="daily-leaderboard-unavailable"
+            class="hidden mt-3 text-sm text-cetus-ink-muted"
+          >
+            Ranking is temporarily unavailable.
+          </p>
+        </div>
         <div id="daily-leaderboard-rows" class="hidden mt-3 space-y-2"></div>
       </Card>
     </div>
@@ -353,6 +355,18 @@ import Button from '@/components/ui/Button.astro'
       rows: leaderboardRows,
     })
 
+    let activeDailyRunKey: string | undefined
+
+    const loadDailyLeaderboard = (runKey: string): void => {
+      activeDailyRunKey = runKey
+      void leaderboardController.load(runKey)
+    }
+
+    const hideDailyLeaderboard = (): void => {
+      activeDailyRunKey = undefined
+      leaderboardController.hide()
+    }
+
     const currentUtcDailyKey = () =>
       createIceSlideDailyCompetitionKey(toIceSlideUtcDateKey(new Date()))
 
@@ -418,8 +432,11 @@ import Button from '@/components/ui/Button.astro'
           restoreIdleModeControlsIfNoResult()
         },
         onScoreSaved: gameData => {
-          if (gameData.mode === 'daily') {
-            leaderboardController.load(gameData.runKey)
+          if (
+            gameData.mode === 'daily' &&
+            gameData.runKey === activeDailyRunKey
+          ) {
+            loadDailyLeaderboard(gameData.runKey)
           }
         },
       })
@@ -431,9 +448,9 @@ import Button from '@/components/ui/Button.astro'
     }
 
     if (readSelectedMode() === 'daily') {
-      leaderboardController.load(currentUtcDailyKey())
+      loadDailyLeaderboard(currentUtcDailyKey())
     } else {
-      leaderboardController.hide()
+      hideDailyLeaderboard()
     }
 
     startBtn.addEventListener('click', async () => {
@@ -445,10 +462,10 @@ import Button from '@/components/ui/Button.astro'
         if (mode === 'daily') {
           const runKey = gameHandle?.getGame()?.getState().runKey
           if (runKey) {
-            leaderboardController.load(runKey)
+            loadDailyLeaderboard(runKey)
           }
         } else {
-          leaderboardController.hide()
+          hideDailyLeaderboard()
         }
       } catch (error) {
         errorEl.textContent =
@@ -478,10 +495,10 @@ import Button from '@/components/ui/Button.astro'
         if (gameHandle?.getGame()?.getState().mode === 'daily') {
           const runKey = gameHandle.getGame()?.getState().runKey
           if (runKey) {
-            leaderboardController.load(runKey)
+            loadDailyLeaderboard(runKey)
           }
         } else {
-          leaderboardController.hide()
+          hideDailyLeaderboard()
         }
       } catch (error) {
         errorEl.textContent =
@@ -502,18 +519,18 @@ import Button from '@/components/ui/Button.astro'
       setModeControlsDisabled(false)
       focusIdleControl()
       if (readSelectedMode() === 'daily') {
-        leaderboardController.load(currentUtcDailyKey())
+        loadDailyLeaderboard(currentUtcDailyKey())
       } else {
-        leaderboardController.hide()
+        hideDailyLeaderboard()
       }
     })
 
     modeRadios.forEach(radio => {
       radio.addEventListener('change', () => {
         if (readSelectedMode() === 'daily') {
-          leaderboardController.load(currentUtcDailyKey())
+          loadDailyLeaderboard(currentUtcDailyKey())
         } else {
-          leaderboardController.hide()
+          hideDailyLeaderboard()
         }
       })
     })


### PR DESCRIPTION
## Summary
- Implement Ice Slide Daily leaderboard with comprehensive score validation, ranking display, and test coverage
- Add pure Daily score admission checks in run.ts with 13 distinct rejection reasons
- Create game-local daily-leaderboard.ts module for async fetch/render/request-token logic
- Add Daily key grammar parsing/formatting to run.ts as single source of truth
- Update /api/scores to validate Ice Slide Daily scores before persistence
- Update /api/leaderboard to support scoped Daily queries with viewer authentication
- Add static Daily Ranking card to Ice Slide page with proper Astro wiring
- Implement comprehensive unit and E2E test coverage using shared frozen fixtures

#### Test plan
- Unit tests for Daily key parsing/formatting round-trips
- Unit tests for all 13 Daily admission rejection reasons
- Unit tests for daily-leaderboard controller async behavior and stale response suppression
- API route tests for score admission boundary (400 vs persistence)
- API route tests for leaderboard scoped queries with viewer matching
- Playwright E2E tests covering active-key load, viewer-row rendering, 503 handling, and successful submit refresh
- All tests passing with maintained 95% Codecov coverage

Generated with [Devin](https://devin.ai)

<!-- This is an auto-generated comment: release notes by coderabbit.ai -->

## Summary by CodeRabbit

* **New Features**
  * Added a Daily leaderboard to Ice Slide with loading, empty, unavailable, signed-out, and ranked states.
  * Highlights the current player’s entry and refreshes rankings after a successful score submission.
  * Daily challenges now use validated competition keys for accurate rankings, including across date changes.
  * Invalid or incomplete Daily scores are rejected before submission.

* **Bug Fixes**
  * Prevented outdated leaderboard responses from replacing newer results.
  * Campaign mode remains unaffected and hides the Daily leaderboard.

<!-- end of auto-generated comment: release notes by coderabbit.ai -->